### PR TITLE
feat(installers): choose which leftover installers to remove

### DIFF
--- a/Sources/CleanupFinder.swift
+++ b/Sources/CleanupFinder.swift
@@ -1,0 +1,88 @@
+//
+//  CleanupFinder.swift
+//  Burrow
+//
+//  Burrow-side scanners for the file-based cleanup tools where the user
+//  should choose WHAT to remove. Mole's `installer`/`purge` are interactive
+//  TUIs with no scriptable selection, so for genuine in-app selection we
+//  find the candidates ourselves and move only the chosen ones to the
+//  Trash (recoverable, no sudo). Clean stays on `mo` — system caches need
+//  Mole's whitelist + elevation, which we don't want to reimplement.
+//
+//  The scan functions take their directories as a parameter so they're
+//  unit-testable against a temp folder.
+//
+
+import Foundation
+
+/// One removable thing the user can select. `id` is the absolute path so a
+/// re-scan keeps selection stable.
+struct FileFinding: Identifiable, Hashable {
+    var id: String { path }
+    let name: String
+    let path: String
+    let size: Int64
+    let isDir: Bool
+    let location: String   // human label, e.g. "Downloads"
+}
+
+/// Leftover installer files (`.dmg`, `.pkg`, `.iso`, `.xip`) — the same
+/// types `mo installer` targets — found in the standard download spots.
+enum InstallerFinder {
+    static let extensions: Set<String> = ["dmg", "pkg", "iso", "xip"]
+
+    /// Standard download locations. Each has an Info.plist usage string, so
+    /// macOS prompts once with a clear message instead of the per-folder
+    /// flood the cache scanners trigger.
+    static func defaultDirs() -> [(label: String, url: URL)] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            ("Downloads", home.appendingPathComponent("Downloads")),
+            ("Desktop", home.appendingPathComponent("Desktop")),
+            ("Documents", home.appendingPathComponent("Documents")),
+        ]
+    }
+
+    /// Scan the given directories (top level only) for installer files,
+    /// largest first.
+    static func scan(in dirs: [(label: String, url: URL)]) -> [FileFinding] {
+        let fm = FileManager.default
+        var out: [FileFinding] = []
+        for (label, dir) in dirs {
+            guard let items = try? fm.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: [.fileSizeKey, .isDirectoryKey],
+                options: [.skipsHiddenFiles]) else { continue }
+            for url in items where extensions.contains(url.pathExtension.lowercased()) {
+                let vals = try? url.resourceValues(forKeys: [.fileSizeKey, .isDirectoryKey])
+                // Logical size — matches what Finder and `mo` report.
+                let size = Int64(vals?.fileSize ?? 0)
+                out.append(FileFinding(name: url.lastPathComponent, path: url.path,
+                                       size: size, isDir: vals?.isDirectory ?? false,
+                                       location: label))
+            }
+        }
+        return out.sorted { $0.size > $1.size }
+    }
+
+    static func scan() -> [FileFinding] { scan(in: defaultDirs()) }
+}
+
+/// Move the given paths to the Trash. Returns the paths that couldn't be
+/// trashed (e.g. permission denied) so the UI can report partial failure.
+/// Trash is recoverable, so this never permanently deletes.
+enum CleanupTrasher {
+    @discardableResult
+    static func trash(_ paths: [String]) -> [String] {
+        let fm = FileManager.default
+        var failed: [String] = []
+        for path in paths {
+            do {
+                try fm.trashItem(at: URL(fileURLWithPath: path), resultingItemURL: nil)
+            } catch {
+                failed.append(path)
+            }
+        }
+        return failed
+    }
+}

