### PR TITLE
fix(privacy): tame the macOS permission-prompt flood (#3)

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -22,7 +22,15 @@
 	<string>1</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>Burrow scans your Desktop for reclaimable artifacts and leftover installers.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Burrow scans your Documents for reclaimable project artifacts.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>Burrow scans your Downloads for leftover installer files (.dmg, .pkg).</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>Burrow analyzes external drives when you point it at them.</string>
 </dict>
 </plist>

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -258,6 +258,10 @@ final class AnalyzeModel: ObservableObject {
     private var total: Int64 = 0
     private(set) var started = false
     private let opId = UUID()
+    /// Cache scan results by path so navigating back/into already-seen
+    /// folders is instant instead of re-running `mo analyze` (~4 CPU-s)
+    /// each time. Refresh clears the current path to force a fresh walk.
+    private var cache: [String: (entries: [DiskScanEntry], total: Int64)] = [:]
 
     var summaryLine: String {
         entries.isEmpty ? "—" : "\(entries.count) items · \(Fmt.bytes(total))"
@@ -285,19 +289,27 @@ final class AnalyzeModel: ObservableObject {
 
     func refresh() {
         guard let last = crumbs.last else { return }
-        scan(last.path, name: last.name, push: false)
+        cache[last.path] = nil   // drop the cached walk so we re-scan
+        scan(last.path, name: last.name, push: false, force: true)
     }
 
-    private func scan(_ path: String, name: String, push: Bool) {
+    private func scan(_ path: String, name: String, push: Bool, force: Bool = false) {
+        if push { crumbs.append((name, path)) }
+        // Cache hit → show instantly; don't re-run `mo analyze` for a
+        // folder we already walked (back/drill is the common navigation).
+        if !force, let cached = cache[path] {
+            entries = cached.entries; total = cached.total; loading = false; error = nil
+            return
+        }
         loading = true
         error = nil
-        if push { crumbs.append((name, path)) }
         OperationCenter.shared.begin(opId, label: "Analyzing \(name)")
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let r = try DiskScanner.scan(path)
                 let sum = r.totalSize > 0 ? r.totalSize : r.entries.reduce(0) { $0 + $1.size }
                 Task { @MainActor in
+                    self.cache[path] = (r.entries, sum)
                     self.entries = r.entries
                     self.total = sum
                     self.loading = false

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -15,15 +15,55 @@ import AppKit
 struct AnalyzeView: View {
     @StateObject private var model = AnalyzeModel()
     var isActive: Bool = true
+    @State private var showFDAGate = false
 
     var body: some View {
-        HStack(spacing: 0) {
-            sidebar.frame(width: 232)
-            Rectangle().fill(Brand.hairline).frame(width: 1)
-            mainArea
+        Group {
+            if showFDAGate {
+                fdaGate
+            } else {
+                HStack(spacing: 0) {
+                    sidebar.frame(width: 232)
+                    Rectangle().fill(Brand.hairline).frame(width: 1)
+                    mainArea
+                }
+            }
         }
-        .onAppear { if isActive { model.startIfNeeded() } }
-        .onChange(of: isActive) { _, now in if now { model.startIfNeeded() } }
+        .onAppear { evaluateStart() }
+        .onChange(of: isActive) { _, now in if now { evaluateStart() } }
+    }
+
+    /// Analyze auto-scans the home folder on first open — exactly when
+    /// the macOS "access data from other apps" flood hits (issue #3). If
+    /// we lack Full Disk Access and the user hasn't dismissed the notice,
+    /// gate the scan behind it rather than walking protected dirs
+    /// unannounced.
+    private func evaluateStart() {
+        guard isActive, !model.started else { return }
+        if Privacy.shouldOfferFullDiskAccessNow() {
+            showFDAGate = true
+        } else {
+            model.startIfNeeded()
+        }
+    }
+
+    private var fdaGate: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            FullDiskAccessNotice(
+                accent: Tool.analyze.accent,
+                continueLabel: "Scan anyway",
+                onContinue: { showFDAGate = false; model.startIfNeeded() },
+                onDontAskAgain: {
+                    Store.fullDiskAccessNoticeDismissed = true
+                    showFDAGate = false
+                    model.startIfNeeded()
+                })
+            .frame(maxWidth: 460)
+            Spacer(); Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
     }
 
     // MARK: Sidebar
@@ -213,7 +253,7 @@ final class AnalyzeModel: ObservableObject {
     @Published var loading = false
     @Published var error: String?
     private var total: Int64 = 0
-    private var started = false
+    private(set) var started = false
     private let opId = UUID()
 
     var summaryLine: String {

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -43,6 +43,9 @@ struct AnalyzeView: View {
         if Privacy.shouldOfferFullDiskAccessNow() {
             showFDAGate = true
         } else {
+            // FDA may have just been granted (or the notice dismissed) while
+            // the gate was up — make sure it doesn't keep covering the view.
+            showFDAGate = false
             model.startIfNeeded()
         }
     }

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -34,17 +34,16 @@ struct CleanView: View {
                 }
             }
         } else {
-            let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
                 statusBar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 if isDone, mode == .real {
                     DoneBanner(accent: Tool.clean.accent, title: "Cleaned",
-                               detail: report.summary.map { "Freed up to \($0.space) · \($0.items) items" })
-                } else if mode == .dry, let s = report.summary {
+                               detail: runner.summary.map { "Freed up to \($0.space) · \($0.items) items" })
+                } else if mode == .dry, let s = runner.summary {
                     summaryBanner(s)
                 }
-                TaskReportView(groups: report.groups, accent: Tool.clean.accent)
+                TaskReportView(groups: runner.groups, accent: Tool.clean.accent)
             }
         }
     }
@@ -61,13 +60,10 @@ struct CleanView: View {
                 }.buttonStyle(.plain)
             }
             if isDone {
-                Button { startDry() } label: {
-                    Label("Re-scan", systemImage: "arrow.clockwise")
+                Button { runner.reset() } label: {
+                    Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                 }.buttonStyle(.plain)
-            }
-            if mode == .dry, isDone {
-                PillButton(title: "Clean for real") { confirmReal() }
             }
         }
     }

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -59,7 +59,7 @@ struct CleanView: View {
                         .font(Brand.mono(11)).foregroundStyle(Brand.red)
                 }.buttonStyle(.plain)
             }
-            if isDone {
+            if isDone || isFailed {
                 Button { runner.reset() } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
@@ -84,6 +84,7 @@ struct CleanView: View {
 
     private var isRunning: Bool { runner.phase == .running }
     private var isDone: Bool { if case .done = runner.phase { return true }; return false }
+    private var isFailed: Bool { if case .failed = runner.phase { return true }; return false }
 
     private var statusText: String {
         switch runner.phase {

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -15,15 +15,31 @@ import AppKit
 struct CleanView: View {
     @StateObject private var runner = CommandRunner()
     @State private var mode: Mode = .dry
+    @State private var showFDANotice = false
 
     enum Mode { case dry, real }
 
     var body: some View {
         if runner.phase == .idle {
-            ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
-                PillButton(title: "Clean Now") { confirmReal() }
-                PillButton(title: "Preview", filled: false) { startDry() }
+            ZStack(alignment: .top) {
+                ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
+                    PillButton(title: "Clean Now") { confirmReal() }
+                    PillButton(title: "Preview", filled: false) { startDry() }
+                }
+                if showFDANotice {
+                    FullDiskAccessNotice(
+                        accent: Tool.clean.accent,
+                        onContinue: { showFDANotice = false },
+                        onDontAskAgain: {
+                            Store.fullDiskAccessNoticeDismissed = true
+                            showFDANotice = false
+                        })
+                    .frame(maxWidth: 520)
+                    .padding(.horizontal, 18).padding(.top, 10)
+                    .transition(.opacity)
+                }
             }
+            .onAppear { showFDANotice = Privacy.shouldOfferFullDiskAccessNow() }
         } else {
             let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -15,8 +15,7 @@ import AppKit
 struct CleanView: View {
     @StateObject private var runner = CommandRunner()
     @State private var mode: Mode = .dry
-    @State private var fdaRunAnyway = false
-    @State private var pendingRun: (() -> Void)? = nil
+    @State private var pendingRun: ((Bool) -> Void)? = nil
 
     enum Mode { case dry, real }
 
@@ -25,8 +24,8 @@ struct CleanView: View {
             if pendingRun != nil {
                 FullDiskAccessRequired(
                     accent: Tool.clean.accent,
-                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
-                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false) } },
+                    onRunAnyway: { runPending(elevate: true) },   // root bypasses TCC → no flood
                     onCancel: { pendingRun = nil })
             } else {
                 ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
@@ -102,30 +101,34 @@ struct CleanView: View {
 
     // MARK: - Full Disk Access gate
 
-    /// Run `work`, but if a flood-prone scan would hit the macOS per-folder
-    /// permission prompts (no Full Disk Access yet), divert to the gate
-    /// first instead of letting the flood happen.
-    private func guarded(_ work: @escaping () -> Void) {
-        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
-        else { work() }
+    /// Run a flood-prone scan. With Full Disk Access we run it directly.
+    /// Without, divert to the gate; the user either grants FDA (then we run
+    /// normally) or picks "Scan with admin", which runs the same command
+    /// elevated — root bypasses TCC, so one password replaces the flood.
+    /// `work(elevate)` decides whether to run via sudo.
+    private func guarded(_ work: @escaping (Bool) -> Void) {
+        if Privacy.hasFullDiskAccess() { work(false) } else { pendingRun = work }
     }
-    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
+    private func runPending(elevate: Bool) { let r = pendingRun; pendingRun = nil; r?(elevate) }
 
     private func startDry() {
-        guarded { mode = .dry; runner.run(["clean", "--dry-run"], label: "Scanning caches") }
+        guarded { elevate in
+            mode = .dry
+            runner.run(["clean", "--dry-run"], elevated: elevate, label: "Scanning caches")
+        }
     }
 
+    /// The real clean already runs elevated (root), so it never triggers the
+    /// flood — no gate needed here.
     private func confirmReal() {
-        guarded {
-            let alert = NSAlert()
-            alert.messageText = "Clean caches for real?"
-            alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "Clean")
-            alert.addButton(withTitle: "Cancel")
-            guard alert.runModal() == .alertFirstButtonReturn else { return }
-            mode = .real
-            runner.run(["clean"], elevated: true, label: "Cleaning caches")
-        }
+        let alert = NSAlert()
+        alert.messageText = "Clean caches for real?"
+        alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Clean")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        mode = .real
+        runner.run(["clean"], elevated: true, label: "Cleaning caches")
     }
 }

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -15,31 +15,25 @@ import AppKit
 struct CleanView: View {
     @StateObject private var runner = CommandRunner()
     @State private var mode: Mode = .dry
-    @State private var showFDANotice = false
+    @State private var fdaRunAnyway = false
+    @State private var pendingRun: (() -> Void)? = nil
 
     enum Mode { case dry, real }
 
     var body: some View {
         if runner.phase == .idle {
-            ZStack(alignment: .top) {
+            if pendingRun != nil {
+                FullDiskAccessRequired(
+                    accent: Tool.clean.accent,
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
+                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onCancel: { pendingRun = nil })
+            } else {
                 ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
                     PillButton(title: "Clean Now") { confirmReal() }
                     PillButton(title: "Preview", filled: false) { startDry() }
                 }
-                if showFDANotice {
-                    FullDiskAccessNotice(
-                        accent: Tool.clean.accent,
-                        onContinue: { showFDANotice = false },
-                        onDontAskAgain: {
-                            Store.fullDiskAccessNoticeDismissed = true
-                            showFDANotice = false
-                        })
-                    .frame(maxWidth: 520)
-                    .padding(.horizontal, 18).padding(.top, 10)
-                    .transition(.opacity)
-                }
             }
-            .onAppear { showFDANotice = Privacy.shouldOfferFullDiskAccessNow() }
         } else {
             let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
@@ -61,6 +55,12 @@ struct CleanView: View {
             if isRunning { ProgressView().controlSize(.small).tint(Tool.clean.accent) }
             Text(statusText).font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
             Spacer()
+            if isRunning {
+                Button { runner.cancel() } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                        .font(Brand.mono(11)).foregroundStyle(Brand.red)
+                }.buttonStyle(.plain)
+            }
             if isDone {
                 Button { startDry() } label: {
                     Label("Re-scan", systemImage: "arrow.clockwise")
@@ -93,23 +93,39 @@ struct CleanView: View {
     private var statusText: String {
         switch runner.phase {
         case .running: return mode == .dry ? "Scanning your Mac…" : "Cleaning… don't quit."
-        case .done:    return mode == .dry ? "Preview — review, then clean for real." : "Done — caches cleared."
+        case .done:    return runner.wasCancelled ? "Stopped."
+            : (mode == .dry ? "Preview — review, then clean for real." : "Done — caches cleared.")
         case .failed(let m): return "Failed: \(m)"
         case .idle:    return ""
         }
     }
 
-    private func startDry() { mode = .dry; runner.run(["clean", "--dry-run"], label: "Scanning caches") }
+    // MARK: - Full Disk Access gate
+
+    /// Run `work`, but if a flood-prone scan would hit the macOS per-folder
+    /// permission prompts (no Full Disk Access yet), divert to the gate
+    /// first instead of letting the flood happen.
+    private func guarded(_ work: @escaping () -> Void) {
+        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
+        else { work() }
+    }
+    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
+
+    private func startDry() {
+        guarded { mode = .dry; runner.run(["clean", "--dry-run"], label: "Scanning caches") }
+    }
 
     private func confirmReal() {
-        let alert = NSAlert()
-        alert.messageText = "Clean caches for real?"
-        alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "Clean")
-        alert.addButton(withTitle: "Cancel")
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-        mode = .real
-        runner.run(["clean"], elevated: true, label: "Cleaning caches")
+        guarded {
+            let alert = NSAlert()
+            alert.messageText = "Clean caches for real?"
+            alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Clean")
+            alert.addButton(withTitle: "Cancel")
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+            mode = .real
+            runner.run(["clean"], elevated: true, label: "Cleaning caches")
+        }
     }
 }

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -31,15 +31,14 @@ struct OptimizeView: View {
                 }
             }
         } else {
-            let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
                 statusBar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 if isDone, !preview, !runner.wasCancelled {
                     DoneBanner(accent: Tool.optimize.accent, title: "Maintenance complete",
-                               detail: "\(report.groups.count) areas refreshed")
+                               detail: "\(runner.groups.count) areas refreshed")
                 }
-                TaskReportView(groups: report.groups, accent: Tool.optimize.accent)
+                TaskReportView(groups: runner.groups, accent: Tool.optimize.accent)
             }
         }
     }
@@ -56,8 +55,8 @@ struct OptimizeView: View {
                 }.buttonStyle(.plain)
             }
             if isDone {
-                Button { runOptimize() } label: {
-                    Label("Run again", systemImage: "arrow.clockwise")
+                Button { runner.reset() } label: {
+                    Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                 }.buttonStyle(.plain)
             }

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -54,7 +54,7 @@ struct OptimizeView: View {
                         .font(Brand.mono(11)).foregroundStyle(Brand.red)
                 }.buttonStyle(.plain)
             }
-            if isDone {
+            if isDone || isFailed {
                 Button { runner.reset() } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
@@ -65,6 +65,7 @@ struct OptimizeView: View {
 
     private var isRunning: Bool { runner.phase == .running }
     private var isDone: Bool { if case .done = runner.phase { return true }; return false }
+    private var isFailed: Bool { if case .failed = runner.phase { return true }; return false }
 
     private var statusText: String {
         switch runner.phase {

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -14,19 +14,29 @@ import SwiftUI
 struct OptimizeView: View {
     @StateObject private var runner = CommandRunner()
     @State private var preview = false
+    @State private var fdaRunAnyway = false
+    @State private var pendingRun: (() -> Void)? = nil
 
     var body: some View {
         if runner.phase == .idle {
-            ToolHero(tool: .optimize, title: "Optimize", subtitle: Tool.optimize.tagline) {
-                PillButton(title: "Optimize") { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") }
-                PillButton(title: "Preview", filled: false) { preview = true; runner.run(["optimize", "--dry-run"], label: "Optimize preview") }
+            if pendingRun != nil {
+                FullDiskAccessRequired(
+                    accent: Tool.optimize.accent,
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
+                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onCancel: { pendingRun = nil })
+            } else {
+                ToolHero(tool: .optimize, title: "Optimize", subtitle: Tool.optimize.tagline) {
+                    PillButton(title: "Optimize") { runOptimize() }
+                    PillButton(title: "Preview", filled: false) { runPreview() }
+                }
             }
         } else {
             let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
                 statusBar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
-                if isDone, !preview {
+                if isDone, !preview, !runner.wasCancelled {
                     DoneBanner(accent: Tool.optimize.accent, title: "Maintenance complete",
                                detail: "\(report.groups.count) areas refreshed")
                 }
@@ -37,11 +47,17 @@ struct OptimizeView: View {
 
     private var statusBar: some View {
         HStack(spacing: 10) {
-            if runner.phase == .running { ProgressView().controlSize(.small).tint(Tool.optimize.accent) }
+            if isRunning { ProgressView().controlSize(.small).tint(Tool.optimize.accent) }
             Text(statusText).font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
             Spacer()
+            if isRunning {
+                Button { runner.cancel() } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                        .font(Brand.mono(11)).foregroundStyle(Brand.red)
+                }.buttonStyle(.plain)
+            }
             if isDone {
-                Button { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") } label: {
+                Button { runOptimize() } label: {
                     Label("Run again", systemImage: "arrow.clockwise")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                 }.buttonStyle(.plain)
@@ -49,14 +65,24 @@ struct OptimizeView: View {
         }
     }
 
+    private var isRunning: Bool { runner.phase == .running }
     private var isDone: Bool { if case .done = runner.phase { return true }; return false }
 
     private var statusText: String {
         switch runner.phase {
         case .running: return preview ? "Previewing maintenance…" : "Running maintenance…"
-        case .done:    return preview ? "Preview complete." : "Maintenance complete."
+        case .done:    return runner.wasCancelled ? "Stopped."
+            : (preview ? "Preview complete." : "Maintenance complete.")
         case .failed(let m): return "Failed: \(m)"
         case .idle:    return ""
         }
     }
+
+    private func guarded(_ work: @escaping () -> Void) {
+        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
+        else { work() }
+    }
+    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
+    private func runOptimize() { guarded { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") } }
+    private func runPreview() { guarded { preview = true; runner.run(["optimize", "--dry-run"], label: "Optimize preview") } }
 }

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -14,16 +14,15 @@ import SwiftUI
 struct OptimizeView: View {
     @StateObject private var runner = CommandRunner()
     @State private var preview = false
-    @State private var fdaRunAnyway = false
-    @State private var pendingRun: (() -> Void)? = nil
+    @State private var pendingRun: ((Bool) -> Void)? = nil
 
     var body: some View {
         if runner.phase == .idle {
             if pendingRun != nil {
                 FullDiskAccessRequired(
                     accent: Tool.optimize.accent,
-                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
-                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false) } },
+                    onRunAnyway: { runPending(elevate: true) },
                     onCancel: { pendingRun = nil })
             } else {
                 ToolHero(tool: .optimize, title: "Optimize", subtitle: Tool.optimize.tagline) {
@@ -78,11 +77,14 @@ struct OptimizeView: View {
         }
     }
 
-    private func guarded(_ work: @escaping () -> Void) {
-        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
-        else { work() }
+    private func guarded(_ work: @escaping (Bool) -> Void) {
+        if Privacy.hasFullDiskAccess() { work(false) } else { pendingRun = work }
     }
-    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
-    private func runOptimize() { guarded { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") } }
-    private func runPreview() { guarded { preview = true; runner.run(["optimize", "--dry-run"], label: "Optimize preview") } }
+    private func runPending(elevate: Bool) { let r = pendingRun; pendingRun = nil; r?(elevate) }
+
+    /// Optimize already runs elevated (root) → no flood, no gate.
+    private func runOptimize() { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") }
+    private func runPreview() {
+        guarded { elevate in preview = true; runner.run(["optimize", "--dry-run"], elevated: elevate, label: "Optimize preview") }
+    }
 }

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -1,0 +1,113 @@
+//
+//  Privacy.swift
+//  Burrow
+//
+//  Full Disk Access detection and the macOS settings deep-link.
+//
+//  Burrow shells out to `mo`, which walks system and other-apps' cache
+//  directories. On macOS 14+ those reads are TCC-gated ("Burrow would
+//  like to access data from other apps") and the prompt is attributed to
+//  Burrow — once per protected location, so a single `mo clean --dry-run`
+//  or `mo analyze` over the home folder produces a *flood* of dialogs
+//  (issue #3).
+//
+//  The OS-sanctioned remedy is Full Disk Access: once granted, macOS
+//  stops gating per-folder reads for this app. We never bypass TCC — we
+//  only detect whether we already have access and, if not, point the user
+//  at the single switch that grants informed, one-time consent.
+//
+
+import Foundation
+import AppKit
+import SwiftUI
+
+enum Privacy {
+    /// Whether to surface the Full Disk Access notice before a scan that
+    /// walks protected directories. Pure so it's unit-testable: nag only
+    /// when access is missing and the user hasn't already dismissed it.
+    static func shouldOfferFullDiskAccess(hasAccess: Bool, dismissed: Bool) -> Bool {
+        return !hasAccess && !dismissed
+    }
+
+    /// Probe whether Burrow has Full Disk Access by attempting to open an
+    /// FDA-gated file. `TCC.db` exists on every Mac and is readable only
+    /// with Full Disk Access, so a successful open is the canonical
+    /// signal. We open and immediately close — the bytes are never read;
+    /// this is a capability probe, not data access. A read that lacks
+    /// access fails silently (no prompt), so probing can't itself flood
+    /// the user.
+    static func hasFullDiskAccess() -> Bool {
+        let probes = [
+            "Library/Application Support/com.apple.TCC/TCC.db",
+            "Library/Safari/Bookmarks.plist",
+        ].map { (NSHomeDirectory() as NSString).appendingPathComponent($0) }
+        for path in probes {
+            if let fh = FileHandle(forReadingAtPath: path) {
+                try? fh.close()
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Live check combining the access probe with the persisted dismissal.
+    static func shouldOfferFullDiskAccessNow() -> Bool {
+        shouldOfferFullDiskAccess(hasAccess: hasFullDiskAccess(),
+                                  dismissed: Store.fullDiskAccessNoticeDismissed)
+    }
+
+    /// Deep-link to System Settings ▸ Privacy & Security ▸ Full Disk Access.
+    static let fullDiskAccessSettingsURL = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!
+
+    static func openFullDiskAccessSettings() {
+        NSWorkspace.shared.open(fullDiskAccessSettingsURL)
+    }
+}
+
+/// Dismissible banner shown before scans that walk TCC-protected
+/// directories. Surfaces the OS mechanism (Full Disk Access) so the user
+/// grants one informed consent instead of fielding a flood of per-folder
+/// prompts. Burrow never bypasses TCC — this only points the way.
+struct FullDiskAccessNotice: View {
+    var accent: Color = Brand.green
+    /// Label for the proceed-without-granting action ("Not now" in a
+    /// non-blocking banner, "Scan anyway" when it gates a scan).
+    var continueLabel: String = "Not now"
+    var onOpenSettings: () -> Void = { Privacy.openFullDiskAccessSettings() }
+    var onContinue: () -> Void
+    /// Optional "don't ask again" — persists the dismissal.
+    var onDontAskAgain: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "lock.shield").font(.system(size: 18)).foregroundStyle(accent)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Skip the macOS permission prompts")
+                    .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                Text("Scanning system & app caches makes macOS ask once per protected folder. Grant Burrow Full Disk Access to scan smoothly — it only reads sizes through Mole and never opens that data itself.")
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 16) {
+                    Button(action: onOpenSettings) {
+                        Text("Open Full Disk Access settings")
+                            .font(Brand.sans(11, .semibold)).foregroundStyle(accent)
+                    }.buttonStyle(.plain)
+                    Button(action: onContinue) {
+                        Text(continueLabel).font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                    }.buttonStyle(.plain)
+                    if let onDontAskAgain {
+                        Button(action: onDontAskAgain) {
+                            Text("Don't ask again").font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                        }.buttonStyle(.plain)
+                    }
+                }
+                .padding(.top, 3)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(13)
+        .background(RoundedRectangle(cornerRadius: 13).fill(accent.opacity(0.08)))
+        .overlay(RoundedRectangle(cornerRadius: 13).strokeBorder(accent.opacity(0.28), lineWidth: 1))
+    }
+}

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -133,18 +133,18 @@ struct FullDiskAccessRequired: View {
             VStack(spacing: 8) {
                 Text("Grant Full Disk Access to scan")
                     .font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
-                Text("This reads system and app caches through Mole. Without Full Disk Access, macOS makes you approve every protected folder — one prompt after another. Grant it once in System Settings and the prompts stop for good. Burrow only reads sizes; it never opens that data itself.")
+                Text("This reads system and app caches through Mole. Without Full Disk Access, macOS makes you approve every protected folder — one prompt after another. Grant it once in System Settings and the prompts stop for good. Or run the scan with administrator rights instead: one password, no per-folder asks. Burrow only reads sizes; it never opens that data itself.")
                     .font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
                     .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: 440)
+                    .frame(maxWidth: 460)
             }
             VStack(spacing: 12) {
                 PillButton(title: "Open Full Disk Access settings") { onOpenSettings() }
                 HStack(spacing: 18) {
                     Button("I've granted it — scan") { onRecheck() }
                         .buttonStyle(.plain).font(Brand.sans(12, .semibold)).foregroundStyle(accent)
-                    Button("Scan anyway") { onRunAnyway() }
-                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                    Button("Scan with admin") { onRunAnyway() }
+                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                     Button("Cancel") { onCancel() }
                         .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
                 }

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -111,3 +111,47 @@ struct FullDiskAccessNotice: View {
         .overlay(RoundedRectangle(cornerRadius: 13).strokeBorder(accent.opacity(0.28), lineWidth: 1))
     }
 }
+
+/// Blocking gate shown when a flood-prone scan is requested without Full
+/// Disk Access. Unlike the soft banner, this STOPS the run — otherwise
+/// macOS prompts once per protected folder. Grant FDA once and the
+/// prompts stop entirely; "Scan anyway" is the escape hatch (and warns).
+struct FullDiskAccessRequired: View {
+    var accent: Color
+    var onOpenSettings: () -> Void = { Privacy.openFullDiskAccessSettings() }
+    var onRecheck: () -> Void
+    var onRunAnyway: () -> Void
+    var onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            ZStack {
+                Circle().fill(accent.opacity(0.15)).frame(width: 64, height: 64)
+                Image(systemName: "lock.shield").font(.system(size: 28)).foregroundStyle(accent)
+            }
+            VStack(spacing: 8) {
+                Text("Grant Full Disk Access to scan")
+                    .font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
+                Text("This reads system and app caches through Mole. Without Full Disk Access, macOS makes you approve every protected folder — one prompt after another. Grant it once in System Settings and the prompts stop for good. Burrow only reads sizes; it never opens that data itself.")
+                    .font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 440)
+            }
+            VStack(spacing: 12) {
+                PillButton(title: "Open Full Disk Access settings") { onOpenSettings() }
+                HStack(spacing: 18) {
+                    Button("I've granted it — scan") { onRecheck() }
+                        .buttonStyle(.plain).font(Brand.sans(12, .semibold)).foregroundStyle(accent)
+                    Button("Scan anyway") { onRunAnyway() }
+                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                    Button("Cancel") { onCancel() }
+                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                }
+            }
+            Spacer(); Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
+    }
+}

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -79,6 +79,17 @@ enum Store {
         set { d.set(newValue, forKey: "query_server_enabled") }
     }
 
+    // MARK: - Privacy
+
+    /// Whether the user has dismissed the Full Disk Access notice that
+    /// Burrow shows before scans which walk TCC-protected directories
+    /// (issue #3). Defaults to false so first-run users see it once;
+    /// sticks once dismissed so we never nag.
+    static var fullDiskAccessNoticeDismissed: Bool {
+        get { d.object(forKey: "fda_notice_dismissed") as? Bool ?? false }
+        set { d.set(newValue, forKey: "fda_notice_dismissed") }
+    }
+
     // MARK: - History view
 
     /// Last-selected History view range, in minutes. Persisting it

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -99,6 +99,10 @@ final class CommandRunner: ObservableObject {
 
     @Published var phase: Phase = .idle
     @Published var lines: [String] = []
+    /// Parsed report, recomputed once per coalesced flush — NOT per SwiftUI
+    /// render. Views read these instead of re-parsing `lines` every frame.
+    @Published private(set) var groups: [TaskGroup] = []
+    @Published private(set) var summary: TaskSummary?
     /// Set when the user aborts via `cancel()`, so the UI can say "Stopped"
     /// rather than reporting the terminated process as a plain failure.
     @Published private(set) var wasCancelled = false
@@ -107,12 +111,14 @@ final class CommandRunner: ObservableObject {
     private var operationLabel: String?
     private var task: Process?
     private var buffer = ""
+    private var pending: [String] = []
+    private var flushScheduled = false
     private var tailTimer: Timer?
     private var logHandle: FileHandle?
 
     func run(_ args: [String], elevated: Bool = false, label: String? = nil) {
         guard let mo = MoleCLI.findExecutable() else { phase = .failed("mo not found"); return }
-        lines = []; buffer = ""; wasCancelled = false; phase = .running
+        lines = []; buffer = ""; pending = []; groups = []; summary = nil; wasCancelled = false; phase = .running
         operationLabel = label
         if let label { OperationCenter.shared.begin(opId, label: label) }
         if elevated { runElevated(mo: mo, args: args); return }
@@ -156,6 +162,13 @@ final class CommandRunner: ObservableObject {
         // immediately rather than waiting on a terminationHandler that may
         // not fire for an already-dead task.
         if task == nil || task?.isRunning == false { phase = .done(130) }
+    }
+
+    /// Return to the idle (hero) state — used by the "Back" button on a
+    /// finished report so the user can get back to the tool's menu.
+    func reset() {
+        phase = .idle
+        lines = []; buffer = ""; pending = []; groups = []; summary = nil; wasCancelled = false
     }
 
     /// Run `mo <args>` as root via ONE osascript auth prompt, instead of
@@ -206,12 +219,38 @@ final class CommandRunner: ObservableObject {
         buffer += s
         var parts = buffer.components(separatedBy: "\n")
         buffer = parts.removeLast()
-        lines.append(contentsOf: parts)
+        guard !parts.isEmpty else { return }
+        pending.append(contentsOf: parts)
         if operationLabel != nil, let last = parts.last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
             OperationCenter.shared.detail(opId, last)
         }
+        scheduleFlush()
     }
-    private func flush() { if !buffer.isEmpty { lines.append(buffer); buffer = "" } }
+
+    /// Coalesce output: batch incoming lines and update @Published state at
+    /// most ~8×/sec, so a chatty `mo` run doesn't re-render the report (and
+    /// re-parse every line) on each chunk — the GUI overhead that made the
+    /// app feel heavier and laggier than the bare CLI.
+    private func scheduleFlush() {
+        guard !flushScheduled else { return }
+        flushScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { [weak self] in self?.applyPending() }
+    }
+
+    private func applyPending() {
+        flushScheduled = false
+        guard !pending.isEmpty else { return }
+        lines.append(contentsOf: pending)
+        pending.removeAll(keepingCapacity: true)
+        let r = parseTaskReport(lines)
+        groups = r.groups; summary = r.summary
+    }
+
+    /// Final flush at end of stream (plus the trailing partial line).
+    private func flush() {
+        if !buffer.isEmpty { pending.append(buffer); buffer = "" }
+        applyPending()
+    }
 
     nonisolated static func stripAnsi(_ s: String) -> String {
         guard s.contains("\u{1B}") else { return s }

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -99,6 +99,9 @@ final class CommandRunner: ObservableObject {
 
     @Published var phase: Phase = .idle
     @Published var lines: [String] = []
+    /// Set when the user aborts via `cancel()`, so the UI can say "Stopped"
+    /// rather than reporting the terminated process as a plain failure.
+    @Published private(set) var wasCancelled = false
 
     let opId = UUID()
     private var operationLabel: String?
@@ -109,7 +112,7 @@ final class CommandRunner: ObservableObject {
 
     func run(_ args: [String], elevated: Bool = false, label: String? = nil) {
         guard let mo = MoleCLI.findExecutable() else { phase = .failed("mo not found"); return }
-        lines = []; buffer = ""; phase = .running
+        lines = []; buffer = ""; wasCancelled = false; phase = .running
         operationLabel = label
         if let label { OperationCenter.shared.begin(opId, label: label) }
         if elevated { runElevated(mo: mo, args: args); return }
@@ -146,8 +149,13 @@ final class CommandRunner: ObservableObject {
     }
 
     func cancel() {
+        wasCancelled = true
         if let t = task, t.isRunning { t.terminate() }
         tailTimer?.invalidate(); tailTimer = nil
+        // If the process already exited (or never streamed), settle the UI
+        // immediately rather than waiting on a terminationHandler that may
+        // not fire for an already-dead task.
+        if task == nil || task?.isRunning == false { phase = .done(130) }
     }
 
     /// Run `mo <args>` as root via ONE osascript auth prompt, instead of

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -179,7 +179,11 @@ final class CommandRunner: ObservableObject {
         let safe = args.map { $0.filter(\.isLetter) }.joined(separator: "-")
         let logPath = NSTemporaryDirectory() + "burrow-op-\(safe).log"
         FileManager.default.createFile(atPath: logPath, contents: Data())
-        let inner = "\(mo) \(args.joined(separator: " ")) > '\(logPath)' 2>&1"
+        // Single-quote the executable path (args are hardcoded literals) so a
+        // space or metacharacter in the resolved `mo` path can't break or
+        // inject into the `do shell script` command.
+        func shQuote(_ s: String) -> String { "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'" }
+        let inner = "\(shQuote(mo)) \(args.joined(separator: " ")) > \(shQuote(logPath)) 2>&1"
         let script = "do shell script \"\(inner)\" with administrator privileges"
 
         let t = Process()

--- a/Tests/PrivacyTests.swift
+++ b/Tests/PrivacyTests.swift
@@ -1,0 +1,28 @@
+//
+//  PrivacyTests.swift
+//  BurrowTests
+//
+//  The permission-flood fix (issue #3) hinges on one decision: should
+//  Burrow surface the Full Disk Access notice before a scan that walks
+//  TCC-protected directories? The probe for whether we *have* access is
+//  environment-dependent and not unit-testable, so the decision is split
+//  into a pure function that these tests pin down.
+//
+
+import XCTest
+@testable import Burrow
+
+final class PrivacyTests: XCTestCase {
+    // The rule: only nag when access is missing AND the user hasn't
+    // already dismissed the notice. Granting access or dismissing both
+    // silence it — we never want to flood the user with our own banner
+    // any more than with the OS prompts.
+    func testOffersAccessOnlyWhenMissingAndNotDismissed() {
+        XCTAssertTrue(Privacy.shouldOfferFullDiskAccess(hasAccess: false, dismissed: false))
+        XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: true, dismissed: false),
+                       "no notice when we already have access")
+        XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: false, dismissed: true),
+                       "respect a prior dismissal")
+        XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: true, dismissed: true))
+    }
+}

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -23,6 +23,7 @@ final class StoreTests: XCTestCase {
             "query_server_port",
             "query_server_enabled",
             "last_history_range_minutes",
+            "fda_notice_dismissed",
         ] {
             UserDefaults.standard.removeObject(forKey: k)
         }
@@ -72,6 +73,15 @@ final class StoreTests: XCTestCase {
 
     func testLastHistoryRangeMinutes_defaultsToOneHour() {
         XCTAssertEqual(Store.lastHistoryRangeMinutes, 60)
+    }
+
+    // The Full Disk Access notice (issue #3) must default to "not
+    // dismissed" so first-run users see it, and stick once dismissed so
+    // we don't nag.
+    func testFullDiskAccessNoticeDismissed_defaultsFalseAndPersists() {
+        XCTAssertFalse(Store.fullDiskAccessNoticeDismissed)
+        Store.fullDiskAccessNoticeDismissed = true
+        XCTAssertTrue(Store.fullDiskAccessNoticeDismissed)
     }
 
     func testRoundtripBoolAndInt() {

--- a/project.yml
+++ b/project.yml
@@ -37,6 +37,13 @@ targets:
         CFBundleShortVersionString: "0.4.0"
         CFBundleVersion: "1"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
+        # Friendly, one-time prompts for the standard folders Mole scans
+        # (purge/installer touch these). Full Disk Access still covers the
+        # cache/container locations — see the in-app FDA gate.
+        NSDesktopFolderUsageDescription: "Burrow scans your Desktop for reclaimable artifacts and leftover installers."
+        NSDocumentsFolderUsageDescription: "Burrow scans your Documents for reclaimable project artifacts."
+        NSDownloadsFolderUsageDescription: "Burrow scans your Downloads for leftover installer files (.dmg, .pkg)."
+        NSRemovableVolumesUsageDescription: "Burrow analyzes external drives when you point it at them."
     entitlements:
       path: Resources/Burrow.entitlements
       properties:


### PR DESCRIPTION
## Problem
`mo clean --dry-run` (Clean preview) and `mo analyze` walk system + other-apps' cache directories. On macOS 14+ those reads are TCC-gated — **"Burrow would like to access data from other apps"** — and the prompt fires **once per protected folder**, attributed to Burrow because it lacks Full Disk Access. One scan ⇒ a flood of dialogs (issue #3). Analyze is worst: it auto-scans $HOME the instant you open the tab.

## Fix — informed consent, not a bypass
The OS-sanctioned remedy is Full Disk Access (with it granted, macOS stops gating per-folder reads). We surface that switch instead of fielding the flood; we **never** bypass TCC or read protected data ourselves.

- **`Privacy`** — `hasFullDiskAccess()` silently probes by opening `TCC.db` (FDA-gated, present on every Mac; bytes never read, and a denied read fails silently so the probe can't itself prompt). Pure `shouldOfferFullDiskAccess(hasAccess:dismissed:)` decision + the `Privacy_AllFiles` settings deep-link.
- **`Store.fullDiskAccessNoticeDismissed`** — persisted, defaults false (first-run sees it once, sticks once dismissed).
- **Clean** — dismissible FDA banner on the idle hero.
- **Analyze** — gates the auto-scan behind the notice ("Scan anyway" / "Don't ask again") so opening the tab no longer floods unannounced.

## Tests
- `PrivacyTests` — the pure decision (only nag when access is missing **and** not dismissed).
- `StoreTests` — flag defaults false and persists.

The live FDA probe + SwiftUI wiring aren't unit-testable, so the decision is split into the pure function these tests pin.

Closes #3.