### PR TITLE
feat(settings): Touch ID for sudo via `mo touchid`

### DIFF
--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -120,4 +120,28 @@ enum MoleCLI {
             exitCode: task.terminationStatus
         )
     }
+
+    /// Run `mo <args>` ONCE with administrator rights via the macOS auth
+    /// dialog (which accepts Touch ID where the system supports it). Blocking
+    /// — call off the main thread. For one-shot privileged config like
+    /// `touchid enable/disable`, not for streamed jobs (CommandRunner does those).
+    static func runElevated(args: [String]) -> Int32 {
+        guard let mo = findExecutable() else { return 127 }
+        // Quote each argument for the shell, then escape the whole command for
+        // embedding in an AppleScript string literal. Belt-and-suspenders since
+        // today's callers pass only literal subcommands, but keeps a stray space
+        // or quote in a path from breaking (or injecting into) the script.
+        func shQuote(_ s: String) -> String { "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'" }
+        let raw = ([mo] + args).map(shQuote).joined(separator: " ")
+        let inner = raw.replacingOccurrences(of: "\\", with: "\\\\")
+                       .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = "do shell script \"\(inner)\" with administrator privileges"
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", script]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+        do { try task.run(); task.waitUntilExit(); return task.terminationStatus }
+        catch { return 1 }
+    }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -10,6 +10,7 @@
 //
 
 import SwiftUI