--- a/Sources/InstallerView.swift
+++ b/Sources/InstallerView.swift
@@ -1,0 +1,186 @@
+//
+//  InstallerView.swift
+//  Burrow
+//
+//  The Installers tool — pick which leftover installer files to remove,
+//  instead of the all-or-nothing `mo installer` run. Mole's `installer` is
+//  an interactive TUI we can't drive over stdio, so Burrow scans the
+//  standard download spots itself (InstallerFinder), shows a checklist like
+//  the Uninstall tab, and moves only the chosen files to the Trash
+//  (recoverable, no sudo).
+//
+
+import SwiftUI
+import AppKit
+
+struct InstallerView: View {
+    @StateObject private var model = InstallerModel()
+    var isActive: Bool = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            content
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            bottomBar.padding(.horizontal, 18).padding(.vertical, 10)
+        }
+        .onAppear { if isActive { model.startIfNeeded() } }
+        .onChange(of: isActive) { _, now in if now { model.startIfNeeded() } }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Text("Installers").font(Brand.serif(18, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(model.summaryLine).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+            Spacer()
+            Button { model.refresh() } label: {
+                Label("Rescan", systemImage: "arrow.clockwise")
+                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+            }.buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.loading {
+            VStack { Spacer()
+                ProgressView("Scanning for installers…").controlSize(.large)
+                    .tint(Tool.installer.accent).font(Brand.mono(11))
+                Spacer() }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.items.isEmpty {
+            VStack(spacing: 8) { Spacer()
+                Image(systemName: "checkmark.seal").font(.system(size: 26)).foregroundStyle(Tool.installer.accent)
+                Text("No leftover installers found.").font(Brand.sans(13)).foregroundStyle(Brand.textSecondary)
+                Text("Checked Downloads, Desktop, and Documents for .dmg / .pkg / .iso / .xip.")
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                Spacer() }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(model.items) { item in
+                        FindingRow(item: item, accent: Tool.installer.accent,
+                                   selected: model.selected.contains(item.id)) { model.toggle(item.id) }
+                        Rectangle().fill(Brand.hairline).frame(height: 1).padding(.leading, 58)
+                    }
+                }
+                .padding(.horizontal, 10).padding(.vertical, 4)
+            }
+            .scrollIndicators(.visible)
+        }
+    }
+
+    private var bottomBar: some View {
+        HStack {
+            Text(model.selectionLabel).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+            Spacer()
+            if !model.items.isEmpty {
+                Button { model.toggleAll() } label: {
+                    Text(model.allSelected ? "select none" : "select all")
+                        .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                }.buttonStyle(.plain).padding(.trailing, 8)
+            }
+            Button { model.confirmAndTrash() } label: {
+                Text("Move to Trash\(model.selected.isEmpty ? "" : " (\(model.selected.count))")")
+                    .font(Brand.sans(12, .semibold))
+                    .foregroundStyle(model.selected.isEmpty ? Brand.textTertiary : .white)
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .background(Capsule().fill(model.selected.isEmpty ? Color.white.opacity(0.06) : Tool.installer.accent))
+            }
+            .buttonStyle(.plain)
+            .disabled(model.selected.isEmpty)
+        }
+    }
+}
+
+/// A selectable file row (icon, name, size · location, checkbox). Shared
+/// shape with the Uninstall tab's AppRow.
+struct FindingRow: View {
+    let item: FileFinding
+    let accent: Color
+    let selected: Bool
+    let onToggle: () -> Void
+    @State private var hover = false
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: NSWorkspace.shared.icon(forFile: item.path))
+                .resizable().frame(width: 28, height: 28)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.name).font(Brand.sans(13, .medium)).foregroundStyle(Brand.textPrimary).lineLimit(1)
+                Text("\(Fmt.bytes(item.size)) · \(item.location)")
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary).lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: 17)).foregroundStyle(selected ? accent : Brand.textTertiary)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 8)
+        .background(hover ? Brand.cardFillHover : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { hover = $0 }
+        .onTapGesture { onToggle() }
+    }
+}
+
+@MainActor
+final class InstallerModel: ObservableObject {
+    @Published var items: [FileFinding] = []
+    @Published var selected: Set<String> = []
+    @Published var loading = false
+    private var started = false
+
+    var summaryLine: String {
+        items.isEmpty ? "" : "\(items.count) found · \(Fmt.bytes(items.reduce(Int64(0)) { $0 + $1.size }))"
+    }
+    var selectionLabel: String {
+        if selected.isEmpty { return items.isEmpty ? "Nothing to remove" : "\(items.count) installers" }
+        let total = items.filter { selected.contains($0.id) }.reduce(Int64(0)) { $0 + $1.size }
+        return "\(selected.count) selected · \(Fmt.bytes(total))"
+    }
+    var allSelected: Bool { !items.isEmpty && selected.count == items.count }
+
+    func startIfNeeded() { guard !started else { return }; started = true; load() }
+    func refresh() { load() }
+    func toggle(_ id: String) { if selected.contains(id) { selected.remove(id) } else { selected.insert(id) } }
+    func toggleAll() { selected = allSelected ? [] : Set(items.map { $0.id }) }
+
+    func load() {
+        loading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let found = InstallerFinder.scan()
+            Task { @MainActor in
+                self.items = found
+                self.selected = self.selected.intersection(Set(found.map { $0.id }))   // drop stale
+                self.loading = false
+            }
+        }
+    }
+
+    /// Confirm, then move the selected files to the Trash. User action only.
+    func confirmAndTrash() {
+        let targets = items.filter { selected.contains($0.id) }
+        guard !targets.isEmpty else { return }
+        let alert = NSAlert()
+        alert.messageText = "Move \(targets.count) installer\(targets.count == 1 ? "" : "s") to the Trash?"
+        alert.informativeText = "These move to the Trash (recoverable):\n\n"
+            + targets.prefix(12).map { "• \($0.name)" }.joined(separator: "\n")
+            + (targets.count > 12 ? "\n… and \(targets.count - 12) more" : "")
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Move to Trash")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let failed = CleanupTrasher.trash(targets.map { $0.path })
+        if !failed.isEmpty {
+            let f = NSAlert()
+            f.messageText = "Couldn't remove \(failed.count) item\(failed.count == 1 ? "" : "s")"
+            f.informativeText = "Some files couldn't be moved to the Trash (permission denied or in use)."
+            f.runModal()
+        }
+        selected = []
+        load()
+    }
+}

