### PR TITLE
feat(menu-bar): option to run without the menu-bar icon (#4)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -206,7 +206,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             statusBar = nil   // StatusBarController.deinit removes the item
             if #available(macOS 14, *) {
                 NSApp.setActivationPolicy(.regular)
-                if mainWC?.window == nil { openMainWindow(initial: .tool(.status)) }
+                // mainWC is retained (isReleasedWhenClosed = false), so its
+                // window is non-nil even when closed — check visibility, not nil,
+                // so hiding the menu bar always leaves a visible window.
+                if mainWC?.window?.isVisible != true { openMainWindow(initial: .tool(.status)) }
             }
         }
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -173,18 +173,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         // Retreat to a pure menu-bar agent only when the menu-bar icon is
-        // the entry point. With it disabled, keep the Dock icon so the app
-        // stays reachable after the window closes (issue #4).
-        if Store.showMenuBarIcon {
+        // the actual entry point — keyed off what we installed at launch,
+        // not the live Store value (which a mid-session toggle could change
+        // before a relaunch, stranding the app). With no status item, keep
+        // the Dock icon so the app stays reachable (issue #4).
+        if statusBar != nil {
             NSApp.setActivationPolicy(.accessory)
         }
     }
 
     /// Clicking the Dock icon (menu-bar-disabled mode) reopens the window.
+    /// When windows are already visible we return false so AppKit performs
+    /// its default raise-windows behaviour rather than us suppressing it.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
-        if !hasVisibleWindows, #available(macOS 14, *) {
-            self.openMainWindow(initial: .tool(.status))
-        }
+        guard !hasVisibleWindows else { return false }
+        if #available(macOS 14, *) { self.openMainWindow(initial: .tool(.status)) }
         return true
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -191,6 +191,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         return true
     }
 
+    // MARK: - Menu-bar visibility (live)
+
+    /// Apply the "Show menu bar icon" setting immediately, without a relaunch.
+    /// Installs/removes the status item, and when hiding it keeps a Dock
+    /// presence + an open window so the app never becomes unreachable.
+    func applyMenuBarVisibility(_ show: Bool) {
+        guard let db = db, let sampler = sampler else { return }
+        if show {
+            if statusBar == nil {
+                statusBar = StatusBarController(db: db, sampler: sampler, delegate: self)
+            }
+        } else {
+            statusBar = nil   // StatusBarController.deinit removes the item
+            if #available(macOS 14, *) {
+                NSApp.setActivationPolicy(.regular)
+                if mainWC?.window == nil { openMainWindow(initial: .tool(.status)) }
+            }
+        }
+    }
+
     // MARK: - Main menu
 
     /// Minimal AppKit main menu — shows when the app is active (.regular,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -79,8 +79,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         self.maintenance = maintenance
         maintenance.start()
 
-        self.statusBar = StatusBarController(db: db, sampler: sampler, delegate: self)
+        if Store.showMenuBarIcon {
+            self.statusBar = StatusBarController(db: db, sampler: sampler, delegate: self)
+        }
         self.setupMainMenu()
+
+        // Without the menu-bar icon there's no agent entry point (the app is
+        // LSUIElement, so no Dock icon either). Run as a regular Dock app and
+        // open the window on launch so it stays reachable (issue #4).
+        if !Store.showMenuBarIcon, #available(macOS 14, *) {
+            NSApp.setActivationPolicy(.regular)
+            self.openMainWindow(initial: .tool(.status))
+        }
 
         // Dev affordance: launch with BURROW_OPEN_ON_LAUNCH=1 to pop the
         // main window straight away (used for screenshot/verify loops).
@@ -162,8 +172,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Window delegate
 
     func windowWillClose(_ notification: Notification) {
-        // Dashboard closed → back to a pure menu-bar agent (no Dock icon).
-        NSApp.setActivationPolicy(.accessory)
+        // Retreat to a pure menu-bar agent only when the menu-bar icon is
+        // the entry point. With it disabled, keep the Dock icon so the app
+        // stays reachable after the window closes (issue #4).
+        if Store.showMenuBarIcon {
+            NSApp.setActivationPolicy(.accessory)
+        }
+    }
+
+    /// Clicking the Dock icon (menu-bar-disabled mode) reopens the window.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        if !hasVisibleWindows, #available(macOS 14, *) {
+            self.openMainWindow(initial: .tool(.status))
+        }
+        return true
     }
 
     // MARK: - Main menu

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -59,8 +59,11 @@ struct SettingsView: View {
                     }
 
                     section("Menu bar", "menubar.rectangle") {
-                        toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { Store.showMenuBarIcon = $0 }
-                        footnote("When off, Burrow shows a Dock icon instead so it stays reachable — the window opens on launch and a Dock click reopens it. Takes effect after a relaunch.")
+                        toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { on in
+                            Store.showMenuBarIcon = on
+                            AppDelegate.shared?.applyMenuBarVisibility(on)
+                        }
+                        footnote("Applies immediately. When off, Burrow shows a Dock icon instead so it stays reachable — a Dock click reopens the window.")
                     }
 
                     section("MCP query server", "antenna.radiowaves.left.and.right") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @State private var retentionDays: Int = Store.retentionDays
     @State private var autoVacuum: Bool = Store.autoVacuum
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
+    @State private var showMenuBarIcon: Bool = Store.showMenuBarIcon
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
 