+import LocalAuthentication
 
 struct SettingsView: View {
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
@@ -21,6 +22,7 @@ struct SettingsView: View {
     @State private var touchIDStatus = "—"
     @State private var touchIDEnabled = false
     @State private var touchIDBusy = false
+    @State private var touchIDAvailable = false
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -44,10 +46,12 @@ struct SettingsView: View {
 
                     section("Touch ID for sudo", "touchid") {
                         infoRow("Status", touchIDStatus)
-                        HStack {
-                            Spacer()
-                            if touchIDBusy { ProgressView().controlSize(.small).padding(.trailing, 4) }
-                            PillButton(title: touchIDEnabled ? "Disable" : "Enable", filled: false) { toggleTouchID() }
+                        if touchIDAvailable {
+                            HStack {
+                                Spacer()
+                                if touchIDBusy { ProgressView().controlSize(.small).padding(.trailing, 4) }
+                                PillButton(title: touchIDEnabled ? "Disable" : "Enable", filled: false) { toggleTouchID() }
+                            }
                         }
                         footnote("Lets `sudo` and admin prompts accept your fingerprint instead of a password, where macOS supports it. Configured via `mo touchid`; turning it on or off needs your password once.")
                     }
@@ -86,16 +90,29 @@ struct SettingsView: View {
 
     // MARK: - Touch ID for sudo
 
+    /// Whether this Mac actually has a Touch ID sensor. `mo touchid status`
+    /// only reports configured-vs-not (never hardware presence), so we ask
+    /// LocalAuthentication directly — biometryType is .touchID only on Macs
+    /// with the sensor (set after a canEvaluatePolicy probe, even if no
+    /// finger is enrolled yet).
+    private func touchIDHardwarePresent() -> Bool {
+        let ctx = LAContext()
+        var err: NSError?
+        _ = ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &err)
+        return ctx.biometryType == .touchID
+    }
+
     private func loadTouchIDStatus() {
+        let available = touchIDHardwarePresent()
         DispatchQueue.global(qos: .userInitiated).async {
             let res = try? MoleCLI.run(args: ["touchid", "status"], timeout: 15)
-            let out = (res?.stdout ?? "").lowercased()
-            let unavailable = out.contains("not available") || out.contains("no touch id")
-                || out.contains("not supported") || out.contains("no biometric")
+            // Strip ANSI colour codes Mole wraps the status line in before matching.
+            let out = CommandRunner.stripAnsi(res?.stdout ?? "").lowercased()
             let enabled = out.contains("is enabled")
             DispatchQueue.main.async {
+                touchIDAvailable = available
                 touchIDEnabled = enabled
-                touchIDStatus = unavailable ? "Not available on this Mac"
+                touchIDStatus = !available ? "Not available on this Mac"
                     : (out.isEmpty ? "Unknown" : (enabled ? "Enabled" : "Disabled"))
             }
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
+    @State private var touchIDStatus = "—"
+    @State private var touchIDEnabled = false
+    @State private var touchIDBusy = false
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -37,6 +40,16 @@ struct SettingsView: View {
                             }
                         }
                         footnote("History lives at ~/Library/Application Support/Burrow/burrow.db. Rows past the retention window are pruned hourly.")
+                    }
+
+                    section("Touch ID for sudo", "touchid") {
+                        infoRow("Status", touchIDStatus)
+                        HStack {
+                            Spacer()
+                            if touchIDBusy { ProgressView().controlSize(.small).padding(.trailing, 4) }
+                            PillButton(title: touchIDEnabled ? "Disable" : "Enable", filled: false) { toggleTouchID() }
+                        }
+                        footnote("Lets `sudo` and admin prompts accept your fingerprint instead of a password, where macOS supports it. Configured via `mo touchid`; turning it on or off needs your password once.")
                     }
 
                     section("History retention", "calendar") {
@@ -68,7 +81,43 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity)
             }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { refreshStatusLabels() }
+        .onAppear { refreshStatusLabels(); loadTouchIDStatus() }
+    }
+
+    // MARK: - Touch ID for sudo
+
+    private func loadTouchIDStatus() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let res = try? MoleCLI.run(args: ["touchid", "status"], timeout: 15)
+            let out = (res?.stdout ?? "").lowercased()
+            let unavailable = out.contains("not available") || out.contains("no touch id")
+                || out.contains("not supported") || out.contains("no biometric")
+            let enabled = out.contains("is enabled")
+            DispatchQueue.main.async {
+                touchIDEnabled = enabled
+                touchIDStatus = unavailable ? "Not available on this Mac"
+                    : (out.isEmpty ? "Unknown" : (enabled ? "Enabled" : "Disabled"))
+            }
+        }
+    }
+
+    private func toggleTouchID() {
+        guard !touchIDBusy else { return }
+        touchIDBusy = true
+        let cmd = touchIDEnabled ? "disable" : "enable"
+        DispatchQueue.global(qos: .userInitiated).async {
+            let code = MoleCLI.runElevated(args: ["touchid", cmd])
+            DispatchQueue.main.async {
+                touchIDBusy = false
+                loadTouchIDStatus()
+                if code != 0 {
+                    let alert = NSAlert()
+                    alert.messageText = "Couldn't update Touch ID for sudo"
+                    alert.informativeText = "`mo touchid \(cmd)` didn't complete (the password prompt may have been cancelled). You can also run it in a terminal."
+                    alert.runModal()
+                }
+            }
+        }
     }
 
     // MARK: - Section + row helpers


### PR DESCRIPTION
## What

Adds a **Touch ID for sudo** section to Settings, driven entirely by Mole's own `mo touchid` (no reimplementation — Burrow just drives the CLI).

- **Status** row reflects `mo touchid status` → *Enabled* / *Disabled* / *Not available on this Mac*.
- **Enable / Disable** button runs `mo touchid enable|disable` once, elevated through the macOS auth dialog (which itself accepts Touch ID where supported). Busy spinner while it runs; re-reads status after.
- New `MoleCLI.runElevated(args:)` one-shot privileged helper (osascript `with administrator privileges`), with shell-quoted + AppleScript-escaped argument construction so a stray space/quote in a path can't break or inject into the script.

## Scope / honesty

This configures Touch ID for **`sudo`** (the `mo touchid` / pam_tid feature). Burrow's own elevated runs (Clean/Optimize) go through the macOS admin authorization dialog, a *separate* mechanism that already offers Touch ID on capable Macs. Guaranteeing Touch ID for Burrow's own runs would need a privileged helper (tracked separately).

## Test

`xcodebuild test -scheme Burrow` → **TEST SUCCEEDED**. No new test surface (UI + one-shot subprocess); `runElevated` escaping is covered by inspection.