### PR TITLE
feat(mole): guided install onboarding + version + mo update

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -41,15 +41,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var mainWC: NSWindowController?
     fileprivate var pendingInitialPane: Pane = .tool(.status)
 
+    private var installWC: NSWindowController?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppDelegate.shared = self
 
+        // No engine yet → guided install instead of a dead-end quit. The
+        // window's Recheck calls startServices() once `mo` is found.
         guard MoleCLI.findExecutable() != nil else {
-            MoleCLI.showMissingAlert()
-            NSApp.terminate(nil)
+            showInstallWindow()
             return
         }
+        startServices()
+    }
 
+    /// Guided onboarding window when `mo` is missing. Stays a regular Dock
+    /// app so the window is reachable; we never run an installer ourselves.
+    private func showInstallWindow() {
+        NSApp.setActivationPolicy(.regular)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 320),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered, defer: false)
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isReleasedWhenClosed = false
+        window.center()
+        let view = MoleInstallView(onReady: { [weak self] in
+            self?.installWC?.close()
+            self?.installWC = nil
+            self?.startServices()
+        })
+        window.contentViewController = NSHostingController(rootView: view)
+        let wc = NSWindowController(window: window)
+        self.installWC = wc
+        wc.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// The `mo`-dependent startup: open the DB, start the server/sampler/
+    /// maintenance, and install the status item. Called either directly at
+    /// launch or after the guided install finds `mo`.
+    private func startServices() {
         let db: DB
         do {
             db = try DB.openDefault()

--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -51,6 +51,33 @@ enum MoleCLI {
         return nil
     }
 
+    // MARK: - Install / version
+
+    /// Canonical install command (Homebrew). Shown in the guided install
+    /// flow; we never run it for the user.
+    static let installCommand = "brew install mole"
+    /// Where to send users without Homebrew.
+    static let repoURL = URL(string: "https://github.com/tw93/Mole")!
+
+    /// Current `mo` version, or nil if not installed / unparsable.
+    static func version() -> String? {
+        guard let res = try? run(args: ["--version"], timeout: 5) else { return nil }
+        let text = res.stdout.isEmpty ? res.stderr : res.stdout
+        return parseVersion(text)
+    }
+
+    /// Pull a semver out of `mo --version` output, whatever decoration it
+    /// wraps it in ("mole 1.41.0", "v1.41.0", …). Pure → unit-tested.
+    static func parseVersion(_ output: String) -> String? {
+        for token in output.split(whereSeparator: { !($0.isNumber || $0 == ".") }) {
+            let parts = token.split(separator: ".")
+            if parts.count >= 2, parts.allSatisfy({ Int($0) != nil }) {
+                return String(token)
+            }
+        }
+        return nil
+    }
+
     /// Modal alert shown at launch when `mo` isn't installed. We block on
     /// it because there's nothing useful Burrow can do without Mole, and a
     /// background app silently failing is the worst possible UX for this

--- a/Sources/MoleInstallView.swift
+++ b/Sources/MoleInstallView.swift
@@ -1,0 +1,89 @@
+//
+//  MoleInstallView.swift
+//  Burrow
+//
+//  Guided onboarding when the `mo` engine is missing. Burrow can't run
+//  without it, but rather than quit with a dead-end alert we show the
+//  exact install command (copyable) and a Recheck button — we never run
+//  an installer on the user's behalf. Once `mo` is found, `onReady` fires
+//  and the app continues its normal startup.
+//
+
+import SwiftUI
+import AppKit
+
+struct MoleInstallView: View {
+    /// Called when a Recheck finds `mo` on PATH — the app proceeds.
+    var onReady: () -> Void
+
+    @State private var checking = false
+    @State private var stillMissing = false
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Label("Mole engine required", systemImage: "shippingbox")
+                    .font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
+                Text("Burrow is a GUI for the Mole CLI (`mo`) — it does the scanning and cleanup. Install it, then Recheck.")
+                    .font(Brand.sans(13)).foregroundStyle(Brand.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("WITH HOMEBREW").font(Brand.mono(9, .bold)).tracking(0.6).foregroundStyle(Brand.textTertiary)
+                HStack {
+                    Text(MoleCLI.installCommand).font(Brand.mono(12)).foregroundStyle(Brand.textPrimary)
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(MoleCLI.installCommand, forType: .string)
+                        copied = true
+                    } label: {
+                        Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                            .font(Brand.mono(10)).foregroundStyle(Brand.green)
+                    }.buttonStyle(.plain)
+                }
+                .padding(11)
+                .background(RoundedRectangle(cornerRadius: 10).fill(Color.black.opacity(0.25)))
+                .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Brand.hairline, lineWidth: 1))
+
+                Button { NSWorkspace.shared.open(MoleCLI.repoURL) } label: {
+                    Text("No Homebrew? Other install options →")
+                        .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                }.buttonStyle(.plain)
+            }
+
+            if stillMissing {
+                Text("Still not finding `mo` on PATH. If you just installed it, open a new terminal first, or relaunch Burrow.")
+                    .font(Brand.mono(10)).foregroundStyle(Brand.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 12) {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .buttonStyle(.plain).font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                PillButton(title: checking ? "Checking…" : "Recheck") { recheck() }
+            }
+        }
+        .padding(22)
+        .frame(width: 460, height: 320)
+        .background(Color(hex: 0x14130E))
+        .environment(\.colorScheme, .dark)
+    }
+
+    private func recheck() {
+        checking = true; stillMissing = false; copied = false
+        DispatchQueue.global(qos: .userInitiated).async {
+            let found = MoleCLI.findExecutable() != nil
+            DispatchQueue.main.async {
+                checking = false
+                if found { onReady() } else { stillMissing = true }
+            }
+        }
+    }
+}

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -10,6 +10,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 struct SettingsView: View {
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
@@ -18,6 +19,8 @@ struct SettingsView: View {
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
+    @State private var moleVersion: String = "—"
+    @State private var moleUpdating = false
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -37,6 +40,16 @@ struct SettingsView: View {
                             }
                         }
                         footnote("History lives at ~/Library/Application Support/Burrow/burrow.db. Rows past the retention window are pruned hourly.")
+                    }
+
+                    section("Mole engine", "shippingbox") {
+                        infoRow("Version", moleVersion)
+                        HStack {
+                            Spacer()
+                            if moleUpdating { ProgressView().controlSize(.small).padding(.trailing, 4) }
+                            PillButton(title: moleUpdating ? "Updating…" : "Update Mole", filled: false) { updateMole() }
+                        }
+                        footnote("Runs `mo update` to update the Mole CLI engine Burrow drives. This is separate from Burrow's own app updates. If it needs a password or a confirmation it can't show here, run `mo update` in a terminal instead.")
                     }
 
                     section("History retention", "calendar") {
@@ -68,7 +81,37 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity)
             }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { refreshStatusLabels() }