@@ -55,6 +56,11 @@ struct SettingsView: View {
                             Store.sampleIntervalSeconds = $0
                         }
                         footnote("Burrow runs `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
+                    }
+
+                    section("Menu bar", "menubar.rectangle") {
+                        toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { Store.showMenuBarIcon = $0 }
+                        footnote("When off, Burrow shows a Dock icon instead so it stays reachable — the window opens on launch and a Dock click reopens it. Takes effect after a relaunch.")
                     }
 
                     section("MCP query server", "antenna.radiowaves.left.and.right") {

--- a/Sources/StatusBarController.swift
+++ b/Sources/StatusBarController.swift
@@ -50,6 +50,12 @@ final class StatusBarController {
         }
     }
 
+    deinit {
+        // Explicitly remove the item so toggling the menu-bar setting off
+        // (AppDelegate drops its reference) clears it from the bar at once.
+        NSStatusBar.system.removeStatusItem(item)
+    }
+
     @objc private func handleClick(_ sender: Any?) {
         guard let button = self.item.button else { return }
         if self.popover.isShown {

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -58,6 +58,17 @@ enum Store {
         set { d.set(newValue, forKey: "auto_vacuum") }
     }
 
+    // MARK: - Menu bar
+
+    /// Whether to install the menu-bar status item (issue #4). On by
+    /// default. When off, Burrow has no menu-bar entry point, so it runs
+    /// as a regular Dock app instead (window opens on launch, Dock click
+    /// reopens it) — read once at launch, so a change needs a relaunch.
+    static var showMenuBarIcon: Bool {
+        get { d.object(forKey: "show_menu_bar_icon") as? Bool ?? true }
+        set { d.set(newValue, forKey: "show_menu_bar_icon") }
+    }
+
     // MARK: - MCP / QueryServer
 
     /// Localhost port for the JSON HTTP server. 9277 by default

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -23,9 +23,18 @@ final class StoreTests: XCTestCase {
             "query_server_port",
             "query_server_enabled",
             "last_history_range_minutes",
+            "show_menu_bar_icon",
         ] {
             UserDefaults.standard.removeObject(forKey: k)
         }
+    }
+
+    // Issue #4: the menu-bar icon is on by default; the off-switch must
+    // persist (it's read once at launch to decide menu-bar vs Dock mode).
+    func testShowMenuBarIcon_defaultsTrueAndPersists() {
+        XCTAssertTrue(Store.showMenuBarIcon)
+        Store.showMenuBarIcon = false
+        XCTAssertFalse(Store.showMenuBarIcon)
     }
 
     func testSampleInterval_defaultsTo60() {


### PR DESCRIPTION
## What
Adds a **"Show menu bar icon"** setting (default on) so users who don't want the menu-bar item can turn it off — issue #4.

## The catch (and how it's handled)
Burrow is `LSUIElement` — no Dock icon — so the menu-bar item is the app's *only* entry point. Simply hiding it would strand the app (running, invisible, unreachable). So when the icon is disabled, Burrow runs as a regular **Dock app** instead:
- `NSApp.setActivationPolicy(.regular)` at launch + the main window opens on launch.
- The Dock icon persists after the window closes (`windowWillClose` only retreats to `.accessory` when the menu-bar icon is the entry point).
- `applicationShouldHandleReopen` reopens the window on a Dock click.

## Surface
- `Store.showMenuBarIcon` (default true), read once at launch → toggling needs a relaunch (Settings footnote says so).
- New **Menu bar** section in Settings with the toggle.
- AppDelegate installs the `StatusBarController` only when enabled.

## Tests
- `StoreTests.testShowMenuBarIcon_defaultsTrueAndPersists` — the unit-testable core; the AppKit activation-policy wiring isn't unit-testable.

Closes #4.