--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -51,7 +51,7 @@ struct RootView: View {
             SoftwareView(isActive: pane == .tool(.apps)).tabVisible(pane == .tool(.apps))
             CleanView().tabVisible(pane == .tool(.clean))
             StreamingToolView(action: .purge).tabVisible(pane == .tool(.purge))
-            StreamingToolView(action: .installer).tabVisible(pane == .tool(.installer))
+            InstallerView(isActive: pane == .tool(.installer)).tabVisible(pane == .tool(.installer))
             OptimizeView().tabVisible(pane == .tool(.optimize))
 
             if pane == .settings {

--- a/Tests/CleanupFinderTests.swift
+++ b/Tests/CleanupFinderTests.swift
@@ -1,0 +1,63 @@
+//
+//  CleanupFinderTests.swift
+//  BurrowTests
+//
+//  InstallerFinder.scan(in:) is the selectable-installers feature's only
+//  non-UI logic, and it takes its directories as a parameter so it can be
+//  pinned against a temp folder.
+//
+
+import XCTest
+@testable import Burrow
+
+final class CleanupFinderTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-finder-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func write(_ name: String, bytes: Int) throws {
+        try Data(count: bytes).write(to: tempDir.appendingPathComponent(name))
+    }
+
+    func testScan_returnsOnlyInstallerTypesBySizeDescending() throws {
+        try write("small.dmg", bytes: 100)
+        try write("big.pkg", bytes: 1_000)
+        try write("notes.txt", bytes: 500)         // wrong type — excluded
+        try write("archive.zip", bytes: 800)        // not an installer type here — excluded
+
+        let found = InstallerFinder.scan(in: [("Test", tempDir)])
+        XCTAssertEqual(found.map { $0.name }, ["big.pkg", "small.dmg"], "installer types only, largest first")
+        XCTAssertEqual(found.first?.size, 1_000)
+        XCTAssertEqual(found.first?.location, "Test")
+        XCTAssertEqual(found.first?.name, "big.pkg")
+        XCTAssertTrue(found.first?.path.hasSuffix("/big.pkg") ?? false)
+    }
+
+    func testScan_isCaseInsensitiveOnExtension() throws {
+        try write("Installer.DMG", bytes: 42)
+        let found = InstallerFinder.scan(in: [("Test", tempDir)])
+        XCTAssertEqual(found.map { $0.name }, ["Installer.DMG"])
+    }
+
+    func testScan_missingDirectoryIsSkippedNotFatal() {
+        let ghost = tempDir.appendingPathComponent("does-not-exist")
+        let found = InstallerFinder.scan(in: [("Gone", ghost), ("Test", tempDir)])
+        XCTAssertTrue(found.isEmpty)
+    }
+
+    func testTrash_movesFilesToTrashAndReportsFailures() throws {
+        try write("toss.dmg", bytes: 10)
+        let real = tempDir.appendingPathComponent("toss.dmg").path
+        let failed = CleanupTrasher.trash([real, "/nonexistent/nope.dmg"])
+        XCTAssertEqual(failed, ["/nonexistent/nope.dmg"], "the missing path fails; the real one is trashed")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: real), "trashed file no longer at its path")
+    }
+}


### PR DESCRIPTION
## Why
The Purge/Installers tools ran `mo` **all-or-nothing** — unlike the Uninstall tab, you couldn't pick what to remove.

## What I found
`mo installer` and `mo purge` are **interactive TUIs** (`Space` select / `Enter` confirm) with **no JSON and no flags for targeted deletion**; `mo clean` only has a `--whitelist` (exclusion). None can be driven over stdio for per-item selection.

## Approach
So for genuine in-GUI selection, Burrow finds the candidates itself and trashes only the chosen ones:
- **`InstallerFinder`** scans Downloads / Desktop / Documents for `.dmg/.pkg/.iso/.xip` (the types `mo installer` targets), largest first.
- **`InstallerView`** shows a checklist like the Uninstall tab (select all / none, running size total) and a confirm sheet.
- **`CleanupTrasher`** moves selected files to the **Trash** — recoverable, no `sudo`, and it reports any that couldn't be removed.
- Only 3 standard folders are touched, each with an Info.plist usage string, so macOS prompts once (no per-folder flood).

## Tests (`CleanupFinderTests`)
Type filter + size-descending order, case-insensitive extension, missing-dir skipped, and trash + partial-failure reporting.

## Scope
- **Clean** stays on `mo` (system caches + Mole's whitelist + elevation — unsafe to reimplement).
- **Purge** is the natural next step: same finder pattern, but scanning the configured `purge_paths` for dev-artifact dirs (node_modules, target/, build, __pycache__…). Filed as a follow-up.

Stacked on #13 (needs the `.installer` tool). Replaces `StreamingToolView(action: .installer)` in RootView.