### PR TITLE
feat(ai): Explain lens — local-model read of your Mac (slice 1)

### DIFF
--- a/Sources/Explain.swift
+++ b/Sources/Explain.swift
@@ -1,0 +1,234 @@
+//
+//  Explain.swift
+//  Burrow
+//
+//  The "Explain" lens — a narrow, optional AI layer over Burrow's OWN
+//  data. It is not a chatbot: it takes the latest sampled snapshot,
+//  asks a model to explain it in plain English, and may suggest ONE
+//  safe next step (Clean / Purge / Installers) that deep-links into the
+//  existing confirm-gated flow. It never acts on its own.
+//
+//  Design split for testability:
+//    * ExplainContext.build  — pure: snapshot → compact facts.
+//    * ExplainPrompt.make    — pure: facts → (system, user) strings.
+//    * ExplainResult.parse   — pure: model text → explanation + action.
+//    * ExplainProvider       — the only impure seam (the network call);
+//                              OllamaProvider is the local-default impl,
+//                              and tests inject a fake.
+//
+//  Backends: local-first (Ollama on localhost) ships here; a
+//  bring-your-own-key cloud provider is the next slice. Off by default;
+//  when local, nothing leaves the machine.
+//
+
+import Foundation
+
+// MARK: - Context
+
+/// The compact, privacy-conscious set of facts we hand the model. Built
+/// from the latest snapshot only — no raw history, no file contents.
+struct ExplainContext: Equatable {
+    let healthScore: Int
+    let healthMsg: String
+    let cpuUsage: Double
+    let memUsedPercent: Double
+    let memPressure: String
+    let diskUsedPercent: Double?
+    let topProcesses: [(name: String, cpu: Double, mem: Double)]
+    let ageSeconds: Int
+
+    static func == (l: ExplainContext, r: ExplainContext) -> Bool {
+        l.healthScore == r.healthScore && l.cpuUsage == r.cpuUsage
+            && l.memUsedPercent == r.memUsedPercent && l.memPressure == r.memPressure
+            && l.diskUsedPercent == r.diskUsedPercent
+            && l.topProcesses.map(\.name) == r.topProcesses.map(\.name)
+    }
+
+    /// Build from the most recent snapshot in the DB, or nil if none yet.
+    static func build(db: DB) -> ExplainContext? {
+        guard let row = db.findLatest(prefix: Sampler.snapshotPrefix),
+              let data = row.json.data(using: .utf8),
+              let s = try? JSONDecoder().decode(MoleStatus.self, from: data) else { return nil }
+        let now = Int(Date().timeIntervalSince1970)
+        let top = (s.topProcesses ?? []).sorted { $0.cpu > $1.cpu }.prefix(5)
+            .map { (name: $0.name, cpu: $0.cpu, mem: $0.memory) }
+        return ExplainContext(
+            healthScore: s.healthScore,
+            healthMsg: s.healthScoreMsg,
+            cpuUsage: s.cpu.usage,
+            memUsedPercent: s.memory.usedPercent,
+            memPressure: s.memory.pressure,
+            diskUsedPercent: s.disks.first?.usedPercent,
+            topProcesses: Array(top),
+            ageSeconds: max(0, now - row.ts))
+    }
+
+    /// Human-readable fact block for the prompt body.
+    var factSheet: String {
+        var lines = [
+            "health_score: \(healthScore)/100 (\(healthMsg))",
+            String(format: "cpu_usage: %.1f%%", cpuUsage),
+            String(format: "memory_used: %.0f%% (pressure: %@)", memUsedPercent, memPressure as NSString),
+        ]
+        if let d = diskUsedPercent { lines.append(String(format: "disk_used: %.0f%%", d)) }
+        if !topProcesses.isEmpty {
+            let procs = topProcesses.map { String(format: "%@ (%.0f%% cpu, %.0f%% mem)", $0.name as NSString, $0.cpu, $0.mem) }
+            lines.append("top_processes: " + procs.joined(separator: ", "))
+        }
+        lines.append("snapshot_age_seconds: \(ageSeconds)")
+        return lines.joined(separator: "\n")
+    }
+}
+
+// MARK: - Suggested action
+
+/// The one safe next step an explanation may recommend. Each maps to a
+/// pane Burrow already has, and only ever deep-links behind the existing
+/// confirm sheet — the lens never runs anything itself.
+enum ExplainSuggestion: String, Equatable {
+    case clean, purge, installer
+
+    var pane: Pane {
+        switch self {
+        case .clean:     return .tool(.clean)
+        case .purge:     return .tool(.purge)
+        case .installer: return .tool(.installer)
+        }
+    }
+
+    var ctaLabel: String {
+        switch self {
+        case .clean:     return "Open Clean"
+        case .purge:     return "Open Purge"
+        case .installer: return "Open Installers"
+        }
+    }
+}
+
+// MARK: - Result
+
+struct ExplainResult: Equatable {
+    let explanation: String
+    let suggestion: ExplainSuggestion?
+
+    /// Parse the model's reply. We ask it to optionally end with a line
+    /// `ACTION: clean|purge|installer|none`; everything before that is the
+    /// explanation. Tolerant of a missing/unknown action (→ no suggestion).
+    static func parse(_ raw: String) -> ExplainResult {
+        var explanationLines: [String] = []
+        var suggestion: ExplainSuggestion?
+        for line in raw.split(separator: "\n", omittingEmptySubsequences: false) {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            if t.uppercased().hasPrefix("ACTION:") {
+                let value = t.dropFirst("ACTION:".count).trimmingCharacters(in: .whitespaces).lowercased()
+                suggestion = ExplainSuggestion(rawValue: value)
+                continue   // don't echo the directive into the explanation
+            }
+            explanationLines.append(String(line))
+        }
+        let explanation = explanationLines.joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return ExplainResult(explanation: explanation, suggestion: suggestion)
+    }
+}
+
+// MARK: - Prompt
+
+enum ExplainPrompt {
+    static func make(_ ctx: ExplainContext) -> (system: String, user: String) {
+        let system = """
+        You explain a macOS user's current system health in plain, calm English. \
+        You are given a single snapshot of metrics. Be concise (2–4 sentences). \
+        Name the most likely cause of anything unusual and say whether it's normal \
+        or worth acting on. Only recommend an action when the data clearly warrants \
+        it. End your reply with exactly one line of the form `ACTION: clean`, \
+        `ACTION: purge`, `ACTION: installer`, or `ACTION: none` — \
+        clean = system/app caches, purge = old project build artifacts, \
+        installer = leftover .dmg/.pkg files. Use `none` if nothing is needed.
+        """
+        let user = "Current snapshot:\n\(ctx.factSheet)"
+        return (system, user)
+    }
+}
+
+// MARK: - Provider seam
+
+protocol ExplainProvider {
+    func complete(system: String, user: String) async throws -> String
+}
+
+enum ExplainError: LocalizedError {
+    case noData
+    case providerUnavailable(String)
+    case badResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .noData: return "No snapshot yet — wait for the first sample."
+        case .providerUnavailable(let m): return m
+        case .badResponse: return "The model returned an unexpected response."
+        }
+    }
+}
+
+/// Local-default provider: talks to an Ollama server on localhost. No key,
+/// nothing leaves the machine. If Ollama isn't running, surfaces an
+/// actionable error rather than hanging.
+struct OllamaProvider: ExplainProvider {
+    var model: String = Store.aiOllamaModel
+    var baseURL: URL = URL(string: "http://127.0.0.1:11434")!
+    var session: URLSession = .shared
+
+    /// Build the `/api/chat` request. Pure + non-private so it's testable.
+    static func makeRequest(baseURL: URL, model: String, system: String, user: String) throws -> URLRequest {
+        var req = URLRequest(url: baseURL.appendingPathComponent("api/chat"))
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "model": model,
+            "stream": false,
+            "messages": [
+                ["role": "system", "content": system],
+                ["role": "user", "content": user],
+            ],
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return req
+    }
+
+    func complete(system: String, user: String) async throws -> String {
+        let req = try OllamaProvider.makeRequest(baseURL: baseURL, model: model, system: system, user: user)
+        let data: Data
+        do {
+            (data, _) = try await session.data(for: req)
+        } catch {
+            throw ExplainError.providerUnavailable(
+                "Couldn't reach a local model (Ollama on \(baseURL.host ?? "localhost")). Is it running? `ollama run \(model)`")
+        }
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let message = obj["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw ExplainError.badResponse
+        }
+        return content
+    }
+}
+
+// MARK: - Engine
+
+/// Orchestrates build → ask → parse. The provider is injectable so tests
+/// drive the whole flow with a fake instead of the network.
+struct ExplainEngine {
+    let provider: ExplainProvider
+
+    init(provider: ExplainProvider = OllamaProvider()) {
+        self.provider = provider
+    }
+
+    func explain(db: DB) async throws -> ExplainResult {
+        guard let ctx = ExplainContext.build(db: db) else { throw ExplainError.noData }
+        let (system, user) = ExplainPrompt.make(ctx)
+        let raw = try await provider.complete(system: system, user: user)
+        return ExplainResult.parse(raw)
+    }
+}

