### PR TITLE
feat(clean): show real freed-space in the Cleaned banner

### DIFF
--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -31,13 +31,25 @@ struct CleanView: View {
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 if isDone, mode == .real {
                     DoneBanner(accent: Tool.clean.accent, title: "Cleaned",
-                               detail: report.summary.map { "Freed up to \($0.space) · \($0.items) items" })
+                               detail: report.summary.map(cleanedDetail))
                 } else if mode == .dry, let s = report.summary {
                     summaryBanner(s)
                 }
                 TaskReportView(groups: report.groups, accent: Tool.clean.accent)
             }
         }
+    }
+
+    /// Post-run detail line. Prefers the real freed-space numbers Mole
+    /// prints after a live clean ("Free space change / now"), falling
+    /// back to the tracked-cleanup size when those aren't present.
+    private func cleanedDetail(_ s: TaskSummary) -> String {
+        var parts: [String] = []
+        if !s.freeChange.isEmpty { parts.append("Freed \(s.freeChange)") }
+        else if !s.space.isEmpty { parts.append("Cleaned \(s.space)") }
+        if !s.freeNow.isEmpty { parts.append("\(s.freeNow) free now") }
+        if !s.items.isEmpty { parts.append("\(s.items) items") }
+        return parts.isEmpty ? "Done" : parts.joined(separator: " · ")
     }
 
     private var statusBar: some View {

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -47,15 +47,23 @@ struct TaskGroup: Identifiable {
 }
 
 struct TaskSummary {
-    let space: String      // "383.8MB"
-    let items: String      // "372"
-    let categories: String // "20"
+    let space: String          // "383.8MB" — potential (dry-run) or tracked (real) cleanup size
+    let items: String          // "372"
+    let categories: String     // "20"
+    var freeChange: String = "" // "+1.39GB" — real run only (disk freed)
+    var freeNow: String = ""    // "2.50GB"  — real run only (free space after)
 }
 
 func parseTaskReport(_ lines: [String]) -> (groups: [TaskGroup], summary: TaskSummary?) {
     var groups: [TaskGroup] = []
-    var summary: TaskSummary?
     let markerChars: Set<Character> = ["→", "➜", "✓", "✔", "•", "◎", "●", "✗", "✘", "✕"]
+
+    // Summary fields accumulate across lines: the dry-run preview packs
+    // them onto one "Potential space:" line, but the real run spreads
+    // "Tracked cleanup:", "Free space change:" and "Free space now:" over
+    // three separate lines.
+    var space = "", items = "", cats = "", freeChange = "", freeNow = ""
+    var sawSummary = false
 
     for raw in lines {
         let t = raw.trimmingCharacters(in: .whitespaces)
@@ -68,27 +76,46 @@ func parseTaskReport(_ lines: [String]) -> (groups: [TaskGroup], summary: TaskSu
             let text = String(t.dropFirst()).trimmingCharacters(in: .whitespaces)
             if groups.isEmpty { groups.append(TaskGroup(title: "Summary", items: [])) }
             groups[groups.count - 1].items.append(TaskItem(marker: TaskMarker(first), text: text))
-        } else if t.hasPrefix("Potential space:") {
-            summary = parseSummary(t)
+        } else if mergeSummaryFields(line: t, space: &space, items: &items, categories: &cats,
+                                     freeChange: &freeChange, freeNow: &freeNow) {
+            sawSummary = true
         } else if t == t.uppercased(), t.count > 4, t.count < 40, !t.contains(":"), !t.contains("|") {
             groups.append(TaskGroup(title: t.capitalized, items: []))
         }
     }
+    let summary = sawSummary
+        ? TaskSummary(space: space, items: items, categories: cats,
+                      freeChange: freeChange, freeNow: freeNow)
+        : nil
     return (groups.filter { !$0.items.isEmpty }, summary)
 }
 
-private func parseSummary(_ line: String) -> TaskSummary {
-    var space = "", items = "", cats = ""
+/// Recognise a summary line from either the dry-run preview ("Potential
+/// space: … | Items: … | Categories: …") or the real run's footer
+/// ("Tracked cleanup: …", "Free space change: …", "Free space now: …")
+/// and merge its fields into the accumulators. Returns whether the line
+/// was a summary line, so the caller stops matching other shapes for it.
+private func mergeSummaryFields(line: String,
+                                space: inout String, items: inout String,
+                                categories: inout String,
+                                freeChange: inout String, freeNow: inout String) -> Bool {
+    let lower = line.lowercased()
+    guard lower.contains("potential space") || lower.contains("tracked cleanup")
+       || lower.contains("free space change") || lower.contains("free space now") else {
+        return false
+    }
     for part in line.components(separatedBy: "|") {
         let kv = part.components(separatedBy: ":")
         guard kv.count >= 2 else { continue }
         let key = kv[0].trimmingCharacters(in: .whitespaces).lowercased()
-        let val = kv[1].trimmingCharacters(in: .whitespaces)
-        if key.contains("space") { space = val }
+        let val = kv[1...].joined(separator: ":").trimmingCharacters(in: .whitespaces)
+        if key.contains("potential space") || key.contains("tracked cleanup") { space = val }
+        else if key.contains("free space change") { freeChange = val }
+        else if key.contains("free space now") { freeNow = val }
         else if key.contains("item") { items = val }
-        else if key.contains("categor") { cats = val }
+        else if key.contains("categor") { categories = val }
     }
-    return TaskSummary(space: space, items: items, categories: cats)
+    return true
 }
 
 // MARK: - Streaming runner

--- a/Tests/TaskReportTests.swift
+++ b/Tests/TaskReportTests.swift
@@ -1,0 +1,53 @@
+//
+//  TaskReportTests.swift
+//  BurrowTests
+//
+//  parseTaskReport turns streamed `mo clean`/`mo optimize` output into
+//  themed cards plus a summary. Two summary shapes exist: the dry-run
+//  preview ("Potential space: …") and the real run's footer ("Tracked
+//  cleanup: … / Free space change: … / Free space now: …"). The real-run
+//  footer was previously unparsed, so the "Cleaned" banner came up blank.
+//
+
+import XCTest
+@testable import Burrow
+
+final class TaskReportTests: XCTestCase {
+    // Real `mo clean` footer — the numbers users actually care about
+    // post-run are how much was freed and how much is now free.
+    func testParsesRealRunSummary() throws {
+        let lines = [
+            "======================================================================",
+            "Cleanup complete",
+            "Tracked cleanup: 1.02GB | Items cleaned: 337 | Categories: 35",
+            "Free space change: +1.39GB",
+            "Free space now: 2.50GB",
+            "======================================================================",
+        ]
+        let summary = try XCTUnwrap(parseTaskReport(lines).summary)
+        XCTAssertEqual(summary.space, "1.02GB")
+        XCTAssertEqual(summary.items, "337")
+        XCTAssertEqual(summary.categories, "35")
+        XCTAssertEqual(summary.freeChange, "+1.39GB")
+        XCTAssertEqual(summary.freeNow, "2.50GB")
+    }
+
+    // The dry-run preview packs everything onto one line and has no
+    // free-space figures (nothing was actually deleted). Guards the
+    // refactor that unified both summary shapes.
+    func testParsesDryRunSummary() throws {
+        let lines = [
+            "➤ Developer tools",
+            "  → npm cache, 191.8MB",
+            "Potential space: 383.8MB | Items: 372 | Categories: 20",
+        ]
+        let result = parseTaskReport(lines)
+        let summary = try XCTUnwrap(result.summary)
+        XCTAssertEqual(summary.space, "383.8MB")
+        XCTAssertEqual(summary.items, "372")
+        XCTAssertEqual(summary.categories, "20")
+        XCTAssertEqual(summary.freeChange, "", "dry-run frees nothing yet")
+        XCTAssertEqual(summary.freeNow, "")
+        XCTAssertEqual(result.groups.count, 1)
+    }
+}


### PR DESCRIPTION
## Problem
After a **real** clean, the "Cleaned" banner came up blank. `parseTaskReport` only recognized the dry-run preview's one-line `Potential space: … | Items: … | Categories: …` summary — but a live `mo clean` reports its numbers in a multi-line footer:

```
Cleanup complete
Tracked cleanup: 1.02GB | Items cleaned: 337 | Categories: 35
Free space change: +1.39GB
Free space now: 2.50GB
```

## Fix
- `TaskSummary` gains `freeChange` / `freeNow`; `parseTaskReport` accumulates summary fields across lines and recognizes both the dry-run and live-run shapes.
- The Clean "Cleaned" banner now shows e.g. **"Freed +1.39GB · 2.50GB free now · 337 items"** instead of nothing.

## Tests (`TaskReportTests`)
- `testParsesRealRunSummary` — the live footer → space/items/categories + freeChange/freeNow.
- `testParsesDryRunSummary` — preview still parses; free-space fields stay empty (nothing deleted yet).