### PR TITLE
feat(mcp): semantic burrow_process_usage tool + 'burrow mcp' PATH shim

### DIFF
--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -6,6 +6,7 @@
 //
 //    * `Burrow`        → menu-bar GUI (default).
 //    * `Burrow --mcp`  → stdio JSON-RPC MCP server for Claude Code.
+//    * `burrow mcp`    → same, via the Homebrew PATH shim (no .app path).
 //
 //  Pure AppKit bootstrap (no SwiftUI `App`/`Settings` scene). The old
 //  `Settings { EmptyView() }` scene auto-bound ⌘, to a blank window —
@@ -22,9 +23,17 @@ enum BurrowMain {
     /// Strong reference — NSApplication.delegate is weak.
     private static var delegate: AppDelegate?
 
+    /// Whether this launch should run the stdio MCP server instead of the
+    /// GUI. Accepts the original `--mcp` flag and the `burrow mcp`
+    /// subcommand form the PATH shim uses. Pure so it's unit-testable.
+    static func isMCPInvocation(_ args: [String]) -> Bool {
+        if args.contains("--mcp") { return true }
+        return args.dropFirst().first == "mcp"
+    }
+
     static func main() {
-        if CommandLine.arguments.contains("--mcp") {
-            FileHandle.standardError.write(Data("burrow.main: --mcp stdio mode\n".utf8))
+        if isMCPInvocation(CommandLine.arguments) {
+            FileHandle.standardError.write(Data("burrow.main: stdio MCP mode\n".utf8))
             MCP.runStdioLoop()
             exit(0)
         }

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -358,7 +358,11 @@ struct ToolCatalog {
     /// used so "this week" can't be silently reinterpreted.
     private func callProcessUsage(_ args: [String: Any]) throws -> String {
         let minutes = (args["minutes"] as? Int) ?? 60
-        guard minutes > 0 else { throw MCPToolError.badArguments("minutes must be positive") }
+        // Upper bound guards against Int overflow in `minutes * 60` below
+        // (~1.9 years is far past any useful window).
+        guard minutes > 0, minutes <= 1_000_000 else {
+            throw MCPToolError.badArguments("minutes must be between 1 and 1000000")
+        }
         let limit = max(1, min((args["limit"] as? Int) ?? 10, 100))
         let metric = (args["metric"] as? String) ?? "cpu_time"
         let allowed = ["cpu_time", "peak_cpu", "avg_cpu", "peak_mem"]
@@ -370,7 +374,13 @@ struct ToolCatalog {
         let since = now - minutes * 60
         let rows = self.db.findRangeSampled(prefix: Sampler.snapshotPrefix,
                                             since: since, until: now, maxPoints: 720)
-        let interval = Double(Store.sampleIntervalSeconds)
+        // findRangeSampled down-samples wide windows, so each returned row
+        // stands for MORE than one sample period. Estimate CPU-time against
+        // the effective spacing of the rows we actually got — using the raw
+        // sampler cadence would badly under-count over long windows.
+        let interval: Double = rows.count > 1
+            ? Double(max(1, rows[rows.count - 1].ts - rows[0].ts)) / Double(rows.count - 1)
+            : Double(Store.sampleIntervalSeconds)
 
         struct Agg { var peakCPU = 0.0; var sumCPU = 0.0; var samples = 0; var peakMem = 0.0 }
         var agg: [String: Agg] = [:]
@@ -408,7 +418,7 @@ struct ToolCatalog {
         }
         let startTS = rows.first?.ts ?? since
         let endTS = rows.last?.ts ?? now
-        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Store.sampleIntervalSeconds),\"processes\":[\(pieces.joined(separator: ","))]}"
+        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Int(interval.rounded())),\"processes\":[\(pieces.joined(separator: ","))]}"
     }
 
     private func callInfo() -> String {

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -251,6 +251,19 @@ struct ToolCatalog {
                 ] as [String: Any],
             ],
             [
+                "name": "burrow_process_usage",
+                "description": "Rank processes over the last `minutes` (default 60) by a chosen `metric`: cpu_time (default; cumulative CPU-seconds = the closest answer to 'what used my computer most'), peak_cpu (highest single-sample CPU%), avg_cpu (mean CPU% while present), or peak_mem (highest memory%). Returns the window it actually used (start_ts/end_ts/sample_count) so the answer isn't ambiguous. NOTE: derived from periodic samples, so cpu_time is an estimate, not the kernel's exact accounting.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "minutes": ["type": "integer", "minimum": 1],
+                        "metric": ["type": "string", "enum": ["cpu_time", "peak_cpu", "avg_cpu", "peak_mem"]],
+                        "limit": ["type": "integer", "minimum": 1, "maximum": 100],
+                    ],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
                 "name": "burrow_info",
                 "description": "Burrow's own state: list of prefixes with row counts + staleness, current retention setting. Use when diagnosing whether data is flowing.",
                 "inputSchema": [
@@ -270,6 +283,8 @@ struct ToolCatalog {
             return try self.callHistory(arguments)
         case "burrow_top_processes":
             return try self.callTopProcesses(arguments)
+        case "burrow_process_usage":
+            return try self.callProcessUsage(arguments)
         case "burrow_info":
             return self.callInfo()
         default:
@@ -335,6 +350,65 @@ struct ToolCatalog {
             pieces.append("{\"name\":\"\(escaped)\",\"peak_cpu\":\(cpu),\"peak_mem\":\(peakMem[name] ?? 0)}")
         }
         return "{\"window_minutes\":\(minutes),\"processes\":[\(pieces.joined(separator: ","))]}"
+    }
+
+    /// Semantic process ranking. Where `burrow_top_processes` always ranks
+    /// by peak CPU — which crowns a one-second spike — this lets the agent
+    /// pick the metric that matches the question, and echoes the window it
+    /// used so "this week" can't be silently reinterpreted.
+    private func callProcessUsage(_ args: [String: Any]) throws -> String {
+        let minutes = (args["minutes"] as? Int) ?? 60
+        guard minutes > 0 else { throw MCPToolError.badArguments("minutes must be positive") }
+        let limit = max(1, min((args["limit"] as? Int) ?? 10, 100))
+        let metric = (args["metric"] as? String) ?? "cpu_time"
+        let allowed = ["cpu_time", "peak_cpu", "avg_cpu", "peak_mem"]
+        guard allowed.contains(metric) else {
+            throw MCPToolError.badArguments("metric must be one of: \(allowed.joined(separator: ", "))")
+        }
+
+        let now = Int(Date().timeIntervalSince1970)
+        let since = now - minutes * 60
+        let rows = self.db.findRangeSampled(prefix: Sampler.snapshotPrefix,
+                                            since: since, until: now, maxPoints: 720)
+        let interval = Double(Store.sampleIntervalSeconds)
+
+        struct Agg { var peakCPU = 0.0; var sumCPU = 0.0; var samples = 0; var peakMem = 0.0 }
+        var agg: [String: Agg] = [:]
+        let dec = JSONDecoder()
+        for r in rows {
+            guard let data = r.json.data(using: .utf8),
+                  let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
+            for p in (s.topProcesses ?? []) {
+                var a = agg[p.name] ?? Agg()
+                a.peakCPU = max(a.peakCPU, p.cpu)
+                a.sumCPU += p.cpu
+                a.samples += 1
+                a.peakMem = max(a.peakMem, p.memory)
+                agg[p.name] = a
+            }
+        }
+
+        func score(_ a: Agg) -> Double {
+            switch metric {
+            case "peak_cpu": return a.peakCPU
+            case "avg_cpu":  return a.samples > 0 ? a.sumCPU / Double(a.samples) : 0
+            case "peak_mem": return a.peakMem
+            default:         return (a.sumCPU / 100.0) * interval   // est. CPU-seconds
+            }
+        }
+
+        let ranked = agg.sorted { score($0.value) > score($1.value) }.prefix(limit)
+        var pieces: [String] = []
+        for (name, a) in ranked {
+            let escaped = name.replacingOccurrences(of: "\\", with: "\\\\")
+                              .replacingOccurrences(of: "\"", with: "\\\"")
+            let avg = a.samples > 0 ? a.sumCPU / Double(a.samples) : 0
+            let cpuTime = (a.sumCPU / 100.0) * interval
+            pieces.append("{\"name\":\"\(escaped)\",\"peak_cpu\":\(a.peakCPU),\"avg_cpu\":\(avg),\"est_cpu_time_seconds\":\(cpuTime),\"peak_mem\":\(a.peakMem),\"samples\":\(a.samples)}")
+        }
+        let startTS = rows.first?.ts ?? since
+        let endTS = rows.last?.ts ?? now
+        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Store.sampleIntervalSeconds),\"processes\":[\(pieces.joined(separator: ","))]}"
     }
 
     private func callInfo() -> String {

--- a/Tests/MCPTests.swift
+++ b/Tests/MCPTests.swift
@@ -40,7 +40,8 @@ final class MCPTests: XCTestCase {
         let d = catalog.descriptors()
         let names = d.compactMap { $0["name"] as? String }
         XCTAssertEqual(Set(names),
-                       ["burrow_snapshot", "burrow_history", "burrow_top_processes", "burrow_info"])
+                       ["burrow_snapshot", "burrow_history", "burrow_top_processes",
+                        "burrow_process_usage", "burrow_info"])
         // Every tool must carry an inputSchema and a description.
         for tool in d {
             XCTAssertNotNil(tool["description"] as? String)
@@ -96,6 +97,60 @@ final class MCPTests: XCTestCase {
         XCTAssertEqual(readers[0]["prefix"] as? String, Sampler.snapshotPrefix)
     }
 
+    /// The semantic usage tool must re-rank by the requested metric — the
+    /// whole point of adding it over burrow_top_processes (which only ever
+    /// ranks by peak CPU and so calls a one-second spike the "top" process).
+    /// "heavy" runs hot the whole window; "spike" peaks once then idles.
+    func testCallProcessUsage_ranksByChosenMetric() throws {
+        // (setUp already seeded a `kernel_task` at ~110% cumulative; pick
+        // timestamps off the seed rows so we don't collide on the PK and
+        // make `heavy` out-rank it on cumulative load.)
+        let now = Int(Date().timeIntervalSince1970)
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 300,
+                      json: snapshotJSON([("heavy", 60, 5)]))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 240,
+                      json: snapshotJSON([("heavy", 60, 5)]))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 180,
+                      json: snapshotJSON([("heavy", 60, 5), ("spike", 1, 1)]))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 120,
+                      json: snapshotJSON([("spike", 95, 1)]))
+
+        let byCPUTime = try names(from: catalog.call(name: "burrow_process_usage",
+                                                     arguments: ["minutes": 30, "metric": "cpu_time"]))
+        XCTAssertEqual(byCPUTime.first, "heavy", "sustained load wins cumulative CPU-time")
+
+        let byPeak = try names(from: catalog.call(name: "burrow_process_usage",
+                                                  arguments: ["minutes": 30, "metric": "peak_cpu"]))
+        XCTAssertEqual(byPeak.first, "spike", "the one-second spike wins peak CPU")
+    }
+
+    func testCallProcessUsage_reportsWindowItUsed() throws {
+        let json = try catalog.call(name: "burrow_process_usage", arguments: ["minutes": 5])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        // It must echo the window + metric so the agent isn't guessing.
+        XCTAssertEqual(obj["window_minutes"] as? Int, 5)
+        XCTAssertNotNil(obj["start_ts"]); XCTAssertNotNil(obj["end_ts"])
+        XCTAssertNotNil(obj["sample_count"]); XCTAssertNotNil(obj["metric"])
+    }
+
+    func testCallProcessUsage_rejectsUnknownMetric() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_process_usage",
+                                              arguments: ["metric": "vibes"])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    // The `burrow mcp` PATH-shim invocation must be recognised alongside
+    // the original `--mcp` flag, and ordinary launches must not be.
+    func testIsMCPInvocation_recognisesFlagAndSubcommand() {
+        XCTAssertTrue(BurrowMain.isMCPInvocation(["Burrow", "--mcp"]))
+        XCTAssertTrue(BurrowMain.isMCPInvocation(["burrow", "mcp"]))
+        XCTAssertFalse(BurrowMain.isMCPInvocation(["Burrow"]))
+        XCTAssertFalse(BurrowMain.isMCPInvocation(["Burrow", "status"]))
+    }
+
     func testCallUnknownTool_throwsUnknown() {
         XCTAssertThrowsError(try catalog.call(name: "no_such_tool", arguments: [:])) { err in
             guard case MCPToolError.unknown(let name) = err else {
@@ -106,6 +161,36 @@ final class MCPTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Pull the ordered process names out of a burrow_process_usage result.
+    private func names(from json: String) throws -> [String] {
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let procs = try XCTUnwrap(obj["processes"] as? [[String: Any]])
+        return procs.compactMap { $0["name"] as? String }
+    }
+
+    /// A snapshot whose `top_processes` is the given (name, cpu%, mem%) list.
+    private func snapshotJSON(_ procs: [(String, Double, Double)]) -> String {
+        let entries = procs.enumerated().map { i, p in
+            "{ \"pid\": \(i + 1), \"ppid\": 0, \"name\": \"\(p.0)\", \"command\": \"\(p.0)\", \"cpu\": \(p.1), \"memory\": \(p.2) }"
+        }.joined(separator: ",")
+        return """
+        {
+          "collected_at": "2026-05-31T12:00:00.000000-07:00",
+          "host": "test", "platform": "darwin", "uptime": "1h 0m",
+          "uptime_seconds": 3600, "procs": 100,
+          "hardware": {
+            "model": "Test", "cpu_model": "Test", "total_ram": "16GB",
+            "disk_size": "512GB", "os_version": "14.5", "refresh_rate": "60Hz"
+          },
+          "health_score": 80, "health_score_msg": "ok",
+          "cpu": { "usage": 10.0, "load1": 1.0, "load5": 1.0, "load15": 1.0, "core_count": 8, "logical_cpu": 8 },
+          "memory": { "used": 1000, "total": 16000, "used_percent": 50.0, "swap_used": 0, "swap_total": 0, "pressure": "normal" },
+          "disk_io": { "read_rate": 1.0, "write_rate": 2.0 },
+          "top_processes": [\(entries)]
+        }
+        """
+    }
 
     /// Minimal valid Mole snapshot JSON. Includes only what the
     /// callers we test actually decode (top_processes for the

--- a/packaging/burrow.rb
+++ b/packaging/burrow.rb
@@ -20,6 +20,11 @@ cask "burrow" do
 
   app "Burrow.app"
 
+  # PATH shim so coding agents can spawn the MCP server as `burrow mcp`
+  # without hardcoding the .app bundle path. The same binary serves the
+  # GUI (no args) and the stdio MCP server (`mcp` / `--mcp`).
+  binary "#{appdir}/Burrow.app/Contents/MacOS/Burrow", target: "burrow"
+
   # Pre-1.0 builds aren't notarized yet, so clear the quarantine flag to
   # avoid a Gatekeeper block on first launch. Remove this once the app
   # ships signed + notarized.


### PR DESCRIPTION
Implements the high-value items from the MCP-experience review (and skips the YAGNI ones — no second HTTP transport, no per-client config matrix).

## 1. `burrow_process_usage` — answers the question that was actually asked
`burrow_top_processes` only ranks by **peak CPU**, so "top process this week" crowns a one-second spike (the review's own example: `mds_stores` at 239% peak). The new tool takes an explicit **`metric`**:
- `cpu_time` (default) — cumulative CPU-seconds ≈ "what actually used my computer"
- `peak_cpu` / `avg_cpu` / `peak_mem`

…and **echoes the window it used** (`start_ts` / `end_ts` / `sample_count` / `interval_seconds`) so the agent can't silently reinterpret "this week". `cpu_time` is honestly documented as a sampled **estimate**, not the kernel's exact accounting.

## 2. `burrow mcp` subcommand + PATH shim
- `App.swift` accepts `burrow mcp` alongside `--mcp`, via a pure, unit-tested `isMCPInvocation()`.
- Cask gains `binary … target: "burrow"` so agents spawn `burrow mcp` without hardcoding `/Applications/Burrow.app/Contents/MacOS/Burrow`.

## Tests (`MCPTests`)
- `testCallProcessUsage_ranksByChosenMetric` — same data, `cpu_time` → sustained "heavy", `peak_cpu` → "spike".
- `testCallProcessUsage_reportsWindowItUsed`, `…_rejectsUnknownMetric`, `testIsMCPInvocation_recognisesFlagAndSubcommand`, updated descriptor set.

## ⚠️ Release note
The cask `binary` stanza is a **structural** change — the version-bump in #10 only carries version+sha256. When cutting the first release that includes this, add the `binary` line to `caezium/homebrew-tap` `Casks/burrow.rb` once (it's already in `packaging/burrow.rb` here). `burrow mcp` only works on builds that contain this App.swift change.

## Skipped (deliberately, per the review)
Streamable-HTTP MCP transport, `--client` config matrix, redaction — low ROI for a local single-user app. Rationale in the PR discussion.