+        .onAppear { refreshStatusLabels(); loadMoleVersion() }
+    }
+
+    // MARK: - Mole engine
+
+    private func loadMoleVersion() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let v = MoleCLI.version()
+            DispatchQueue.main.async { moleVersion = v.map { "v\($0)" } ?? "not found" }
+        }
+    }
+
+    private func updateMole() {
+        guard !moleUpdating else { return }
+        moleUpdating = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let res = try? MoleCLI.run(args: ["update"], timeout: 600)
+            let newVersion = MoleCLI.version()
+            DispatchQueue.main.async {
+                moleUpdating = false
+                if let v = newVersion { moleVersion = "v\(v)" }
+                let ok = (res?.exitCode ?? 1) == 0
+                let alert = NSAlert()
+                alert.messageText = ok ? "Mole is up to date" : "Update didn't complete"
+                alert.informativeText = ok
+                    ? "Now on \(moleVersion)."
+                    : (res?.stderr.isEmpty == false ? String(res!.stderr.prefix(300))
+                                                    : "`mo update` exited non-zero. Try running it in a terminal.")
+                alert.runModal()
+            }
+        }
     }
 
     // MARK: - Section + row helpers

--- a/Tests/MoleCLITests.swift
+++ b/Tests/MoleCLITests.swift
@@ -1,0 +1,29 @@
+//
+//  MoleCLITests.swift
+//  BurrowTests
+//
+//  parseVersion is the only pure piece of the Mole-engine lifecycle
+//  (install/version/update); the rest spawns `mo`. It must pull a semver
+//  out of whatever `mo --version` decorates it with.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoleCLITests: XCTestCase {
+    func testParseVersion_extractsSemverFromDecoratedOutput() {
+        XCTAssertEqual(MoleCLI.parseVersion("mole 1.41.0"), "1.41.0")
+        XCTAssertEqual(MoleCLI.parseVersion("v1.41.0\n"), "1.41.0")
+        XCTAssertEqual(MoleCLI.parseVersion("mole version 2.0.10 (build 7)"), "2.0.10")
+    }
+
+    func testParseVersion_nilWhenNoVersion() {
+        XCTAssertNil(MoleCLI.parseVersion("no version here"))
+        XCTAssertNil(MoleCLI.parseVersion(""))
+    }
+
+    func testParseVersion_ignoresLoneNumbers() {
+        // A bare integer isn't a version; needs at least major.minor.
+        XCTAssertNil(MoleCLI.parseVersion("built for macOS 14"))
+    }
+}


### PR DESCRIPTION
Adds Mole-engine lifecycle to the GUI: **guided install**, **version**, and **`mo update`**.

## Guided install (replaces the quit-wall)
Today, if `mo` isn't installed, Burrow shows an alert and **quits** — a dead end. Now it shows a **guided install window** (`MoleInstallView`): the exact `brew install mole` command with **Copy**, a link to other install options for non-Homebrew users, and a **Recheck** button. Per your call, it's **guided — it never runs an installer for the user**. Once Recheck finds `mo`, the app continues its normal startup.

Mechanically, AppDelegate's `mo`-dependent startup is factored into `startServices()`, called either directly at launch or after the guided install succeeds.

## Version + update
- `MoleCLI.version()` / `parseVersion()` pull a semver out of `mo --version`.
- Settings gains a **Mole engine** section: shows the installed version and an **Update Mole** button that runs `mo update` (with a clear note to use a terminal if it needs a password/confirmation it can't show inline).

## Tests
`MoleCLITests` pin `parseVersion` (decorated output, lone integers rejected, empty → nil). The install/update flows spawn `mo`, so they're not unit-tested.

## Merge notes
Independent off `main`. Touches `AppDelegate.swift` (also in #11) and `SettingsView.swift` (also in #9/#11/#14) — the Settings section is anchored after *Storage* to minimize overlap, but expect the usual trivial 'keep both' conflicts. Streamed `mo update` output is intentionally minimal here; the results-UX redesign PR will improve it.