### PR TITLE
feat(activity): mo history cleanup log (Activity pane)

### DIFF
--- a/Sources/ActivityView.swift
+++ b/Sources/ActivityView.swift
@@ -1,0 +1,138 @@
+//
+//  ActivityView.swift
+//  Burrow
+//
+//  The Activity pane — Mole's cleanup history (`mo history --json`): past
+//  clean / optimize / uninstall / purge sessions, what they removed and
+//  what they skipped or failed. Distinct from the metrics "History" pane.
+//
+
+import SwiftUI
+
+struct ActivityView: View {
+    @StateObject private var model = ActivityModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header.padding(.horizontal, 20).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { model.loadIfNeeded() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Activity").font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
+                Text("Recent Mole cleanup sessions").font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+            Spacer()
+            Button { model.reload() } label: {
+                Image(systemName: "arrow.clockwise").font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Brand.textSecondary)
+            }.buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.loading {
+            VStack { Spacer(); ProgressView("Reading history…").controlSize(.large)
+                .font(Brand.mono(11)); Spacer() }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.sessions.isEmpty {
+            VStack(spacing: 8) {
+                Spacer()
+                Image(systemName: "clock.badge.questionmark").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
+                Text("No cleanup history yet").font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
+                Text("Run a Clean or Optimize and it'll show up here.").font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                Spacer()
+            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(model.sessions) { SessionRow(session: $0) }
+                }
+                .padding(.horizontal, 18).padding(.vertical, 12)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+private struct SessionRow: View {
+    let session: HistorySession
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Image(systemName: glyph).font(.system(size: 12, weight: .semibold)).foregroundStyle(accent)
+                    Text(session.command.capitalized).font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                    if !session.isComplete {
+                        Text("incomplete").font(Brand.mono(9)).foregroundStyle(Brand.orange)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Capsule().fill(Brand.orange.opacity(0.15)))
+                    }
+                    Spacer()
+                    Text(session.startedAt).font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                }
+                HStack(spacing: 14) {
+                    stat("\(session.items)", "items")
+                    if !session.size.isEmpty, session.size != "0B" { stat(session.size, "freed") }
+                    if session.removed > 0 { stat("\(session.removed)", "removed", Brand.green) }
+                    if session.skipped > 0 { stat("\(session.skipped)", "skipped", Brand.textSecondary) }
+                    if session.failed > 0 { stat("\(session.failed)", "failed", Brand.red) }
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    private func stat(_ value: String, _ label: String, _ color: Color = Brand.textPrimary) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text(value).font(Brand.mono(12, .semibold)).foregroundStyle(color)
+            Text(label).font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+        }
+    }
+
+    private var glyph: String {
+        switch session.command {
+        case "clean":     return "sparkles"
+        case "optimize":  return "wand.and.stars"
+        case "uninstall": return "trash"
+        case "purge":     return "folder.badge.minus"
+        case "installer": return "arrow.down.app"
+        default:          return "clock.arrow.circlepath"
+        }
+    }
+    private var accent: Color {
+        switch session.command {
+        case "clean":     return Tool.clean.accent
+        case "optimize":  return Tool.optimize.accent
+        case "uninstall": return Tool.apps.accent
+        default:          return Brand.textSecondary
+        }
+    }
+}
+
+@MainActor
+final class ActivityModel: ObservableObject {
+    @Published var sessions: [HistorySession] = []
+    @Published var loading = false
+    private var started = false
+
+    func loadIfNeeded() { guard !started else { return }; started = true; reload() }
+
+    func reload() {
+        loading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let parsed = MoleHistory.load()
+            Task { @MainActor in
+                self.sessions = parsed
+                self.loading = false
+            }
+        }
+    }
+}

--- a/Sources/MoleHistory.swift
+++ b/Sources/MoleHistory.swift
@@ -1,0 +1,64 @@
+//
+//  MoleHistory.swift
+//  Burrow
+//
+//  Thin wrapper around `mo history --json` — Mole's record of past
+//  cleanup/optimize/uninstall sessions. Distinct from Burrow's own
+//  metrics "History" (the SQLite sample series); this is the cleanup
+//  activity log. We just spawn, parse, and return typed sessions.
+//
+
+import Foundation
+
+struct HistorySession: Identifiable {
+    let id = UUID()
+    let command: String        // "clean", "optimize", "uninstall", …
+    let startedAt: String
+    let endedAt: String        // "" when the session didn't finish cleanly
+    let items: Int
+    let size: String           // human string from Mole, e.g. "2.93GB"
+    let operationCount: Int
+    let removed: Int
+    let trashed: Int
+    let skipped: Int
+    let failed: Int
+
+    var isComplete: Bool { !endedAt.isEmpty }
+}
+
+enum MoleHistory {
+    /// Decode `mo history --json`. Loose: we only depend on `sessions[*]`
+    /// and the fields we surface; unknown keys can drift upstream freely.
+    static func parse(_ data: Data) -> [HistorySession] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sessions = obj["sessions"] as? [[String: Any]] else { return [] }
+        return sessions.map { s in
+            let actions = s["actions"] as? [String: Any] ?? [:]
+            return HistorySession(
+                command: s["command"] as? String ?? "?",
+                startedAt: s["started_at"] as? String ?? "",
+                endedAt: s["ended_at"] as? String ?? "",
+                items: intVal(s["items"]),
+                size: s["size"] as? String ?? "",
+                operationCount: intVal(s["operation_count"]),
+                removed: intVal(actions["removed"]),
+                trashed: intVal(actions["trashed"]),
+                skipped: intVal(actions["skipped"]),
+                failed: intVal(actions["failed"]))
+        }
+    }
+
+    /// Run `mo history --json` and parse it. Synchronous — call off-main.
+    static func load() -> [HistorySession] {
+        guard let res = try? MoleCLI.run(args: ["history", "--json"], timeout: 30),
+              res.exitCode == 0,
+              let data = res.stdout.data(using: .utf8) else { return [] }
+        return parse(data)
+    }
+
+    private static func intVal(_ v: Any?) -> Int {
+        if let i = v as? Int { return i }
+        if let d = v as? Double { return Int(d) }
+        return 0
+    }
+}