--- a/Sources/Explain.swift
+++ b/Sources/Explain.swift
@@ -27,7 +27,7 @@ import Foundation
 
 /// The compact, privacy-conscious set of facts we hand the model. Built
 /// from the latest snapshot only — no raw history, no file contents.
-struct ExplainContext: Equatable {
+struct ExplainContext {
     let healthScore: Int
     let healthMsg: String
     let cpuUsage: Double
@@ -37,12 +37,9 @@ struct ExplainContext: Equatable {
     let topProcesses: [(name: String, cpu: Double, mem: Double)]
     let ageSeconds: Int
 
-    static func == (l: ExplainContext, r: ExplainContext) -> Bool {
-        l.healthScore == r.healthScore && l.cpuUsage == r.cpuUsage
-            && l.memUsedPercent == r.memUsedPercent && l.memPressure == r.memPressure
-            && l.diskUsedPercent == r.diskUsedPercent
-            && l.topProcesses.map(\.name) == r.topProcesses.map(\.name)
-    }
+    // (No Equatable: the tuple-array property can't synthesize it, and a
+    // hand-written one that ignored fields would be a misleading footgun.
+    // Nothing compares contexts today.)
 
     /// Build from the most recent snapshot in the DB, or nil if none yet.
     static func build(db: DB) -> ExplainContext? {
@@ -184,6 +181,9 @@ struct OllamaProvider: ExplainProvider {
         var req = URLRequest(url: baseURL.appendingPathComponent("api/chat"))
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Bound the wait so the Explain sheet stays responsive even if
+        // localhost accepts the connection but the model never replies.
+        req.timeoutInterval = 30
         let body: [String: Any] = [
             "model": model,
             "stream": false,

--- a/Sources/ExplainView.swift
+++ b/Sources/ExplainView.swift
@@ -1,0 +1,79 @@
+//
+//  ExplainView.swift
+//  Burrow
+//
+//  The Explain lens's UI: a small panel that runs the ExplainEngine over
+//  the latest snapshot and shows a plain-English read of the machine,
+//  plus — when warranted — one button that deep-links into Clean / Purge /
+//  Installers (behind their existing confirm sheets). It never acts on
+//  its own; the button just navigates.
+//
+
+import SwiftUI
+
+struct ExplainView: View {
+    let db: DB
+    var onNavigate: (Pane) -> Void
+    var onClose: () -> Void
+
+    @State private var loading = true
+    @State private var result: ExplainResult?
+    @State private var error: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Label("Explain", systemImage: "sparkles")
+                    .font(Brand.serif(18, .medium)).foregroundStyle(Brand.textPrimary)
+                Spacer()
+                Button { onClose() } label: {
+                    Image(systemName: "xmark.circle.fill").font(.system(size: 16))
+                        .foregroundStyle(Brand.textTertiary)
+                }.buttonStyle(.plain)
+            }
+
+            Group {
+                if loading {
+                    HStack(spacing: 10) {
+                        ProgressView().controlSize(.small)
+                        Text("Reading your Mac…").font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                    }
+                } else if let error {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(error).font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Button("Retry") { run() }
+                            .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.green)
+                    }
+                } else if let result {
+                    Text(result.explanation)
+                        .font(Brand.sans(13)).foregroundStyle(Brand.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if let s = result.suggestion {
+                        PillButton(title: s.ctaLabel) { onNavigate(s.pane); onClose() }
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+            Text("AI read of one snapshot — it can be wrong, and never acts on its own.")
+                .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+        }
+        .padding(18)
+        .frame(width: 440, height: 300)
+        .background(Color(hex: 0x14130E))
+        .environment(\.colorScheme, .dark)
+        .onAppear { run() }
+    }
+
+    private func run() {
+        loading = true; error = nil; result = nil
+        Task {
+            do {
+                let r = try await ExplainEngine().explain(db: db)
+                await MainActor.run { self.result = r; self.loading = false }
+            } catch {
+                await MainActor.run { self.error = error.localizedDescription; self.loading = false }
+            }
+        }
+    }
+}

--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -46,7 +46,8 @@ struct RootView: View {
     // when you leave — same lightweight pattern, fewer live timers.
     private var content: some View {
         ZStack {
-            StatusView(db: db, sampler: sampler).tabVisible(pane == .tool(.status))
+            StatusView(db: db, sampler: sampler, onNavigate: { pane = $0 })
+                .tabVisible(pane == .tool(.status))
             AnalyzeView(isActive: pane == .tool(.analyze)).tabVisible(pane == .tool(.analyze))
             SoftwareView(isActive: pane == .tool(.apps)).tabVisible(pane == .tool(.apps))
             CleanView().tabVisible(pane == .tool(.clean))

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -16,6 +16,8 @@ struct SettingsView: View {
     @State private var retentionDays: Int = Store.retentionDays
     @State private var autoVacuum: Bool = Store.autoVacuum
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
+    @State private var aiEnabled: Bool = Store.aiEnabled
+    @State private var aiOllamaModel: String = Store.aiOllamaModel
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
 
@@ -55,6 +57,19 @@ struct SettingsView: View {
                             Store.sampleIntervalSeconds = $0
                         }
                         footnote("Burrow runs `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
+                    }
+
+                    section("Explain (AI) — experimental", "sparkles") {
+                        toggleRow("Enable the Explain lens", isOn: $aiEnabled) { Store.aiEnabled = $0 }
+                        HStack {
+                            Text("Local model (Ollama)").font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
+                            Spacer()
+                            TextField("llama3.2", text: $aiOllamaModel)
+                                .textFieldStyle(.plain).font(Brand.mono(11))
+                                .multilineTextAlignment(.trailing).frame(width: 130)
+                                .onSubmit { Store.aiOllamaModel = aiOllamaModel }
+                        }
+                        footnote("Adds an \u{201C}Explain\u{201D} button to Status that reads your latest snapshot and explains it in plain English, optionally suggesting Clean/Purge/Installers. Runs against a local Ollama model by default — nothing leaves this Mac. Start it with `ollama run <model>`. (Cloud key support is coming.)")
                     }
 
                     section("MCP query server", "antenna.radiowaves.left.and.right") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -67,7 +67,9 @@ struct SettingsView: View {
                             TextField("llama3.2", text: $aiOllamaModel)
                                 .textFieldStyle(.plain).font(Brand.mono(11))
                                 .multilineTextAlignment(.trailing).frame(width: 130)
-                                .onSubmit { Store.aiOllamaModel = aiOllamaModel }
+                                // Persist on every edit, not just on Enter, so
+                                // closing Settings doesn't lose the change.
+                                .onChange(of: aiOllamaModel) { _, v in Store.aiOllamaModel = v }
                         }
                         footnote("Adds an \u{201C}Explain\u{201D} button to Status that reads your latest snapshot and explains it in plain English, optionally suggesting Clean/Purge/Installers. Runs against a local Ollama model by default — nothing leaves this Mac. Start it with `ollama run <model>`. (Cloud key support is coming.)")
                     }

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -17,9 +17,15 @@ import AppKit
 
 struct StatusView: View {
     @StateObject private var model: StatusModel
+    private let db: DB
+    var onNavigate: (Pane) -> Void
 
-    init(db: DB, sampler: Sampler) {
+    @State private var showExplain = false
+
+    init(db: DB, sampler: Sampler, onNavigate: @escaping (Pane) -> Void = { _ in }) {
         _model = StateObject(wrappedValue: StatusModel(db: db, sampler: sampler))
+        self.db = db
+        self.onNavigate = onNavigate
     }
 
     private let row1H: CGFloat = 150
@@ -29,6 +35,7 @@ struct StatusView: View {
         ScrollView {
             VStack(spacing: 13) {
                 if let s = model.snap {
+                    if Store.aiEnabled { explainBar }
                     HStack(spacing: 13) {
                         HealthCard(s: s, minHeight: row1H)
                         cpuTile(s).frame(minHeight: row1H)
@@ -53,6 +60,27 @@ struct StatusView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear { model.start() }
         .onDisappear { model.stop() }
+        .sheet(isPresented: $showExplain) {
+            ExplainView(db: db,
+                        onNavigate: { showExplain = false; onNavigate($0) },
+                        onClose: { showExplain = false })
+        }
+    }
+
+    /// Opt-in "Explain" entry point (Status pane). Hidden unless the AI
+    /// lens is enabled in Settings.
+    private var explainBar: some View {
+        HStack {
+            Spacer()
+            Button { showExplain = true } label: {
+                Label("Explain", systemImage: "sparkles")
+                    .font(Brand.mono(11, .semibold)).foregroundStyle(Tool.status.accent)
+                    .padding(.horizontal, 12).padding(.vertical, 6)
+                    .background(Capsule().fill(Tool.status.accent.opacity(0.12)))
+                    .overlay(Capsule().strokeBorder(Tool.status.accent.opacity(0.30), lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+        }
     }
 
     private var waiting: some View {

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -58,6 +58,26 @@ enum Store {
         set { d.set(newValue, forKey: "auto_vacuum") }
     }
 
+    // MARK: - AI (Explain lens)
+
+    /// Whether the optional "Explain" AI lens is enabled. Off by default —
+    /// it's opt-in, and when on it defaults to a local model so nothing
+    /// leaves the Mac.
+    static var aiEnabled: Bool {
+        get { d.object(forKey: "ai_enabled") as? Bool ?? false }
+        set { d.set(newValue, forKey: "ai_enabled") }
+    }
+
+    /// The local Ollama model the Explain lens talks to. Small + fast by
+    /// default; the user can point it at any model they've pulled.
+    static var aiOllamaModel: String {
+        get {
+            let v = (d.string(forKey: "ai_ollama_model") ?? "").trimmingCharacters(in: .whitespaces)
+            return v.isEmpty ? "llama3.2" : v
+        }
+        set { d.set(newValue, forKey: "ai_ollama_model") }
+    }
+
     // MARK: - MCP / QueryServer
 
     /// Localhost port for the JSON HTTP server. 9277 by default

--- a/Tests/ExplainTests.swift
+++ b/Tests/ExplainTests.swift
@@ -1,0 +1,140 @@
+//
+//  ExplainTests.swift
+//  BurrowTests
+//
+//  The Explain lens splits into pure pieces (context, prompt, parse) and
+//  one network seam (ExplainProvider). These tests pin the pure pieces
+//  and drive the whole engine with a fake provider — no model required.
+//
+
+import XCTest
+@testable import Burrow
+
+final class ExplainTests: XCTestCase {
+    private var tempDir: URL!
+    private var db: DB!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-explain-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        db = try DB(at: tempDir.appendingPathComponent("burrow.db"))
+    }
+
+    override func tearDown() {
+        db = nil
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Context
+
+    func testContextBuild_nilWhenNoSnapshot() {
+        XCTAssertNil(ExplainContext.build(db: db))
+    }
+
+    func testContextBuild_extractsFactsAndTopProcesses() throws {
+        let now = Int(Date().timeIntervalSince1970)
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now, json: snapshot())
+        let ctx = try XCTUnwrap(ExplainContext.build(db: db))
+        XCTAssertEqual(ctx.healthScore, 80)
+        XCTAssertEqual(ctx.cpuUsage, 91.0, accuracy: 0.001)
+        XCTAssertEqual(ctx.topProcesses.first?.name, "hot", "top process is the highest-CPU one")
+        XCTAssertTrue(ctx.factSheet.contains("health_score"))
+        XCTAssertTrue(ctx.factSheet.contains("hot"))
+    }
+
+    // MARK: - Parse
+
+    func testParse_extractsActionAndStripsDirective() {
+        let r = ExplainResult.parse("CPU is busy indexing. Safe to ignore.\nACTION: clean")
+        XCTAssertEqual(r.suggestion, .clean)
+        XCTAssertFalse(r.explanation.contains("ACTION:"), "the directive line is stripped")
+        XCTAssertTrue(r.explanation.contains("indexing"))
+    }
+
+    func testParse_noneMeansNoSuggestion() {
+        XCTAssertNil(ExplainResult.parse("Everything looks healthy.\nACTION: none").suggestion)
+    }
+
+    func testParse_toleratesMissingAction() {
+        let r = ExplainResult.parse("Just an explanation, no directive.")
+        XCTAssertNil(r.suggestion)
+        XCTAssertEqual(r.explanation, "Just an explanation, no directive.")
+    }
+
+    // MARK: - Prompt
+
+    func testPrompt_embedsFactsAndAsksForActionLine() throws {
+        let now = Int(Date().timeIntervalSince1970)
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now, json: snapshot())
+        let ctx = try XCTUnwrap(ExplainContext.build(db: db))
+        let (system, user) = ExplainPrompt.make(ctx)
+        XCTAssertTrue(system.contains("ACTION:"), "model is instructed to emit an action line")
+        XCTAssertTrue(user.contains("health_score"))
+    }
+
+    // MARK: - Ollama request shape
+
+    func testOllamaRequest_postsChatWithMessages() throws {
+        let req = try OllamaProvider.makeRequest(
+            baseURL: URL(string: "http://127.0.0.1:11434")!,
+            model: "llama3.2", system: "sys", user: "usr")
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.url?.path, "/api/chat")
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: XCTUnwrap(req.httpBody)) as? [String: Any])
+        XCTAssertEqual(body["model"] as? String, "llama3.2")
+        let messages = try XCTUnwrap(body["messages"] as? [[String: String]])
+        XCTAssertEqual(messages.map { $0["role"] }, ["system", "user"])
+    }
+
+    // MARK: - Engine end-to-end (fake provider)
+
+    func testEngine_parsesProviderReplyIntoActionableResult() async throws {
+        let now = Int(Date().timeIntervalSince1970)
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now, json: snapshot())
+        let engine = ExplainEngine(provider: FakeProvider(reply: "Disk is nearly full.\nACTION: clean"))
+        let result = try await engine.explain(db: db)
+        XCTAssertEqual(result.suggestion, .clean)
+        XCTAssertEqual(result.suggestion?.pane, .tool(.clean))
+        XCTAssertTrue(result.explanation.contains("Disk"))
+    }
+
+    func testEngine_throwsWhenNoSnapshot() async {
+        let engine = ExplainEngine(provider: FakeProvider(reply: "x"))
+        do {
+            _ = try await engine.explain(db: db)
+            XCTFail("expected noData")
+        } catch let ExplainError.noData {
+            // expected
+        } catch {
+            XCTFail("expected .noData, got \(error)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private struct FakeProvider: ExplainProvider {
+        let reply: String
+        func complete(system: String, user: String) async throws -> String { reply }
+    }
+
+    /// Snapshot with a clear top process ("hot" at 91% CPU).
+    private func snapshot() -> String {
+        return """
+        {
+          "collected_at": "2026-05-31T12:00:00.000000-07:00",
+          "host": "test", "platform": "darwin", "uptime": "1h", "uptime_seconds": 3600, "procs": 100,
+          "hardware": { "model": "T", "cpu_model": "T", "total_ram": "16GB", "disk_size": "512GB", "os_version": "14.5", "refresh_rate": "60Hz" },
+          "health_score": 80, "health_score_msg": "ok",
+          "cpu": { "usage": 91.0, "load1": 1.0, "load5": 1.0, "load15": 1.0, "core_count": 8, "logical_cpu": 8 },
+          "memory": { "used": 8000, "total": 16000, "used_percent": 70.0, "swap_used": 0, "swap_total": 0, "pressure": "warning" },
+          "disk_io": { "read_rate": 1.0, "write_rate": 2.0 },
+          "disks": [ { "mount": "/", "used": 480, "total": 512, "used_percent": 94.0, "external": false } ],
+          "top_processes": [
+            { "pid": 1, "ppid": 0, "name": "idle", "command": "x", "cpu": 2.0, "memory": 1.0 },
+            { "pid": 2, "ppid": 0, "name": "hot", "command": "x", "cpu": 91.0, "memory": 30.0 }
+          ]
+        }
+        """
+    }
+}

--- a/Tests/ExplainTests.swift
+++ b/Tests/ExplainTests.swift
@@ -104,7 +104,7 @@ final class ExplainTests: XCTestCase {
         do {
             _ = try await engine.explain(db: db)
             XCTFail("expected noData")
-        } catch let ExplainError.noData {
+        } catch ExplainError.noData {
             // expected
         } catch {
             XCTFail("expected .noData, got \(error)")


### PR DESCRIPTION
Implements the AI posture we agreed on: a **narrow Explain lens**, not a chatbot. Local-default backend, actionable suggestions.

> **Stacked on #13** (base = `feat/parity-tabs`) — the suggestions deep-link to the Purge/Installers panes that #13 adds. Merge #13 first; this then retargets to main.

## What it does
An opt-in **"Explain"** button on Status reads your *latest snapshot* and explains it in plain English ("CPU's pinned by `mds_stores` reindexing — temporary, safe to ignore"), and may suggest **one** safe step (Clean / Purge / Installers) that **deep-links into the existing confirm sheet**. It never runs anything itself.

## Architecture (built for testability + the 'local & private' story)
- **Pure core**: `ExplainContext.build` (snapshot → compact facts, no file contents/history), `ExplainPrompt.make`, `ExplainResult.parse` (model text → explanation + optional `ACTION:` directive).
- **One impure seam**: `ExplainProvider`. `OllamaProvider` talks to a **local** model on `127.0.0.1:11434` — nothing leaves the Mac. `ExplainEngine` takes an injectable provider so tests drive the whole flow with a fake.
- **Off by default**; Settings → *Explain (AI)* toggles it and sets the Ollama model.

## Tests (`ExplainTests`, 9)
context build (incl. nil-when-empty), `ACTION:` parse (clean / none / missing), prompt embeds facts + asks for the action line, Ollama request shape, and the engine end-to-end via a fake provider (→ actionable result).

## Slice 2 (next)
- **Cloud bring-your-own-key** provider (Keychain), with the backend picker (you chose local-default + optional cloud).
- **Per-process / per-spike** "explain this".
- Honest data-leaves-the-machine warning when cloud is selected.