--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -58,6 +58,9 @@ struct RootView: View {
             if pane == .history {
                 HistoryView(db: db)
             }
+            if pane == .activity {
+                ActivityView()
+            }
         }
     }
 }

--- a/Sources/Tool.swift
+++ b/Sources/Tool.swift
@@ -92,6 +92,7 @@ enum Pane: Equatable, Hashable {
     case tool(Tool)
     case settings
     case history
+    case activity
 
     /// Window tint scrim. Tools carry their own colour; the utilities use
     /// a neutral dark so they read as "chrome", not a sixth tool.
@@ -99,7 +100,7 @@ enum Pane: Equatable, Hashable {
         switch self {
         case .tool(let t):
             return t.scrim
-        case .settings, .history:
+        case .settings, .history, .activity:
             return LinearGradient(colors: [Color(hex: 0x16150F).opacity(0.90), Brand.nearBlack.opacity(0.97)],
                                   startPoint: .top, endPoint: .bottom)
         }

--- a/Sources/TopNav.swift
+++ b/Sources/TopNav.swift
@@ -37,6 +37,7 @@ struct TopNav: View {
 
     private var utilityGroup: some View {
         HStack(spacing: 2) {
+            utility("list.bullet.rectangle", pane: .activity)
             utility("clock.arrow.circlepath", pane: .history)
             utility("gearshape", pane: .settings)
         }

--- a/Tests/MoleHistoryTests.swift
+++ b/Tests/MoleHistoryTests.swift
@@ -1,0 +1,50 @@
+//
+//  MoleHistoryTests.swift
+//  BurrowTests
+//
+//  Pins the `mo history --json` parser against a real sample of Mole's
+//  output shape.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoleHistoryTests: XCTestCase {
+    private let sample = """
+    {
+      "logs": {"operations": "/x/operations.log"},
+      "limit": 20,
+      "sessions": [
+        { "command": "clean", "started_at": "2026-06-06 20:33:49", "ended_at": "2026-06-06 20:35:23",
+          "items": 118, "size": "2.93GB", "operation_count": 126,
+          "actions": {"removed": 100, "trashed": 0, "skipped": 24, "failed": 2, "rebuilt": 0, "other": 0} },
+        { "command": "optimize", "started_at": "2026-06-06 20:32:46", "ended_at": "",
+          "items": 0, "size": "0B", "operation_count": 0,
+          "actions": {"removed": 0, "trashed": 0, "skipped": 0, "failed": 0} }
+      ]
+    }
+    """
+
+    func testParse_mapsSessionsAndActions() {
+        let sessions = MoleHistory.parse(Data(sample.utf8))
+        XCTAssertEqual(sessions.count, 2)
+        let clean = sessions[0]
+        XCTAssertEqual(clean.command, "clean")
+        XCTAssertEqual(clean.items, 118)
+        XCTAssertEqual(clean.size, "2.93GB")
+        XCTAssertEqual(clean.removed, 100)
+        XCTAssertEqual(clean.skipped, 24)
+        XCTAssertEqual(clean.failed, 2)
+        XCTAssertTrue(clean.isComplete)
+    }
+
+    func testParse_emptyEndedAtMeansIncomplete() {
+        let sessions = MoleHistory.parse(Data(sample.utf8))
+        XCTAssertFalse(sessions[1].isComplete, "blank ended_at → session didn't finish")
+    }
+
+    func testParse_toleratesGarbage() {
+        XCTAssertEqual(MoleHistory.parse(Data("not json".utf8)).count, 0)
+        XCTAssertEqual(MoleHistory.parse(Data("{}".utf8)).count, 0)
+    }
+}


### PR DESCRIPTION
Adds support for **`mo history`** — Mole's log of past cleanup sessions — as a new **Activity** pane (list icon in the top-nav utilities, next to History/Settings).

## What
- **`MoleHistory.parse/load`** decodes `mo history --json` into typed `HistorySession`s (command, started/ended, items, freed size, and the removed/trashed/skipped/failed action counts).
- **`ActivityView`** renders session cards: per-command glyph + colour (clean/optimize/uninstall/purge/installer), key stats, and an *incomplete* badge when a session has no `ended_at`.
- New **`Pane.activity`** + TopNav utility + RootView routing. (This is the cleanup-activity log — distinct from Burrow's metrics *History* pane.)

## Tests (`MoleHistoryTests`)
Parser pinned against a real `mo history --json` sample: field mapping, incomplete (`ended_at: ""`) sessions, and garbage tolerance.

## Merge notes
Off `main`. Touches `Tool.swift` (the `Pane` enum — separate region from #13's `Tool` cases), `RootView.swift` (#13/#14), `TopNav.swift` (clean). Trivial 'keep both' at worst.