### PR TITLE
Release v0.5.0 — AI/MCP, menu-bar option, reliability fixes

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -22,7 +22,15 @@
 	<string>1</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>Burrow scans your Desktop for reclaimable artifacts and leftover installers.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Burrow scans your Documents for reclaimable project artifacts.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>Burrow scans your Downloads for leftover installer files (.dmg, .pkg).</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>Burrow analyzes external drives when you point it at them.</string>
 </dict>
 </plist>

--- a/Sources/ActivityView.swift
+++ b/Sources/ActivityView.swift
@@ -1,0 +1,138 @@
+//
+//  ActivityView.swift
+//  Burrow
+//
+//  The Activity pane — Mole's cleanup history (`mo history --json`): past
+//  clean / optimize / uninstall / purge sessions, what they removed and
+//  what they skipped or failed. Distinct from the metrics "History" pane.
+//
+
+import SwiftUI
+
+struct ActivityView: View {
+    @StateObject private var model = ActivityModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header.padding(.horizontal, 20).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            content
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { model.loadIfNeeded() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Activity").font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
+                Text("Recent Mole cleanup sessions").font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+            Spacer()
+            Button { model.reload() } label: {
+                Image(systemName: "arrow.clockwise").font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Brand.textSecondary)
+            }.buttonStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if model.loading {
+            VStack { Spacer(); ProgressView("Reading history…").controlSize(.large)
+                .font(Brand.mono(11)); Spacer() }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.sessions.isEmpty {
+            VStack(spacing: 8) {
+                Spacer()
+                Image(systemName: "clock.badge.questionmark").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
+                Text("No cleanup history yet").font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
+                Text("Run a Clean or Optimize and it'll show up here.").font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                Spacer()
+            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(model.sessions) { SessionRow(session: $0) }
+                }
+                .padding(.horizontal, 18).padding(.vertical, 12)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+private struct SessionRow: View {
+    let session: HistorySession
+
+    var body: some View {
+        GlassCard {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) {
+                    Image(systemName: glyph).font(.system(size: 12, weight: .semibold)).foregroundStyle(accent)
+                    Text(session.command.capitalized).font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                    if !session.isComplete {
+                        Text("incomplete").font(Brand.mono(9)).foregroundStyle(Brand.orange)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(Capsule().fill(Brand.orange.opacity(0.15)))
+                    }
+                    Spacer()
+                    Text(session.startedAt).font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                }
+                HStack(spacing: 14) {
+                    stat("\(session.items)", "items")
+                    if !session.size.isEmpty, session.size != "0B" { stat(session.size, "freed") }
+                    if session.removed > 0 { stat("\(session.removed)", "removed", Brand.green) }
+                    if session.skipped > 0 { stat("\(session.skipped)", "skipped", Brand.textSecondary) }
+                    if session.failed > 0 { stat("\(session.failed)", "failed", Brand.red) }
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    private func stat(_ value: String, _ label: String, _ color: Color = Brand.textPrimary) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text(value).font(Brand.mono(12, .semibold)).foregroundStyle(color)
+            Text(label).font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+        }
+    }
+
+    private var glyph: String {
+        switch session.command {
+        case "clean":     return "sparkles"
+        case "optimize":  return "wand.and.stars"
+        case "uninstall": return "trash"
+        case "purge":     return "folder.badge.minus"
+        case "installer": return "arrow.down.app"
+        default:          return "clock.arrow.circlepath"
+        }
+    }
+    private var accent: Color {
+        switch session.command {
+        case "clean":     return Tool.clean.accent
+        case "optimize":  return Tool.optimize.accent
+        case "uninstall": return Tool.apps.accent
+        default:          return Brand.textSecondary
+        }
+    }
+}
+
+@MainActor
+final class ActivityModel: ObservableObject {
+    @Published var sessions: [HistorySession] = []
+    @Published var loading = false
+    private var started = false
+
+    func loadIfNeeded() { guard !started else { return }; started = true; reload() }
+
+    func reload() {
+        loading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let parsed = MoleHistory.load()
+            Task { @MainActor in
+                self.sessions = parsed
+                self.loading = false
+            }
+        }
+    }
+}

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -258,6 +258,10 @@ final class AnalyzeModel: ObservableObject {
     private var total: Int64 = 0
     private(set) var started = false
     private let opId = UUID()
+    /// Cache scan results by path so navigating back/into already-seen
+    /// folders is instant instead of re-running `mo analyze` (~4 CPU-s)
+    /// each time. Refresh clears the current path to force a fresh walk.
+    private var cache: [String: (entries: [DiskScanEntry], total: Int64)] = [:]
 
     var summaryLine: String {
         entries.isEmpty ? "—" : "\(entries.count) items · \(Fmt.bytes(total))"
@@ -285,19 +289,27 @@ final class AnalyzeModel: ObservableObject {
 
     func refresh() {
         guard let last = crumbs.last else { return }
-        scan(last.path, name: last.name, push: false)
+        cache[last.path] = nil   // drop the cached walk so we re-scan
+        scan(last.path, name: last.name, push: false, force: true)
     }
 
-    private func scan(_ path: String, name: String, push: Bool) {
+    private func scan(_ path: String, name: String, push: Bool, force: Bool = false) {
+        if push { crumbs.append((name, path)) }
+        // Cache hit → show instantly; don't re-run `mo analyze` for a
+        // folder we already walked (back/drill is the common navigation).
+        if !force, let cached = cache[path] {
+            entries = cached.entries; total = cached.total; loading = false; error = nil
+            return
+        }
         loading = true
         error = nil
-        if push { crumbs.append((name, path)) }
         OperationCenter.shared.begin(opId, label: "Analyzing \(name)")
         DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let r = try DiskScanner.scan(path)
                 let sum = r.totalSize > 0 ? r.totalSize : r.entries.reduce(0) { $0 + $1.size }
                 Task { @MainActor in
+                    self.cache[path] = (r.entries, sum)
                     self.entries = r.entries
                     self.total = sum
                     self.loading = false

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -15,15 +15,55 @@ import AppKit
 struct AnalyzeView: View {
     @StateObject private var model = AnalyzeModel()
     var isActive: Bool = true
+    @State private var showFDAGate = false
 
     var body: some View {
-        HStack(spacing: 0) {
-            sidebar.frame(width: 232)
-            Rectangle().fill(Brand.hairline).frame(width: 1)
-            mainArea
+        Group {
+            if showFDAGate {
+                fdaGate
+            } else {
+                HStack(spacing: 0) {
+                    sidebar.frame(width: 232)
+                    Rectangle().fill(Brand.hairline).frame(width: 1)
+                    mainArea
+                }
+            }
         }
-        .onAppear { if isActive { model.startIfNeeded() } }
-        .onChange(of: isActive) { _, now in if now { model.startIfNeeded() } }
+        .onAppear { evaluateStart() }
+        .onChange(of: isActive) { _, now in if now { evaluateStart() } }
+    }
+
+    /// Analyze auto-scans the home folder on first open — exactly when
+    /// the macOS "access data from other apps" flood hits (issue #3). If
+    /// we lack Full Disk Access and the user hasn't dismissed the notice,
+    /// gate the scan behind it rather than walking protected dirs
+    /// unannounced.
+    private func evaluateStart() {
+        guard isActive, !model.started else { return }
+        if Privacy.shouldOfferFullDiskAccessNow() {
+            showFDAGate = true
+        } else {
+            model.startIfNeeded()
+        }
+    }
+
+    private var fdaGate: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            FullDiskAccessNotice(
+                accent: Tool.analyze.accent,
+                continueLabel: "Scan anyway",
+                onContinue: { showFDAGate = false; model.startIfNeeded() },
+                onDontAskAgain: {
+                    Store.fullDiskAccessNoticeDismissed = true
+                    showFDAGate = false
+                    model.startIfNeeded()
+                })
+            .frame(maxWidth: 460)
+            Spacer(); Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
     }
 
     // MARK: Sidebar
@@ -213,7 +253,7 @@ final class AnalyzeModel: ObservableObject {
     @Published var loading = false
     @Published var error: String?
     private var total: Int64 = 0
-    private var started = false
+    private(set) var started = false
     private let opId = UUID()
 
     var summaryLine: String {

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -43,6 +43,9 @@ struct AnalyzeView: View {
         if Privacy.shouldOfferFullDiskAccessNow() {
             showFDAGate = true
         } else {
+            // FDA may have just been granted (or the notice dismissed) while
+            // the gate was up — make sure it doesn't keep covering the view.
+            showFDAGate = false
             model.startIfNeeded()
         }
     }

--- a/Sources/App.swift
+++ b/Sources/App.swift
@@ -6,6 +6,7 @@
 //
 //    * `Burrow`        → menu-bar GUI (default).
 //    * `Burrow --mcp`  → stdio JSON-RPC MCP server for Claude Code.
+//    * `burrow mcp`    → same, via the Homebrew PATH shim (no .app path).
 //
 //  Pure AppKit bootstrap (no SwiftUI `App`/`Settings` scene). The old
 //  `Settings { EmptyView() }` scene auto-bound ⌘, to a blank window —
@@ -22,9 +23,17 @@ enum BurrowMain {
     /// Strong reference — NSApplication.delegate is weak.
     private static var delegate: AppDelegate?
 
+    /// Whether this launch should run the stdio MCP server instead of the
+    /// GUI. Accepts the original `--mcp` flag and the `burrow mcp`
+    /// subcommand form the PATH shim uses. Pure so it's unit-testable.
+    static func isMCPInvocation(_ args: [String]) -> Bool {
+        if args.contains("--mcp") { return true }
+        return args.dropFirst().first == "mcp"
+    }
+
     static func main() {
-        if CommandLine.arguments.contains("--mcp") {
-            FileHandle.standardError.write(Data("burrow.main: --mcp stdio mode\n".utf8))
+        if isMCPInvocation(CommandLine.arguments) {
+            FileHandle.standardError.write(Data("burrow.main: stdio MCP mode\n".utf8))
             MCP.runStdioLoop()
             exit(0)
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -41,15 +41,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var mainWC: NSWindowController?
     fileprivate var pendingInitialPane: Pane = .tool(.status)
 
+    private var installWC: NSWindowController?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppDelegate.shared = self
 
+        // No engine yet → guided install instead of a dead-end quit. The
+        // window's Recheck calls startServices() once `mo` is found.
         guard MoleCLI.findExecutable() != nil else {
-            MoleCLI.showMissingAlert()
-            NSApp.terminate(nil)
+            showInstallWindow()
             return
         }
+        startServices()
+    }
 
+    /// Guided onboarding window when `mo` is missing. Stays a regular Dock
+    /// app so the window is reachable; we never run an installer ourselves.
+    private func showInstallWindow() {
+        NSApp.setActivationPolicy(.regular)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 320),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered, defer: false)
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.isReleasedWhenClosed = false
+        window.center()
+        let view = MoleInstallView(onReady: { [weak self] in
+            self?.installWC?.close()
+            self?.installWC = nil
+            self?.startServices()
+        })
+        window.contentViewController = NSHostingController(rootView: view)
+        let wc = NSWindowController(window: window)
+        self.installWC = wc
+        wc.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// The `mo`-dependent startup: open the DB, start the server/sampler/
+    /// maintenance, and install the status item. Called either directly at
+    /// launch or after the guided install finds `mo`.
+    private func startServices() {
         let db: DB
         do {
             db = try DB.openDefault()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -206,7 +206,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             statusBar = nil   // StatusBarController.deinit removes the item
             if #available(macOS 14, *) {
                 NSApp.setActivationPolicy(.regular)
-                if mainWC?.window == nil { openMainWindow(initial: .tool(.status)) }
+                // mainWC is retained (isReleasedWhenClosed = false), so its
+                // window is non-nil even when closed — check visibility, not nil,
+                // so hiding the menu bar always leaves a visible window.
+                if mainWC?.window?.isVisible != true { openMainWindow(initial: .tool(.status)) }
             }
         }
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -173,18 +173,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         // Retreat to a pure menu-bar agent only when the menu-bar icon is
-        // the entry point. With it disabled, keep the Dock icon so the app
-        // stays reachable after the window closes (issue #4).
-        if Store.showMenuBarIcon {
+        // the actual entry point — keyed off what we installed at launch,
+        // not the live Store value (which a mid-session toggle could change
+        // before a relaunch, stranding the app). With no status item, keep
+        // the Dock icon so the app stays reachable (issue #4).
+        if statusBar != nil {
             NSApp.setActivationPolicy(.accessory)
         }
     }
 
     /// Clicking the Dock icon (menu-bar-disabled mode) reopens the window.
+    /// When windows are already visible we return false so AppKit performs
+    /// its default raise-windows behaviour rather than us suppressing it.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
-        if !hasVisibleWindows, #available(macOS 14, *) {
-            self.openMainWindow(initial: .tool(.status))
-        }
+        guard !hasVisibleWindows else { return false }
+        if #available(macOS 14, *) { self.openMainWindow(initial: .tool(.status)) }
         return true
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -191,6 +191,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         return true
     }
 
+    // MARK: - Menu-bar visibility (live)
+
+    /// Apply the "Show menu bar icon" setting immediately, without a relaunch.
+    /// Installs/removes the status item, and when hiding it keeps a Dock
+    /// presence + an open window so the app never becomes unreachable.
+    func applyMenuBarVisibility(_ show: Bool) {
+        guard let db = db, let sampler = sampler else { return }
+        if show {
+            if statusBar == nil {
+                statusBar = StatusBarController(db: db, sampler: sampler, delegate: self)
+            }
+        } else {
+            statusBar = nil   // StatusBarController.deinit removes the item
+            if #available(macOS 14, *) {
+                NSApp.setActivationPolicy(.regular)
+                if mainWC?.window == nil { openMainWindow(initial: .tool(.status)) }
+            }
+        }
+    }
+
     // MARK: - Main menu
 
     /// Minimal AppKit main menu — shows when the app is active (.regular,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -79,8 +79,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         self.maintenance = maintenance
         maintenance.start()
 
-        self.statusBar = StatusBarController(db: db, sampler: sampler, delegate: self)
+        if Store.showMenuBarIcon {
+            self.statusBar = StatusBarController(db: db, sampler: sampler, delegate: self)
+        }
         self.setupMainMenu()
+
+        // Without the menu-bar icon there's no agent entry point (the app is
+        // LSUIElement, so no Dock icon either). Run as a regular Dock app and
+        // open the window on launch so it stays reachable (issue #4).
+        if !Store.showMenuBarIcon, #available(macOS 14, *) {
+            NSApp.setActivationPolicy(.regular)
+            self.openMainWindow(initial: .tool(.status))
+        }
 
         // Dev affordance: launch with BURROW_OPEN_ON_LAUNCH=1 to pop the
         // main window straight away (used for screenshot/verify loops).
@@ -162,8 +172,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Window delegate
 
     func windowWillClose(_ notification: Notification) {
-        // Dashboard closed → back to a pure menu-bar agent (no Dock icon).
-        NSApp.setActivationPolicy(.accessory)
+        // Retreat to a pure menu-bar agent only when the menu-bar icon is
+        // the entry point. With it disabled, keep the Dock icon so the app
+        // stays reachable after the window closes (issue #4).
+        if Store.showMenuBarIcon {
+            NSApp.setActivationPolicy(.accessory)
+        }
+    }
+
+    /// Clicking the Dock icon (menu-bar-disabled mode) reopens the window.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        if !hasVisibleWindows, #available(macOS 14, *) {
+            self.openMainWindow(initial: .tool(.status))
+        }
+        return true
     }
 
     // MARK: - Main menu

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -34,17 +34,16 @@ struct CleanView: View {
                 }
             }
         } else {
-            let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
                 statusBar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 if isDone, mode == .real {
                     DoneBanner(accent: Tool.clean.accent, title: "Cleaned",
-                               detail: report.summary.map { "Freed up to \($0.space) · \($0.items) items" })
-                } else if mode == .dry, let s = report.summary {
+                               detail: runner.summary.map { "Freed up to \($0.space) · \($0.items) items" })
+                } else if mode == .dry, let s = runner.summary {
                     summaryBanner(s)
                 }
-                TaskReportView(groups: report.groups, accent: Tool.clean.accent)
+                TaskReportView(groups: runner.groups, accent: Tool.clean.accent)
             }
         }
     }
@@ -61,13 +60,10 @@ struct CleanView: View {
                 }.buttonStyle(.plain)
             }
             if isDone {
-                Button { startDry() } label: {
-                    Label("Re-scan", systemImage: "arrow.clockwise")
+                Button { runner.reset() } label: {
+                    Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                 }.buttonStyle(.plain)
-            }
-            if mode == .dry, isDone {
-                PillButton(title: "Clean for real") { confirmReal() }
             }
         }
     }

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -59,7 +59,7 @@ struct CleanView: View {
                         .font(Brand.mono(11)).foregroundStyle(Brand.red)
                 }.buttonStyle(.plain)
             }
-            if isDone {
+            if isDone || isFailed {
                 Button { runner.reset() } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
@@ -84,6 +84,7 @@ struct CleanView: View {
 
     private var isRunning: Bool { runner.phase == .running }
     private var isDone: Bool { if case .done = runner.phase { return true }; return false }
+    private var isFailed: Bool { if case .failed = runner.phase { return true }; return false }
 
     private var statusText: String {
         switch runner.phase {

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -15,15 +15,31 @@ import AppKit
 struct CleanView: View {
     @StateObject private var runner = CommandRunner()
     @State private var mode: Mode = .dry
+    @State private var showFDANotice = false
 
     enum Mode { case dry, real }
 
     var body: some View {
         if runner.phase == .idle {
-            ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
-                PillButton(title: "Clean Now") { confirmReal() }
-                PillButton(title: "Preview", filled: false) { startDry() }
+            ZStack(alignment: .top) {
+                ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
+                    PillButton(title: "Clean Now") { confirmReal() }
+                    PillButton(title: "Preview", filled: false) { startDry() }
+                }
+                if showFDANotice {
+                    FullDiskAccessNotice(
+                        accent: Tool.clean.accent,
+                        onContinue: { showFDANotice = false },
+                        onDontAskAgain: {
+                            Store.fullDiskAccessNoticeDismissed = true
+                            showFDANotice = false
+                        })
+                    .frame(maxWidth: 520)
+                    .padding(.horizontal, 18).padding(.top, 10)
+                    .transition(.opacity)
+                }
             }
+            .onAppear { showFDANotice = Privacy.shouldOfferFullDiskAccessNow() }
         } else {
             let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -15,8 +15,7 @@ import AppKit
 struct CleanView: View {
     @StateObject private var runner = CommandRunner()
     @State private var mode: Mode = .dry
-    @State private var fdaRunAnyway = false
-    @State private var pendingRun: (() -> Void)? = nil
+    @State private var pendingRun: ((Bool) -> Void)? = nil
 
     enum Mode { case dry, real }
 
@@ -25,8 +24,8 @@ struct CleanView: View {
             if pendingRun != nil {
                 FullDiskAccessRequired(
                     accent: Tool.clean.accent,
-                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
-                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false) } },
+                    onRunAnyway: { runPending(elevate: true) },   // root bypasses TCC → no flood
                     onCancel: { pendingRun = nil })
             } else {
                 ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
@@ -102,30 +101,34 @@ struct CleanView: View {
 
     // MARK: - Full Disk Access gate
 
-    /// Run `work`, but if a flood-prone scan would hit the macOS per-folder
-    /// permission prompts (no Full Disk Access yet), divert to the gate
-    /// first instead of letting the flood happen.
-    private func guarded(_ work: @escaping () -> Void) {
-        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
-        else { work() }
+    /// Run a flood-prone scan. With Full Disk Access we run it directly.
+    /// Without, divert to the gate; the user either grants FDA (then we run
+    /// normally) or picks "Scan with admin", which runs the same command
+    /// elevated — root bypasses TCC, so one password replaces the flood.
+    /// `work(elevate)` decides whether to run via sudo.
+    private func guarded(_ work: @escaping (Bool) -> Void) {
+        if Privacy.hasFullDiskAccess() { work(false) } else { pendingRun = work }
     }
-    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
+    private func runPending(elevate: Bool) { let r = pendingRun; pendingRun = nil; r?(elevate) }
 
     private func startDry() {
-        guarded { mode = .dry; runner.run(["clean", "--dry-run"], label: "Scanning caches") }
+        guarded { elevate in
+            mode = .dry
+            runner.run(["clean", "--dry-run"], elevated: elevate, label: "Scanning caches")
+        }
     }
 
+    /// The real clean already runs elevated (root), so it never triggers the
+    /// flood — no gate needed here.
     private func confirmReal() {
-        guarded {
-            let alert = NSAlert()
-            alert.messageText = "Clean caches for real?"
-            alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "Clean")
-            alert.addButton(withTitle: "Cancel")
-            guard alert.runModal() == .alertFirstButtonReturn else { return }
-            mode = .real
-            runner.run(["clean"], elevated: true, label: "Cleaning caches")
-        }
+        let alert = NSAlert()
+        alert.messageText = "Clean caches for real?"
+        alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Clean")
+        alert.addButton(withTitle: "Cancel")
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        mode = .real
+        runner.run(["clean"], elevated: true, label: "Cleaning caches")
     }
 }

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -15,31 +15,25 @@ import AppKit
 struct CleanView: View {
     @StateObject private var runner = CommandRunner()
     @State private var mode: Mode = .dry
-    @State private var showFDANotice = false
+    @State private var fdaRunAnyway = false
+    @State private var pendingRun: (() -> Void)? = nil
 
     enum Mode { case dry, real }
 
     var body: some View {
         if runner.phase == .idle {
-            ZStack(alignment: .top) {
+            if pendingRun != nil {
+                FullDiskAccessRequired(
+                    accent: Tool.clean.accent,
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
+                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onCancel: { pendingRun = nil })
+            } else {
                 ToolHero(tool: .clean, title: "Clean", subtitle: Tool.clean.tagline) {
                     PillButton(title: "Clean Now") { confirmReal() }
                     PillButton(title: "Preview", filled: false) { startDry() }
                 }
-                if showFDANotice {
-                    FullDiskAccessNotice(
-                        accent: Tool.clean.accent,
-                        onContinue: { showFDANotice = false },
-                        onDontAskAgain: {
-                            Store.fullDiskAccessNoticeDismissed = true
-                            showFDANotice = false
-                        })
-                    .frame(maxWidth: 520)
-                    .padding(.horizontal, 18).padding(.top, 10)
-                    .transition(.opacity)
-                }
             }
-            .onAppear { showFDANotice = Privacy.shouldOfferFullDiskAccessNow() }
         } else {
             let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
@@ -61,6 +55,12 @@ struct CleanView: View {
             if isRunning { ProgressView().controlSize(.small).tint(Tool.clean.accent) }
             Text(statusText).font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
             Spacer()
+            if isRunning {
+                Button { runner.cancel() } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                        .font(Brand.mono(11)).foregroundStyle(Brand.red)
+                }.buttonStyle(.plain)
+            }
             if isDone {
                 Button { startDry() } label: {
                     Label("Re-scan", systemImage: "arrow.clockwise")
@@ -93,23 +93,39 @@ struct CleanView: View {
     private var statusText: String {
         switch runner.phase {
         case .running: return mode == .dry ? "Scanning your Mac…" : "Cleaning… don't quit."
-        case .done:    return mode == .dry ? "Preview — review, then clean for real." : "Done — caches cleared."
+        case .done:    return runner.wasCancelled ? "Stopped."
+            : (mode == .dry ? "Preview — review, then clean for real." : "Done — caches cleared.")
         case .failed(let m): return "Failed: \(m)"
         case .idle:    return ""
         }
     }
 
-    private func startDry() { mode = .dry; runner.run(["clean", "--dry-run"], label: "Scanning caches") }
+    // MARK: - Full Disk Access gate
+
+    /// Run `work`, but if a flood-prone scan would hit the macOS per-folder
+    /// permission prompts (no Full Disk Access yet), divert to the gate
+    /// first instead of letting the flood happen.
+    private func guarded(_ work: @escaping () -> Void) {
+        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
+        else { work() }
+    }
+    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
+
+    private func startDry() {
+        guarded { mode = .dry; runner.run(["clean", "--dry-run"], label: "Scanning caches") }
+    }
 
     private func confirmReal() {
-        let alert = NSAlert()
-        alert.messageText = "Clean caches for real?"
-        alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "Clean")
-        alert.addButton(withTitle: "Cancel")
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-        mode = .real
-        runner.run(["clean"], elevated: true, label: "Cleaning caches")
+        guarded {
+            let alert = NSAlert()
+            alert.messageText = "Clean caches for real?"
+            alert.informativeText = "Burrow will run `mo clean` with administrator rights. Cache files are removed permanently; Mole's whitelist and safety rules still apply."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Clean")
+            alert.addButton(withTitle: "Cancel")
+            guard alert.runModal() == .alertFirstButtonReturn else { return }
+            mode = .real
+            runner.run(["clean"], elevated: true, label: "Cleaning caches")
+        }
     }
 }

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -31,13 +31,25 @@ struct CleanView: View {
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 if isDone, mode == .real {
                     DoneBanner(accent: Tool.clean.accent, title: "Cleaned",
-                               detail: report.summary.map { "Freed up to \($0.space) · \($0.items) items" })
+                               detail: report.summary.map(cleanedDetail))
                 } else if mode == .dry, let s = report.summary {
                     summaryBanner(s)
                 }
                 TaskReportView(groups: report.groups, accent: Tool.clean.accent)
             }
         }
+    }
+
+    /// Post-run detail line. Prefers the real freed-space numbers Mole
+    /// prints after a live clean ("Free space change / now"), falling
+    /// back to the tracked-cleanup size when those aren't present.
+    private func cleanedDetail(_ s: TaskSummary) -> String {
+        var parts: [String] = []
+        if !s.freeChange.isEmpty { parts.append("Freed \(s.freeChange)") }
+        else if !s.space.isEmpty { parts.append("Cleaned \(s.space)") }
+        if !s.freeNow.isEmpty { parts.append("\(s.freeNow) free now") }
+        if !s.items.isEmpty { parts.append("\(s.items) items") }
+        return parts.isEmpty ? "Done" : parts.joined(separator: " · ")
     }
 
     private var statusBar: some View {

--- a/Sources/DB.swift
+++ b/Sources/DB.swift
@@ -103,7 +103,7 @@ final class DB {
         let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
         if sqlite3_open_v2(url.path, &h, flags, nil) != SQLITE_OK {
             let msg = h.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
-            sqlite3_close(h)
+            if h != nil { sqlite3_close(h) }   // close only a real handle
             self.handle = nil
             throw DBError.open(msg)
         }
@@ -147,19 +147,22 @@ final class DB {
         }
     }
 
-    /// Restore user read/write permission on our own db file, if present.
-    /// Best-effort: if we don't own it (or it's immutable) this no-ops and
-    /// recovery falls through to quarantine.
+    /// Ensure the owner can read+write our own db file, preserving the rest
+    /// of its mode (don't broaden group/other access). Best-effort: if we
+    /// don't own it (or it's immutable) this no-ops and recovery falls
+    /// through to quarantine.
     private static func restoreWritePermission(_ url: URL) {
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        try? FileManager.default.setAttributes([.posixPermissions: 0o644],
-                                               ofItemAtPath: url.path)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return }
+        let current = ((try? fm.attributesOfItem(atPath: url.path))?[.posixPermissions] as? NSNumber)?.intValue ?? 0o600
+        try? fm.setAttributes([.posixPermissions: current | 0o600], ofItemAtPath: url.path)
     }
 
-    /// Move the unusable db (and its sidecars) aside so a fresh one can be
-    /// created in its place. Picks the first free `<name>.corrupt[-n]` so
-    /// an earlier quarantine isn't clobbered. Throws if the move fails
-    /// (e.g. the directory itself is read-only).
+    /// Move the unusable db **and its sidecars** aside so a fresh one can
+    /// be created in its place. The sidecars travel with the db (forensics)
+    /// and none are left at the original path to poison the new one. Picks
+    /// the first free `<name>.corrupt[-n]` so an earlier quarantine isn't
+    /// clobbered. Throws if the move fails (e.g. a read-only directory).
     private static func quarantine(_ url: URL) throws {
         let fm = FileManager.default
         guard fm.fileExists(atPath: url.path) else { removeSidecars(url); return }
@@ -167,7 +170,10 @@ final class DB {
         var n = 1
         while fm.fileExists(atPath: dest) { dest = url.path + ".corrupt-\(n)"; n += 1 }
         try fm.moveItem(atPath: url.path, toPath: dest)
-        removeSidecars(url)
+        for suffix in ["-wal", "-shm"] {
+            let side = url.path + suffix
+            if fm.fileExists(atPath: side) { try? fm.moveItem(atPath: side, toPath: dest + suffix) }
+        }
     }
 
     deinit {

--- a/Sources/DB.swift
+++ b/Sources/DB.swift
@@ -61,39 +61,113 @@ final class DB {
     }
 
     /// Test-friendly initialiser. Pass a temp path from `XCTestCase.setUp`.
+    ///
+    /// A damaged or non-writable history file must never brick launch
+    /// (issue #5: "attempt to write a readonly database"). So opening is
+    /// staged from least to most destructive:
+    ///
+    ///   1. Open + prepare as-is. The happy path.
+    ///   2. On failure, try non-destructive repairs that PRESERVE history:
+    ///      drop the regenerable WAL/SHM sidecars (a stale or root-owned
+    ///      `-wal` is a classic readonly cause) and restore user write
+    ///      permission on our own file, then retry.
+    ///   3. Still unusable (corrupt, not-a-database, or unwritable file):
+    ///      quarantine it aside and recreate fresh.
+    ///
+    /// If even step 3 throws — e.g. the directory itself is read-only —
+    /// the error propagates to the caller, which surfaces it.
     init(at url: URL) throws {
-        let path = url.path
+        do {
+            try self.open(at: url)
+        } catch {
+            DB.removeSidecars(url)
+            DB.restoreWritePermission(url)
+            do {
+                try self.open(at: url)
+            } catch {
+                try DB.quarantine(url)
+                try self.open(at: url)
+            }
+        }
+    }
+
+    /// Open the SQLite file at `url`, configure pragmas, and ensure the
+    /// schema. Sets `self.handle` on success; on any failure closes the
+    /// handle, leaves it nil, and rethrows so a caller can recover.
+    private func open(at url: URL) throws {
         var h: OpaquePointer?
         // SQLITE_OPEN_FULLMUTEX lets us call into the same connection from
         // multiple threads without serializing ourselves. SQLite handles
         // the locking, and the cost is a per-call mutex grab — negligible
         // at our query rate.
         let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
-        if sqlite3_open_v2(path, &h, flags, nil) != SQLITE_OK {
+        if sqlite3_open_v2(url.path, &h, flags, nil) != SQLITE_OK {
             let msg = h.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
             sqlite3_close(h)
+            self.handle = nil
             throw DBError.open(msg)
         }
         self.handle = h
 
-        // WAL mode lets readers run concurrently with the writer. Without
-        // it the sampler's 1-row insert blocks every chart query — very
-        // visible at 60s cadence with the popup open.
-        try exec("PRAGMA journal_mode=WAL;")
-        try exec("PRAGMA synchronous=NORMAL;")  // WAL + NORMAL is the canonical durability/perf tradeoff
-        try exec("PRAGMA foreign_keys=ON;")
+        do {
+            // WAL mode lets readers run concurrently with the writer.
+            // Without it the sampler's 1-row insert blocks every chart
+            // query — very visible at 60s cadence with the popup open.
+            try exec("PRAGMA journal_mode=WAL;")
+            try exec("PRAGMA synchronous=NORMAL;")  // WAL + NORMAL is the canonical durability/perf tradeoff
+            try exec("PRAGMA foreign_keys=ON;")
 
-        try exec("""
-            CREATE TABLE IF NOT EXISTS samples (
-                prefix TEXT NOT NULL,
-                ts     INTEGER NOT NULL,
-                json   TEXT NOT NULL,
-                PRIMARY KEY (prefix, ts)
-            );
-            """)
-        // Cross-prefix TTL prune needs a ts-only index; the PK above is
-        // (prefix, ts) so it can't satisfy `WHERE ts < ?` without scanning.
-        try exec("CREATE INDEX IF NOT EXISTS idx_samples_ts ON samples(ts);")
+            try exec("""
+                CREATE TABLE IF NOT EXISTS samples (
+                    prefix TEXT NOT NULL,
+                    ts     INTEGER NOT NULL,
+                    json   TEXT NOT NULL,
+                    PRIMARY KEY (prefix, ts)
+                );
+                """)
+            // Cross-prefix TTL prune needs a ts-only index; the PK above is
+            // (prefix, ts) so it can't satisfy `WHERE ts < ?` without scanning.
+            try exec("CREATE INDEX IF NOT EXISTS idx_samples_ts ON samples(ts);")
+        } catch {
+            // A pragma/schema write failed — the file is corrupt or
+            // readonly. Close so the next attempt opens cleanly.
+            sqlite3_close(self.handle)
+            self.handle = nil
+            throw error
+        }
+    }
+
+    // MARK: - Recovery (issue #5)
+
+    /// Delete the WAL/SHM sidecars. They're regenerated on next open, and
+    /// a stale or root-owned `-wal` is a common "readonly database" cause.
+    private static func removeSidecars(_ url: URL) {
+        for suffix in ["-wal", "-shm"] {
+            try? FileManager.default.removeItem(atPath: url.path + suffix)
+        }
+    }
+
+    /// Restore user read/write permission on our own db file, if present.
+    /// Best-effort: if we don't own it (or it's immutable) this no-ops and
+    /// recovery falls through to quarantine.
+    private static func restoreWritePermission(_ url: URL) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                               ofItemAtPath: url.path)
+    }
+
+    /// Move the unusable db (and its sidecars) aside so a fresh one can be
+    /// created in its place. Picks the first free `<name>.corrupt[-n]` so
+    /// an earlier quarantine isn't clobbered. Throws if the move fails
+    /// (e.g. the directory itself is read-only).
+    private static func quarantine(_ url: URL) throws {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { removeSidecars(url); return }
+        var dest = url.path + ".corrupt"
+        var n = 1
+        while fm.fileExists(atPath: dest) { dest = url.path + ".corrupt-\(n)"; n += 1 }
+        try fm.moveItem(atPath: url.path, toPath: dest)
+        removeSidecars(url)
     }
 
     deinit {

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -358,7 +358,11 @@ struct ToolCatalog {
     /// used so "this week" can't be silently reinterpreted.
     private func callProcessUsage(_ args: [String: Any]) throws -> String {
         let minutes = (args["minutes"] as? Int) ?? 60
-        guard minutes > 0 else { throw MCPToolError.badArguments("minutes must be positive") }
+        // Upper bound guards against Int overflow in `minutes * 60` below
+        // (~1.9 years is far past any useful window).
+        guard minutes > 0, minutes <= 1_000_000 else {
+            throw MCPToolError.badArguments("minutes must be between 1 and 1000000")
+        }
         let limit = max(1, min((args["limit"] as? Int) ?? 10, 100))
         let metric = (args["metric"] as? String) ?? "cpu_time"
         let allowed = ["cpu_time", "peak_cpu", "avg_cpu", "peak_mem"]
@@ -370,7 +374,13 @@ struct ToolCatalog {
         let since = now - minutes * 60
         let rows = self.db.findRangeSampled(prefix: Sampler.snapshotPrefix,
                                             since: since, until: now, maxPoints: 720)
-        let interval = Double(Store.sampleIntervalSeconds)
+        // findRangeSampled down-samples wide windows, so each returned row
+        // stands for MORE than one sample period. Estimate CPU-time against
+        // the effective spacing of the rows we actually got — using the raw
+        // sampler cadence would badly under-count over long windows.
+        let interval: Double = rows.count > 1
+            ? Double(max(1, rows[rows.count - 1].ts - rows[0].ts)) / Double(rows.count - 1)
+            : Double(Store.sampleIntervalSeconds)
 
         struct Agg { var peakCPU = 0.0; var sumCPU = 0.0; var samples = 0; var peakMem = 0.0 }
         var agg: [String: Agg] = [:]
@@ -408,7 +418,7 @@ struct ToolCatalog {
         }
         let startTS = rows.first?.ts ?? since
         let endTS = rows.last?.ts ?? now
-        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Store.sampleIntervalSeconds),\"processes\":[\(pieces.joined(separator: ","))]}"
+        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Int(interval.rounded())),\"processes\":[\(pieces.joined(separator: ","))]}"
     }
 
     private func callInfo() -> String {

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -251,6 +251,19 @@ struct ToolCatalog {
                 ] as [String: Any],
             ],
             [
+                "name": "burrow_process_usage",
+                "description": "Rank processes over the last `minutes` (default 60) by a chosen `metric`: cpu_time (default; cumulative CPU-seconds = the closest answer to 'what used my computer most'), peak_cpu (highest single-sample CPU%), avg_cpu (mean CPU% while present), or peak_mem (highest memory%). Returns the window it actually used (start_ts/end_ts/sample_count) so the answer isn't ambiguous. NOTE: derived from periodic samples, so cpu_time is an estimate, not the kernel's exact accounting.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "minutes": ["type": "integer", "minimum": 1],
+                        "metric": ["type": "string", "enum": ["cpu_time", "peak_cpu", "avg_cpu", "peak_mem"]],
+                        "limit": ["type": "integer", "minimum": 1, "maximum": 100],
+                    ],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
                 "name": "burrow_info",
                 "description": "Burrow's own state: list of prefixes with row counts + staleness, current retention setting. Use when diagnosing whether data is flowing.",
                 "inputSchema": [
@@ -270,6 +283,8 @@ struct ToolCatalog {
             return try self.callHistory(arguments)
         case "burrow_top_processes":
             return try self.callTopProcesses(arguments)
+        case "burrow_process_usage":
+            return try self.callProcessUsage(arguments)
         case "burrow_info":
             return self.callInfo()
         default:
@@ -335,6 +350,65 @@ struct ToolCatalog {
             pieces.append("{\"name\":\"\(escaped)\",\"peak_cpu\":\(cpu),\"peak_mem\":\(peakMem[name] ?? 0)}")
         }
         return "{\"window_minutes\":\(minutes),\"processes\":[\(pieces.joined(separator: ","))]}"
+    }
+
+    /// Semantic process ranking. Where `burrow_top_processes` always ranks
+    /// by peak CPU — which crowns a one-second spike — this lets the agent
+    /// pick the metric that matches the question, and echoes the window it
+    /// used so "this week" can't be silently reinterpreted.
+    private func callProcessUsage(_ args: [String: Any]) throws -> String {
+        let minutes = (args["minutes"] as? Int) ?? 60
+        guard minutes > 0 else { throw MCPToolError.badArguments("minutes must be positive") }
+        let limit = max(1, min((args["limit"] as? Int) ?? 10, 100))
+        let metric = (args["metric"] as? String) ?? "cpu_time"
+        let allowed = ["cpu_time", "peak_cpu", "avg_cpu", "peak_mem"]
+        guard allowed.contains(metric) else {
+            throw MCPToolError.badArguments("metric must be one of: \(allowed.joined(separator: ", "))")
+        }
+
+        let now = Int(Date().timeIntervalSince1970)
+        let since = now - minutes * 60
+        let rows = self.db.findRangeSampled(prefix: Sampler.snapshotPrefix,
+                                            since: since, until: now, maxPoints: 720)
+        let interval = Double(Store.sampleIntervalSeconds)
+
+        struct Agg { var peakCPU = 0.0; var sumCPU = 0.0; var samples = 0; var peakMem = 0.0 }
+        var agg: [String: Agg] = [:]
+        let dec = JSONDecoder()
+        for r in rows {
+            guard let data = r.json.data(using: .utf8),
+                  let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
+            for p in (s.topProcesses ?? []) {
+                var a = agg[p.name] ?? Agg()
+                a.peakCPU = max(a.peakCPU, p.cpu)
+                a.sumCPU += p.cpu
+                a.samples += 1
+                a.peakMem = max(a.peakMem, p.memory)
+                agg[p.name] = a
+            }
+        }
+
+        func score(_ a: Agg) -> Double {
+            switch metric {
+            case "peak_cpu": return a.peakCPU
+            case "avg_cpu":  return a.samples > 0 ? a.sumCPU / Double(a.samples) : 0
+            case "peak_mem": return a.peakMem
+            default:         return (a.sumCPU / 100.0) * interval   // est. CPU-seconds
+            }
+        }
+
+        let ranked = agg.sorted { score($0.value) > score($1.value) }.prefix(limit)
+        var pieces: [String] = []
+        for (name, a) in ranked {
+            let escaped = name.replacingOccurrences(of: "\\", with: "\\\\")
+                              .replacingOccurrences(of: "\"", with: "\\\"")
+            let avg = a.samples > 0 ? a.sumCPU / Double(a.samples) : 0
+            let cpuTime = (a.sumCPU / 100.0) * interval
+            pieces.append("{\"name\":\"\(escaped)\",\"peak_cpu\":\(a.peakCPU),\"avg_cpu\":\(avg),\"est_cpu_time_seconds\":\(cpuTime),\"peak_mem\":\(a.peakMem),\"samples\":\(a.samples)}")
+        }
+        let startTS = rows.first?.ts ?? since
+        let endTS = rows.last?.ts ?? now
+        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Store.sampleIntervalSeconds),\"processes\":[\(pieces.joined(separator: ","))]}"
     }
 
     private func callInfo() -> String {

--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -51,6 +51,33 @@ enum MoleCLI {
         return nil
     }
 
+    // MARK: - Install / version
+
+    /// Canonical install command (Homebrew). Shown in the guided install
+    /// flow; we never run it for the user.
+    static let installCommand = "brew install mole"
+    /// Where to send users without Homebrew.
+    static let repoURL = URL(string: "https://github.com/tw93/Mole")!
+
+    /// Current `mo` version, or nil if not installed / unparsable.
+    static func version() -> String? {
+        guard let res = try? run(args: ["--version"], timeout: 5) else { return nil }
+        let text = res.stdout.isEmpty ? res.stderr : res.stdout
+        return parseVersion(text)
+    }
+
+    /// Pull a semver out of `mo --version` output, whatever decoration it
+    /// wraps it in ("mole 1.41.0", "v1.41.0", …). Pure → unit-tested.
+    static func parseVersion(_ output: String) -> String? {
+        for token in output.split(whereSeparator: { !($0.isNumber || $0 == ".") }) {
+            let parts = token.split(separator: ".")
+            if parts.count >= 2, parts.allSatisfy({ Int($0) != nil }) {
+                return String(token)
+            }
+        }
+        return nil
+    }
+
     /// Modal alert shown at launch when `mo` isn't installed. We block on
     /// it because there's nothing useful Burrow can do without Mole, and a
     /// background app silently failing is the worst possible UX for this

--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -120,4 +120,28 @@ enum MoleCLI {
             exitCode: task.terminationStatus
         )
     }
+
+    /// Run `mo <args>` ONCE with administrator rights via the macOS auth
+    /// dialog (which accepts Touch ID where the system supports it). Blocking
+    /// — call off the main thread. For one-shot privileged config like
+    /// `touchid enable/disable`, not for streamed jobs (CommandRunner does those).
+    static func runElevated(args: [String]) -> Int32 {
+        guard let mo = findExecutable() else { return 127 }
+        // Quote each argument for the shell, then escape the whole command for
+        // embedding in an AppleScript string literal. Belt-and-suspenders since
+        // today's callers pass only literal subcommands, but keeps a stray space
+        // or quote in a path from breaking (or injecting into) the script.
+        func shQuote(_ s: String) -> String { "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'" }
+        let raw = ([mo] + args).map(shQuote).joined(separator: " ")
+        let inner = raw.replacingOccurrences(of: "\\", with: "\\\\")
+                       .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = "do shell script \"\(inner)\" with administrator privileges"
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", script]
+        task.standardOutput = Pipe()
+        task.standardError = Pipe()
+        do { try task.run(); task.waitUntilExit(); return task.terminationStatus }
+        catch { return 1 }
+    }
 }

--- a/Sources/MoleHistory.swift
+++ b/Sources/MoleHistory.swift
@@ -1,0 +1,64 @@
+//
+//  MoleHistory.swift
+//  Burrow
+//
+//  Thin wrapper around `mo history --json` — Mole's record of past
+//  cleanup/optimize/uninstall sessions. Distinct from Burrow's own
+//  metrics "History" (the SQLite sample series); this is the cleanup
+//  activity log. We just spawn, parse, and return typed sessions.
+//
+
+import Foundation
+
+struct HistorySession: Identifiable {
+    let id = UUID()
+    let command: String        // "clean", "optimize", "uninstall", …
+    let startedAt: String
+    let endedAt: String        // "" when the session didn't finish cleanly
+    let items: Int
+    let size: String           // human string from Mole, e.g. "2.93GB"
+    let operationCount: Int
+    let removed: Int
+    let trashed: Int
+    let skipped: Int
+    let failed: Int
+
+    var isComplete: Bool { !endedAt.isEmpty }
+}
+
+enum MoleHistory {
+    /// Decode `mo history --json`. Loose: we only depend on `sessions[*]`
+    /// and the fields we surface; unknown keys can drift upstream freely.
+    static func parse(_ data: Data) -> [HistorySession] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sessions = obj["sessions"] as? [[String: Any]] else { return [] }
+        return sessions.map { s in
+            let actions = s["actions"] as? [String: Any] ?? [:]
+            return HistorySession(
+                command: s["command"] as? String ?? "?",
+                startedAt: s["started_at"] as? String ?? "",
+                endedAt: s["ended_at"] as? String ?? "",
+                items: intVal(s["items"]),
+                size: s["size"] as? String ?? "",
+                operationCount: intVal(s["operation_count"]),
+                removed: intVal(actions["removed"]),
+                trashed: intVal(actions["trashed"]),
+                skipped: intVal(actions["skipped"]),
+                failed: intVal(actions["failed"]))
+        }
+    }
+
+    /// Run `mo history --json` and parse it. Synchronous — call off-main.
+    static func load() -> [HistorySession] {
+        guard let res = try? MoleCLI.run(args: ["history", "--json"], timeout: 30),
+              res.exitCode == 0,
+              let data = res.stdout.data(using: .utf8) else { return [] }
+        return parse(data)
+    }
+
+    private static func intVal(_ v: Any?) -> Int {
+        if let i = v as? Int { return i }
+        if let d = v as? Double { return Int(d) }
+        return 0
+    }
+}

--- a/Sources/MoleInstallView.swift
+++ b/Sources/MoleInstallView.swift
@@ -1,0 +1,89 @@
+//
+//  MoleInstallView.swift
+//  Burrow
+//
+//  Guided onboarding when the `mo` engine is missing. Burrow can't run
+//  without it, but rather than quit with a dead-end alert we show the
+//  exact install command (copyable) and a Recheck button — we never run
+//  an installer on the user's behalf. Once `mo` is found, `onReady` fires
+//  and the app continues its normal startup.
+//
+
+import SwiftUI
+import AppKit
+
+struct MoleInstallView: View {
+    /// Called when a Recheck finds `mo` on PATH — the app proceeds.
+    var onReady: () -> Void
+
+    @State private var checking = false
+    @State private var stillMissing = false
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Label("Mole engine required", systemImage: "shippingbox")
+                    .font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
+                Text("Burrow is a GUI for the Mole CLI (`mo`) — it does the scanning and cleanup. Install it, then Recheck.")
+                    .font(Brand.sans(13)).foregroundStyle(Brand.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("WITH HOMEBREW").font(Brand.mono(9, .bold)).tracking(0.6).foregroundStyle(Brand.textTertiary)
+                HStack {
+                    Text(MoleCLI.installCommand).font(Brand.mono(12)).foregroundStyle(Brand.textPrimary)
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(MoleCLI.installCommand, forType: .string)
+                        copied = true
+                    } label: {
+                        Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                            .font(Brand.mono(10)).foregroundStyle(Brand.green)
+                    }.buttonStyle(.plain)
+                }
+                .padding(11)
+                .background(RoundedRectangle(cornerRadius: 10).fill(Color.black.opacity(0.25)))
+                .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Brand.hairline, lineWidth: 1))
+
+                Button { NSWorkspace.shared.open(MoleCLI.repoURL) } label: {
+                    Text("No Homebrew? Other install options →")
+                        .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                }.buttonStyle(.plain)
+            }
+
+            if stillMissing {
+                Text("Still not finding `mo` on PATH. If you just installed it, open a new terminal first, or relaunch Burrow.")
+                    .font(Brand.mono(10)).foregroundStyle(Brand.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 12) {
+                Spacer()
+                Button("Quit") { NSApp.terminate(nil) }
+                    .buttonStyle(.plain).font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                PillButton(title: checking ? "Checking…" : "Recheck") { recheck() }
+            }
+        }
+        .padding(22)
+        .frame(width: 460, height: 320)
+        .background(Color(hex: 0x14130E))
+        .environment(\.colorScheme, .dark)
+    }
+
+    private func recheck() {
+        checking = true; stillMissing = false; copied = false
+        DispatchQueue.global(qos: .userInitiated).async {
+            let found = MoleCLI.findExecutable() != nil
+            DispatchQueue.main.async {
+                checking = false
+                if found { onReady() } else { stillMissing = true }
+            }
+        }
+    }
+}

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -31,15 +31,14 @@ struct OptimizeView: View {
                 }
             }
         } else {
-            let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
                 statusBar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 if isDone, !preview, !runner.wasCancelled {
                     DoneBanner(accent: Tool.optimize.accent, title: "Maintenance complete",
-                               detail: "\(report.groups.count) areas refreshed")
+                               detail: "\(runner.groups.count) areas refreshed")
                 }
-                TaskReportView(groups: report.groups, accent: Tool.optimize.accent)
+                TaskReportView(groups: runner.groups, accent: Tool.optimize.accent)
             }
         }
     }
@@ -56,8 +55,8 @@ struct OptimizeView: View {
                 }.buttonStyle(.plain)
             }
             if isDone {
-                Button { runOptimize() } label: {
-                    Label("Run again", systemImage: "arrow.clockwise")
+                Button { runner.reset() } label: {
+                    Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                 }.buttonStyle(.plain)
             }

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -54,7 +54,7 @@ struct OptimizeView: View {
                         .font(Brand.mono(11)).foregroundStyle(Brand.red)
                 }.buttonStyle(.plain)
             }
-            if isDone {
+            if isDone || isFailed {
                 Button { runner.reset() } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
@@ -65,6 +65,7 @@ struct OptimizeView: View {
 
     private var isRunning: Bool { runner.phase == .running }
     private var isDone: Bool { if case .done = runner.phase { return true }; return false }
+    private var isFailed: Bool { if case .failed = runner.phase { return true }; return false }
 
     private var statusText: String {
         switch runner.phase {

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -14,19 +14,29 @@ import SwiftUI
 struct OptimizeView: View {
     @StateObject private var runner = CommandRunner()
     @State private var preview = false
+    @State private var fdaRunAnyway = false
+    @State private var pendingRun: (() -> Void)? = nil
 
     var body: some View {
         if runner.phase == .idle {
-            ToolHero(tool: .optimize, title: "Optimize", subtitle: Tool.optimize.tagline) {
-                PillButton(title: "Optimize") { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") }
-                PillButton(title: "Preview", filled: false) { preview = true; runner.run(["optimize", "--dry-run"], label: "Optimize preview") }
+            if pendingRun != nil {
+                FullDiskAccessRequired(
+                    accent: Tool.optimize.accent,
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
+                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onCancel: { pendingRun = nil })
+            } else {
+                ToolHero(tool: .optimize, title: "Optimize", subtitle: Tool.optimize.tagline) {
+                    PillButton(title: "Optimize") { runOptimize() }
+                    PillButton(title: "Preview", filled: false) { runPreview() }
+                }
             }
         } else {
             let report = parseTaskReport(runner.lines)
             VStack(spacing: 0) {
                 statusBar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
-                if isDone, !preview {
+                if isDone, !preview, !runner.wasCancelled {
                     DoneBanner(accent: Tool.optimize.accent, title: "Maintenance complete",
                                detail: "\(report.groups.count) areas refreshed")
                 }
@@ -37,11 +47,17 @@ struct OptimizeView: View {
 
     private var statusBar: some View {
         HStack(spacing: 10) {
-            if runner.phase == .running { ProgressView().controlSize(.small).tint(Tool.optimize.accent) }
+            if isRunning { ProgressView().controlSize(.small).tint(Tool.optimize.accent) }
             Text(statusText).font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
             Spacer()
+            if isRunning {
+                Button { runner.cancel() } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                        .font(Brand.mono(11)).foregroundStyle(Brand.red)
+                }.buttonStyle(.plain)
+            }
             if isDone {
-                Button { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") } label: {
+                Button { runOptimize() } label: {
                     Label("Run again", systemImage: "arrow.clockwise")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                 }.buttonStyle(.plain)
@@ -49,14 +65,24 @@ struct OptimizeView: View {
         }
     }
 
+    private var isRunning: Bool { runner.phase == .running }
     private var isDone: Bool { if case .done = runner.phase { return true }; return false }
 
     private var statusText: String {
         switch runner.phase {
         case .running: return preview ? "Previewing maintenance…" : "Running maintenance…"
-        case .done:    return preview ? "Preview complete." : "Maintenance complete."
+        case .done:    return runner.wasCancelled ? "Stopped."
+            : (preview ? "Preview complete." : "Maintenance complete.")
         case .failed(let m): return "Failed: \(m)"
         case .idle:    return ""
         }
     }
+
+    private func guarded(_ work: @escaping () -> Void) {
+        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
+        else { work() }
+    }
+    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
+    private func runOptimize() { guarded { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") } }
+    private func runPreview() { guarded { preview = true; runner.run(["optimize", "--dry-run"], label: "Optimize preview") } }
 }

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -14,16 +14,15 @@ import SwiftUI
 struct OptimizeView: View {
     @StateObject private var runner = CommandRunner()
     @State private var preview = false
-    @State private var fdaRunAnyway = false
-    @State private var pendingRun: (() -> Void)? = nil
+    @State private var pendingRun: ((Bool) -> Void)? = nil
 
     var body: some View {
         if runner.phase == .idle {
             if pendingRun != nil {
                 FullDiskAccessRequired(
                     accent: Tool.optimize.accent,
-                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending() } },
-                    onRunAnyway: { fdaRunAnyway = true; runPending() },
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false) } },
+                    onRunAnyway: { runPending(elevate: true) },
                     onCancel: { pendingRun = nil })
             } else {
                 ToolHero(tool: .optimize, title: "Optimize", subtitle: Tool.optimize.tagline) {
@@ -78,11 +77,14 @@ struct OptimizeView: View {
         }
     }
 
-    private func guarded(_ work: @escaping () -> Void) {
-        if !fdaRunAnyway && !Privacy.hasFullDiskAccess() { pendingRun = work }
-        else { work() }
+    private func guarded(_ work: @escaping (Bool) -> Void) {
+        if Privacy.hasFullDiskAccess() { work(false) } else { pendingRun = work }
     }
-    private func runPending() { let r = pendingRun; pendingRun = nil; r?() }
-    private func runOptimize() { guarded { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") } }
-    private func runPreview() { guarded { preview = true; runner.run(["optimize", "--dry-run"], label: "Optimize preview") } }
+    private func runPending(elevate: Bool) { let r = pendingRun; pendingRun = nil; r?(elevate) }
+
+    /// Optimize already runs elevated (root) → no flood, no gate.
+    private func runOptimize() { preview = false; runner.run(["optimize"], elevated: true, label: "Optimizing") }
+    private func runPreview() {
+        guarded { elevate in preview = true; runner.run(["optimize", "--dry-run"], elevated: elevate, label: "Optimize preview") }
+    }
 }

--- a/Sources/PopupView.swift
+++ b/Sources/PopupView.swift
@@ -76,20 +76,15 @@ struct PopupView: View {
     // MARK: Activity (cards for running / just-finished jobs, at the bottom)
 
     private var activitySection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Eyebrow(text: "Activity", glyph: "bolt.fill", color: Brand.gold)
-            ForEach(ops.ops) { op in
-                HStack(spacing: 8) {
-                    opIcon(op.phase)
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text(op.label).font(Brand.sans(11, .medium)).foregroundStyle(Brand.textPrimary).lineLimit(1)
-                        if !op.detail.isEmpty {
-                            Text(op.detail).font(Brand.mono(9)).foregroundStyle(Brand.textTertiary).lineLimit(1)
-                        }
-                    }
-                    Spacer(minLength: 4)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Eyebrow(text: "Activity", glyph: "bolt.fill", color: Brand.gold)
+                Spacer()
+                if runningCount > 0 {
+                    Text("\(runningCount) running").font(Brand.mono(9, .medium)).foregroundStyle(Brand.gold)
                 }
             }
+            ForEach(ops.ops) { op in opRow(op) }
         }
         .padding(10)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -97,15 +92,90 @@ struct PopupView: View {
         .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
+    private var runningCount: Int { ops.ops.filter { $0.phase == .running }.count }
+
     @ViewBuilder
-    private func opIcon(_ phase: OperationCenter.Phase) -> some View {
+    private func opRow(_ op: OperationCenter.Op) -> some View {
+        let accent = opAccent(op.label)
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 8) {
+                opIcon(op.phase, accent: accent)
+                Text(op.label).font(Brand.sans(11, .medium)).foregroundStyle(Brand.textPrimary).lineLimit(1)
+                Spacer(minLength: 4)
+                opStatus(op)
+            }
+            if !op.detail.isEmpty {
+                Text(op.detail).font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    .lineLimit(1).truncationMode(.middle).padding(.leading, 23)
+            }
+            if op.phase == .running {
+                IndeterminateBar(color: accent).padding(.leading, 23)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func opIcon(_ phase: OperationCenter.Phase, accent: Color) -> some View {
         switch phase {
         case .running:
-            ProgressView().controlSize(.small).scaleEffect(0.7).frame(width: 16, height: 16)
+            Circle().fill(accent).frame(width: 8, height: 8)
+                .shadow(color: accent.opacity(0.6), radius: 3).padding(3.5)
         case .done:
             Image(systemName: "checkmark.circle.fill").font(.system(size: 13)).foregroundStyle(Brand.green)
         case .failed:
             Image(systemName: "xmark.circle.fill").font(.system(size: 13)).foregroundStyle(Brand.red)
+        }
+    }
+
+    @ViewBuilder
+    private func opStatus(_ op: OperationCenter.Op) -> some View {
+        switch op.phase {
+        case .running:
+            TimelineView(.periodic(from: Date(), by: 1)) { ctx in
+                Text(Self.elapsed(from: op.startedAt, to: ctx.date))
+                    .font(Brand.mono(9)).foregroundStyle(Brand.textSecondary)
+            }
+        case .done:
+            Text("done").font(Brand.mono(9, .medium)).foregroundStyle(Brand.green)
+        case .failed:
+            Text("failed").font(Brand.mono(9, .medium)).foregroundStyle(Brand.red)
+        }
+    }
+
+    /// Tint a job by its verb so the menu-bar HUD echoes the tool colours.
+    private func opAccent(_ label: String) -> Color {
+        let l = label.lowercased()
+        if l.contains("clean") { return Tool.clean.accent }
+        if l.contains("optimi") { return Tool.optimize.accent }
+        if l.contains("analy") { return Tool.analyze.accent }
+        if l.contains("uninstall") { return Tool.apps.accent }
+        return Brand.gold
+    }
+
+    static func elapsed(from start: Date, to now: Date) -> String {
+        let s = max(0, Int(now.timeIntervalSince(start)))
+        return s < 60 ? "\(s)s" : String(format: "%d:%02d", s / 60, s % 60)
+    }
+
+    /// Thin indeterminate progress bar for a running op — conveys "still
+    /// working" without a fake percentage we don't have.
+    private struct IndeterminateBar: View {
+        let color: Color
+        @State private var animate = false
+        var body: some View {
+            GeometryReader { geo in
+                Capsule().fill(color.opacity(0.16))
+                    .overlay(alignment: .leading) {
+                        Capsule().fill(color)
+                            .frame(width: geo.size.width * 0.35)
+                            .offset(x: animate ? geo.size.width * 0.65 : 0)
+                    }
+                    .clipShape(Capsule())
+            }
+            .frame(height: 3)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) { animate = true }
+            }
         }
     }
 

--- a/Sources/PopupView.swift
+++ b/Sources/PopupView.swift
@@ -32,6 +32,7 @@ struct PopupView: View {
         // the box and the arrow, so they match.
         VStack(alignment: .leading, spacing: 9) {
             header
+            if ops.hasActivity { activitySection }   // running jobs up top, where they're seen
             if let s = model.snap {
                 healthHero(s)
                 metricGrid(s)
@@ -40,7 +41,6 @@ struct PopupView: View {
             } else {
                 waiting
             }
-            if ops.hasActivity { activitySection }
             Rectangle().fill(Brand.hairline).frame(height: 1)
             footer
         }
@@ -267,16 +267,22 @@ struct PopupView: View {
 
     private var footer: some View {
         VStack(spacing: 8) {
-            HStack(spacing: 5) {
+            // Icon pills — text labels for every tool overflow the narrow
+            // popover; glyphs (tinted by tool) stay compact and tidy.
+            HStack(spacing: 6) {
                 ForEach(Tool.navOrder) { tool in
                     Button { open(.tool(tool)) } label: {
-                        Text(tool.label).font(Brand.mono(9, .medium))
-                            .foregroundStyle(Brand.textSecondary)
-                            .padding(.horizontal, 7).padding(.vertical, 4)
+                        Image(systemName: tool.glyph)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(tool.accent)
+                            .frame(width: 30, height: 26)
                             .background(Capsule().fill(Brand.chipFill))
-                    }.buttonStyle(.plain)
+                    }
+                    .buttonStyle(.plain)
+                    .help(tool.title)
                 }
             }
+            .frame(maxWidth: .infinity)
             HStack(spacing: 12) {
                 iconButton("clock.arrow.circlepath") { openHistory() }
                 iconButton("gearshape") { openSettings() }
@@ -286,7 +292,10 @@ struct PopupView: View {
                     .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.textPrimary)
                 iconButton("power") { NSApp.terminate(nil) }
             }
-            Text("MCP 127.0.0.1:\(Store.queryServerPort)")
+            // `verbatim:` so the port isn't localized into "9,277".
+            Text(verbatim: Store.queryServerEnabled
+                 ? "MCP · 127.0.0.1:\(Store.queryServerPort) + stdio"
+                 : "MCP · stdio (burrow --mcp)")
                 .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -1,0 +1,113 @@
+//
+//  Privacy.swift
+//  Burrow
+//
+//  Full Disk Access detection and the macOS settings deep-link.
+//
+//  Burrow shells out to `mo`, which walks system and other-apps' cache
+//  directories. On macOS 14+ those reads are TCC-gated ("Burrow would
+//  like to access data from other apps") and the prompt is attributed to
+//  Burrow — once per protected location, so a single `mo clean --dry-run`
+//  or `mo analyze` over the home folder produces a *flood* of dialogs
+//  (issue #3).
+//
+//  The OS-sanctioned remedy is Full Disk Access: once granted, macOS
+//  stops gating per-folder reads for this app. We never bypass TCC — we
+//  only detect whether we already have access and, if not, point the user
+//  at the single switch that grants informed, one-time consent.
+//
+
+import Foundation
+import AppKit
+import SwiftUI
+
+enum Privacy {
+    /// Whether to surface the Full Disk Access notice before a scan that
+    /// walks protected directories. Pure so it's unit-testable: nag only
+    /// when access is missing and the user hasn't already dismissed it.
+    static func shouldOfferFullDiskAccess(hasAccess: Bool, dismissed: Bool) -> Bool {
+        return !hasAccess && !dismissed
+    }
+
+    /// Probe whether Burrow has Full Disk Access by attempting to open an
+    /// FDA-gated file. `TCC.db` exists on every Mac and is readable only
+    /// with Full Disk Access, so a successful open is the canonical
+    /// signal. We open and immediately close — the bytes are never read;
+    /// this is a capability probe, not data access. A read that lacks
+    /// access fails silently (no prompt), so probing can't itself flood
+    /// the user.
+    static func hasFullDiskAccess() -> Bool {
+        let probes = [
+            "Library/Application Support/com.apple.TCC/TCC.db",
+            "Library/Safari/Bookmarks.plist",
+        ].map { (NSHomeDirectory() as NSString).appendingPathComponent($0) }
+        for path in probes {
+            if let fh = FileHandle(forReadingAtPath: path) {
+                try? fh.close()
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Live check combining the access probe with the persisted dismissal.
+    static func shouldOfferFullDiskAccessNow() -> Bool {
+        shouldOfferFullDiskAccess(hasAccess: hasFullDiskAccess(),
+                                  dismissed: Store.fullDiskAccessNoticeDismissed)
+    }
+
+    /// Deep-link to System Settings ▸ Privacy & Security ▸ Full Disk Access.
+    static let fullDiskAccessSettingsURL = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!
+
+    static func openFullDiskAccessSettings() {
+        NSWorkspace.shared.open(fullDiskAccessSettingsURL)
+    }
+}
+
+/// Dismissible banner shown before scans that walk TCC-protected
+/// directories. Surfaces the OS mechanism (Full Disk Access) so the user
+/// grants one informed consent instead of fielding a flood of per-folder
+/// prompts. Burrow never bypasses TCC — this only points the way.
+struct FullDiskAccessNotice: View {
+    var accent: Color = Brand.green
+    /// Label for the proceed-without-granting action ("Not now" in a
+    /// non-blocking banner, "Scan anyway" when it gates a scan).
+    var continueLabel: String = "Not now"
+    var onOpenSettings: () -> Void = { Privacy.openFullDiskAccessSettings() }
+    var onContinue: () -> Void
+    /// Optional "don't ask again" — persists the dismissal.
+    var onDontAskAgain: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "lock.shield").font(.system(size: 18)).foregroundStyle(accent)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Skip the macOS permission prompts")
+                    .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                Text("Scanning system & app caches makes macOS ask once per protected folder. Grant Burrow Full Disk Access to scan smoothly — it only reads sizes through Mole and never opens that data itself.")
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 16) {
+                    Button(action: onOpenSettings) {
+                        Text("Open Full Disk Access settings")
+                            .font(Brand.sans(11, .semibold)).foregroundStyle(accent)
+                    }.buttonStyle(.plain)
+                    Button(action: onContinue) {
+                        Text(continueLabel).font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                    }.buttonStyle(.plain)
+                    if let onDontAskAgain {
+                        Button(action: onDontAskAgain) {
+                            Text("Don't ask again").font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                        }.buttonStyle(.plain)
+                    }
+                }
+                .padding(.top, 3)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(13)
+        .background(RoundedRectangle(cornerRadius: 13).fill(accent.opacity(0.08)))
+        .overlay(RoundedRectangle(cornerRadius: 13).strokeBorder(accent.opacity(0.28), lineWidth: 1))
+    }
+}

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -133,18 +133,18 @@ struct FullDiskAccessRequired: View {
             VStack(spacing: 8) {
                 Text("Grant Full Disk Access to scan")
                     .font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
-                Text("This reads system and app caches through Mole. Without Full Disk Access, macOS makes you approve every protected folder — one prompt after another. Grant it once in System Settings and the prompts stop for good. Burrow only reads sizes; it never opens that data itself.")
+                Text("This reads system and app caches through Mole. Without Full Disk Access, macOS makes you approve every protected folder — one prompt after another. Grant it once in System Settings and the prompts stop for good. Or run the scan with administrator rights instead: one password, no per-folder asks. Burrow only reads sizes; it never opens that data itself.")
                     .font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
                     .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: 440)
+                    .frame(maxWidth: 460)
             }
             VStack(spacing: 12) {
                 PillButton(title: "Open Full Disk Access settings") { onOpenSettings() }
                 HStack(spacing: 18) {
                     Button("I've granted it — scan") { onRecheck() }
                         .buttonStyle(.plain).font(Brand.sans(12, .semibold)).foregroundStyle(accent)
-                    Button("Scan anyway") { onRunAnyway() }
-                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                    Button("Scan with admin") { onRunAnyway() }
+                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                     Button("Cancel") { onCancel() }
                         .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
                 }

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -111,3 +111,47 @@ struct FullDiskAccessNotice: View {
         .overlay(RoundedRectangle(cornerRadius: 13).strokeBorder(accent.opacity(0.28), lineWidth: 1))
     }
 }
+
+/// Blocking gate shown when a flood-prone scan is requested without Full
+/// Disk Access. Unlike the soft banner, this STOPS the run — otherwise
+/// macOS prompts once per protected folder. Grant FDA once and the
+/// prompts stop entirely; "Scan anyway" is the escape hatch (and warns).
+struct FullDiskAccessRequired: View {
+    var accent: Color
+    var onOpenSettings: () -> Void = { Privacy.openFullDiskAccessSettings() }
+    var onRecheck: () -> Void
+    var onRunAnyway: () -> Void
+    var onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            ZStack {
+                Circle().fill(accent.opacity(0.15)).frame(width: 64, height: 64)
+                Image(systemName: "lock.shield").font(.system(size: 28)).foregroundStyle(accent)
+            }
+            VStack(spacing: 8) {
+                Text("Grant Full Disk Access to scan")
+                    .font(Brand.serif(20, .medium)).foregroundStyle(Brand.textPrimary)
+                Text("This reads system and app caches through Mole. Without Full Disk Access, macOS makes you approve every protected folder — one prompt after another. Grant it once in System Settings and the prompts stop for good. Burrow only reads sizes; it never opens that data itself.")
+                    .font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                    .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 440)
+            }
+            VStack(spacing: 12) {
+                PillButton(title: "Open Full Disk Access settings") { onOpenSettings() }
+                HStack(spacing: 18) {
+                    Button("I've granted it — scan") { onRecheck() }
+                        .buttonStyle(.plain).font(Brand.sans(12, .semibold)).foregroundStyle(accent)
+                    Button("Scan anyway") { onRunAnyway() }
+                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                    Button("Cancel") { onCancel() }
+                        .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                }
+            }
+            Spacer(); Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
+    }
+}

--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -58,6 +58,9 @@ struct RootView: View {
             if pane == .history {
                 HistoryView(db: db)
             }
+            if pane == .activity {
+                ActivityView()
+            }
         }
     }
 }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -10,6 +10,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 struct SettingsView: View {
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
@@ -18,6 +19,8 @@ struct SettingsView: View {
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
+    @State private var moleVersion: String = "—"
+    @State private var moleUpdating = false
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -37,6 +40,16 @@ struct SettingsView: View {
                             }
                         }
                         footnote("History lives at ~/Library/Application Support/Burrow/burrow.db. Rows past the retention window are pruned hourly.")
+                    }
+
+                    section("Mole engine", "shippingbox") {
+                        infoRow("Version", moleVersion)
+                        HStack {
+                            Spacer()
+                            if moleUpdating { ProgressView().controlSize(.small).padding(.trailing, 4) }
+                            PillButton(title: moleUpdating ? "Updating…" : "Update Mole", filled: false) { updateMole() }
+                        }
+                        footnote("Runs `mo update` to update the Mole CLI engine Burrow drives. This is separate from Burrow's own app updates. If it needs a password or a confirmation it can't show here, run `mo update` in a terminal instead.")
                     }
 
                     section("History retention", "calendar") {
@@ -68,7 +81,37 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity)
             }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { refreshStatusLabels() }
+        .onAppear { refreshStatusLabels(); loadMoleVersion() }
+    }
+
+    // MARK: - Mole engine
+
+    private func loadMoleVersion() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let v = MoleCLI.version()
+            DispatchQueue.main.async { moleVersion = v.map { "v\($0)" } ?? "not found" }
+        }
+    }
+
+    private func updateMole() {
+        guard !moleUpdating else { return }
+        moleUpdating = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let res = try? MoleCLI.run(args: ["update"], timeout: 600)
+            let newVersion = MoleCLI.version()
+            DispatchQueue.main.async {
+                moleUpdating = false
+                if let v = newVersion { moleVersion = "v\(v)" }
+                let ok = (res?.exitCode ?? 1) == 0
+                let alert = NSAlert()
+                alert.messageText = ok ? "Mole is up to date" : "Update didn't complete"
+                alert.informativeText = ok
+                    ? "Now on \(moleVersion)."
+                    : (res?.stderr.isEmpty == false ? String(res!.stderr.prefix(300))
+                                                    : "`mo update` exited non-zero. Try running it in a terminal.")
+                alert.runModal()
+            }
+        }
     }
 
     // MARK: - Section + row helpers

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -59,8 +59,11 @@ struct SettingsView: View {
                     }
 
                     section("Menu bar", "menubar.rectangle") {
-                        toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { Store.showMenuBarIcon = $0 }
-                        footnote("When off, Burrow shows a Dock icon instead so it stays reachable — the window opens on launch and a Dock click reopens it. Takes effect after a relaunch.")
+                        toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { on in
+                            Store.showMenuBarIcon = on
+                            AppDelegate.shared?.applyMenuBarVisibility(on)
+                        }
+                        footnote("Applies immediately. When off, Burrow shows a Dock icon instead so it stays reachable — a Dock click reopens the window.")
                     }
 
                     section("MCP query server", "antenna.radiowaves.left.and.right") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -10,6 +10,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 struct SettingsView: View {
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
@@ -18,6 +19,21 @@ struct SettingsView: View {
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
+    @State private var copiedConfig = false
+
+    /// Drop-in MCP config for Claude Code / Cursor / Codex / Cline — they
+    /// all share the same `{command, args}` stdio shape, so one snippet
+    /// covers every agent.
+    private let mcpConfigJSON = """
+    {
+      "mcpServers": {
+        "burrow": {
+          "command": "/Applications/Burrow.app/Contents/MacOS/Burrow",
+          "args": ["--mcp"]
+        }
+      }
+    }
+    """
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -57,10 +73,28 @@ struct SettingsView: View {
                         footnote("Burrow runs `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
                     }
 
-                    section("MCP query server", "antenna.radiowaves.left.and.right") {
-                        toggleRow("Enable MCP query server", isOn: $queryServerEnabled) { Store.queryServerEnabled = $0 }
+                    section("Ask your AI about your Mac (MCP)", "sparkles") {
+                        Text("Burrow exposes your Mac's recorded history to coding agents — Claude Code, Cursor, Codex, Cline — over MCP. Add the config below, then ask in plain language. The server starts on demand over stdio; there's no port and no always-on listener.")
+                            .font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        codeBlock(mcpConfigJSON)
+
+                        infoRow("Tools", "snapshot · history · top_processes · info")
+
+                        subLabel("Try asking")
+                        promptRow("What's my Mac's CPU and memory usage right now?")
+                        promptRow("Show the CPU trend over the last 2 hours.")
+                        promptRow("Which apps spiked CPU in the last 30 minutes?")
+                        promptRow("Is Burrow collecting data? When was the last sample?")
+
+                        footnote("Config path is your agent's MCP settings (e.g. ~/.claude/settings.json). Read-only: agents can query history but never write or run cleanups. Data stays on this Mac.")
+                    }
+
+                    section("Local HTTP query server", "antenna.radiowaves.left.and.right") {
+                        toggleRow("Enable HTTP query server", isOn: $queryServerEnabled) { Store.queryServerEnabled = $0 }
                         infoRow("Endpoint", "127.0.0.1:\(Store.queryServerPort)")
-                        footnote("Toggle + port changes take effect after a relaunch. Exposes /health, /info, /snapshot, /metrics over localhost, plus the `Burrow --mcp` stdio server for Claude Code.")
+                        footnote("Optional REST surface for dashboards or curl: /health, /info, /snapshot, /metrics over localhost. Separate from the MCP stdio server above; toggle + port changes take effect after a relaunch.")
                     }
                 }
                 .padding(22)
@@ -93,6 +127,48 @@ struct SettingsView: View {
     private func footnote(_ text: String) -> some View {
         Text(text).font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
             .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// Small all-caps section sub-heading (e.g. "TRY ASKING").
+    private func subLabel(_ text: String) -> some View {
+        Text(text.uppercased()).font(Brand.mono(9, .bold)).tracking(0.6)
+            .foregroundStyle(Brand.textTertiary).padding(.top, 2)
+    }
+
+    /// One example prompt the user can paste to their agent.
+    private func promptRow(_ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: "arrow.right").font(.system(size: 8, weight: .bold))
+                .foregroundStyle(Brand.green)
+            Text("\u{201C}\(text)\u{201D}").font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+    }
+
+    /// Monospace config block with a one-click copy button.
+    private func codeBlock(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(text).font(Brand.mono(10)).foregroundStyle(Brand.textPrimary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack {
+                Spacer()
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                    copiedConfig = true
+                } label: {
+                    Label(copiedConfig ? "Copied" : "Copy config",
+                          systemImage: copiedConfig ? "checkmark" : "doc.on.doc")
+                        .font(Brand.mono(10)).foregroundStyle(Brand.green)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(11)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.black.opacity(0.25)))
+        .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
     private func toggleRow(_ label: String, isOn: Binding<Bool>, onChange: @escaping (Bool) -> Void) -> some View {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -80,7 +80,7 @@ struct SettingsView: View {
 
                         codeBlock(mcpConfigJSON)
 
-                        infoRow("Tools", "snapshot · history · top_processes · info")
+                        infoRow("Tools", "burrow_snapshot · _history · _top_processes · _info")
 
                         subLabel("Try asking")
                         promptRow("What's my Mac's CPU and memory usage right now?")
@@ -139,7 +139,7 @@ struct SettingsView: View {
     private func promptRow(_ text: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Image(systemName: "arrow.right").font(.system(size: 8, weight: .bold))
-                .foregroundStyle(Brand.green)
+                .foregroundStyle(Brand.green).accessibilityHidden(true)
             Text("\u{201C}\(text)\u{201D}").font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
             Spacer(minLength: 0)
@@ -158,6 +158,8 @@ struct SettingsView: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(text, forType: .string)
                     copiedConfig = true
+                    // Reset the label so a later copy confirms again.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) { copiedConfig = false }
                 } label: {
                     Label(copiedConfig ? "Copied" : "Copy config",
                           systemImage: copiedConfig ? "checkmark" : "doc.on.doc")

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @State private var retentionDays: Int = Store.retentionDays
     @State private var autoVacuum: Bool = Store.autoVacuum
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
+    @State private var showMenuBarIcon: Bool = Store.showMenuBarIcon
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
 
@@ -55,6 +56,11 @@ struct SettingsView: View {
                             Store.sampleIntervalSeconds = $0
                         }
                         footnote("Burrow runs `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
+                    }
+
+                    section("Menu bar", "menubar.rectangle") {
+                        toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { Store.showMenuBarIcon = $0 }
+                        footnote("When off, Burrow shows a Dock icon instead so it stays reachable — the window opens on launch and a Dock click reopens it. Takes effect after a relaunch.")
                     }
 
                     section("MCP query server", "antenna.radiowaves.left.and.right") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -10,6 +10,7 @@
 //
 
 import SwiftUI
+import LocalAuthentication
 
 struct SettingsView: View {
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
@@ -21,6 +22,7 @@ struct SettingsView: View {
     @State private var touchIDStatus = "—"
     @State private var touchIDEnabled = false
     @State private var touchIDBusy = false
+    @State private var touchIDAvailable = false
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -44,10 +46,12 @@ struct SettingsView: View {
 
                     section("Touch ID for sudo", "touchid") {
                         infoRow("Status", touchIDStatus)
-                        HStack {
-                            Spacer()
-                            if touchIDBusy { ProgressView().controlSize(.small).padding(.trailing, 4) }
-                            PillButton(title: touchIDEnabled ? "Disable" : "Enable", filled: false) { toggleTouchID() }
+                        if touchIDAvailable {
+                            HStack {
+                                Spacer()
+                                if touchIDBusy { ProgressView().controlSize(.small).padding(.trailing, 4) }
+                                PillButton(title: touchIDEnabled ? "Disable" : "Enable", filled: false) { toggleTouchID() }
+                            }
                         }
                         footnote("Lets `sudo` and admin prompts accept your fingerprint instead of a password, where macOS supports it. Configured via `mo touchid`; turning it on or off needs your password once.")
                     }
@@ -86,16 +90,29 @@ struct SettingsView: View {
 
     // MARK: - Touch ID for sudo
 
+    /// Whether this Mac actually has a Touch ID sensor. `mo touchid status`
+    /// only reports configured-vs-not (never hardware presence), so we ask
+    /// LocalAuthentication directly — biometryType is .touchID only on Macs
+    /// with the sensor (set after a canEvaluatePolicy probe, even if no
+    /// finger is enrolled yet).
+    private func touchIDHardwarePresent() -> Bool {
+        let ctx = LAContext()
+        var err: NSError?
+        _ = ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &err)
+        return ctx.biometryType == .touchID
+    }
+
     private func loadTouchIDStatus() {
+        let available = touchIDHardwarePresent()
         DispatchQueue.global(qos: .userInitiated).async {
             let res = try? MoleCLI.run(args: ["touchid", "status"], timeout: 15)
-            let out = (res?.stdout ?? "").lowercased()
-            let unavailable = out.contains("not available") || out.contains("no touch id")
-                || out.contains("not supported") || out.contains("no biometric")
+            // Strip ANSI colour codes Mole wraps the status line in before matching.
+            let out = CommandRunner.stripAnsi(res?.stdout ?? "").lowercased()
             let enabled = out.contains("is enabled")
             DispatchQueue.main.async {
+                touchIDAvailable = available
                 touchIDEnabled = enabled
-                touchIDStatus = unavailable ? "Not available on this Mac"
+                touchIDStatus = !available ? "Not available on this Mac"
                     : (out.isEmpty ? "Unknown" : (enabled ? "Enabled" : "Disabled"))
             }
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -18,6 +18,9 @@ struct SettingsView: View {
     @State private var queryServerEnabled: Bool = Store.queryServerEnabled
     @State private var dbSizeText: String = "—"
     @State private var lastMaintenanceText: String = "—"
+    @State private var touchIDStatus = "—"
+    @State private var touchIDEnabled = false
+    @State private var touchIDBusy = false
 
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
@@ -37,6 +40,16 @@ struct SettingsView: View {
                             }
                         }
                         footnote("History lives at ~/Library/Application Support/Burrow/burrow.db. Rows past the retention window are pruned hourly.")
+                    }
+
+                    section("Touch ID for sudo", "touchid") {
+                        infoRow("Status", touchIDStatus)
+                        HStack {
+                            Spacer()
+                            if touchIDBusy { ProgressView().controlSize(.small).padding(.trailing, 4) }
+                            PillButton(title: touchIDEnabled ? "Disable" : "Enable", filled: false) { toggleTouchID() }
+                        }
+                        footnote("Lets `sudo` and admin prompts accept your fingerprint instead of a password, where macOS supports it. Configured via `mo touchid`; turning it on or off needs your password once.")
                     }
 
                     section("History retention", "calendar") {
@@ -68,7 +81,43 @@ struct SettingsView: View {
                 .frame(maxWidth: .infinity)
             }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { refreshStatusLabels() }
+        .onAppear { refreshStatusLabels(); loadTouchIDStatus() }
+    }
+
+    // MARK: - Touch ID for sudo
+
+    private func loadTouchIDStatus() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let res = try? MoleCLI.run(args: ["touchid", "status"], timeout: 15)
+            let out = (res?.stdout ?? "").lowercased()
+            let unavailable = out.contains("not available") || out.contains("no touch id")
+                || out.contains("not supported") || out.contains("no biometric")
+            let enabled = out.contains("is enabled")
+            DispatchQueue.main.async {
+                touchIDEnabled = enabled
+                touchIDStatus = unavailable ? "Not available on this Mac"
+                    : (out.isEmpty ? "Unknown" : (enabled ? "Enabled" : "Disabled"))
+            }
+        }
+    }
+
+    private func toggleTouchID() {
+        guard !touchIDBusy else { return }
+        touchIDBusy = true
+        let cmd = touchIDEnabled ? "disable" : "enable"
+        DispatchQueue.global(qos: .userInitiated).async {
+            let code = MoleCLI.runElevated(args: ["touchid", cmd])
+            DispatchQueue.main.async {
+                touchIDBusy = false
+                loadTouchIDStatus()
+                if code != 0 {
+                    let alert = NSAlert()
+                    alert.messageText = "Couldn't update Touch ID for sudo"
+                    alert.informativeText = "`mo touchid \(cmd)` didn't complete (the password prompt may have been cancelled). You can also run it in a terminal."
+                    alert.runModal()
+                }
+            }
+        }
     }
 
     // MARK: - Section + row helpers

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -135,14 +135,38 @@ struct SettingsView: View {
             .foregroundStyle(Brand.textTertiary).padding(.top, 2)
     }
 
-    /// One example prompt the user can paste to their agent.
-    private func promptRow(_ text: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Image(systemName: "arrow.right").font(.system(size: 8, weight: .bold))
-                .foregroundStyle(Brand.green).accessibilityHidden(true)
-            Text("\u{201C}\(text)\u{201D}").font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer(minLength: 0)
+    /// One example prompt with a one-click copy button (the text isn't
+    /// selectable, so the button is the only way to grab it).
+    private func promptRow(_ text: String) -> some View { PromptRow(text: text) }
+
+    private struct PromptRow: View {
+        let text: String
+        @State private var copied = false
+        @State private var hovering = false
+
+        var body: some View {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "arrow.right").font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(Brand.green).accessibilityHidden(true)
+                Text("\u{201C}\(text)\u{201D}").font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 6)
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text, forType: .string)
+                    copied = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { copied = false }
+                } label: {
+                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                        .font(.system(size: 10))
+                        .foregroundStyle(copied ? Brand.green : (hovering ? Brand.textSecondary : Brand.textTertiary))
+                }
+                .buttonStyle(.plain)
+                .help("Copy prompt")
+                .accessibilityLabel("Copy prompt")
+            }
+            .contentShape(Rectangle())
+            .onHover { hovering = $0 }
         }
     }
 

--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -335,6 +335,11 @@ final class SoftwareModel: ObservableObject {
                 self.apps = parsed
                 self.selected = []
                 self.loading = false
+                // Re-fetched apps have lastUsed == nil; recompute dates if the
+                // user is still sorting by Recent (mirror load()), else Recent
+                // would silently collapse after an uninstall.
+                self.recentLoaded = false
+                if self.sort == .recent { self.ensureRecentDates() }
                 OperationCenter.shared.end(opId, success: (res?.exitCode ?? 1) == 0,
                                            detail: "\(targets.count) moved to Trash")
             }

--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -216,10 +216,31 @@ final class SoftwareModel: ObservableObject {
         load()
     }
 
-    func setSort(_ s: AppSort) { sort = s }
+    func setSort(_ s: AppSort) {
+        sort = s
+        if s == .recent { ensureRecentDates() }
+    }
 
     func toggle(_ id: String) {
         if selected.contains(id) { selected.remove(id) } else { selected.insert(id) }
+    }
+
+    private var recentLoaded = false
+
+    /// "Last used" needs a Spotlight query per app — only worth it when the
+    /// user actually sorts by Recent, not on every Software-tab open.
+    private func ensureRecentDates() {
+        guard !recentLoaded, !apps.isEmpty else { return }
+        recentLoaded = true
+        let snapshot = apps
+        DispatchQueue.global(qos: .userInitiated).async {
+            let dated = snapshot.map { a in
+                InstalledApp(id: a.id, name: a.name, bundleId: a.bundleId, source: a.source,
+                             uninstallName: a.uninstallName, path: a.path, sizeStr: a.sizeStr,
+                             sizeBytes: a.sizeBytes, lastUsed: Self.lastUsedDate(a.path))
+            }
+            Task { @MainActor in self.apps = dated }
+        }
     }
 
     func load() {
@@ -230,6 +251,8 @@ final class SoftwareModel: ObservableObject {
             Task { @MainActor in
                 self.apps = parsed
                 self.loading = false
+                self.recentLoaded = false
+                if self.sort == .recent { self.ensureRecentDates() }
             }
         }
     }
@@ -256,7 +279,7 @@ final class SoftwareModel: ObservableObject {
                 path: path,
                 sizeStr: sizeStr,
                 sizeBytes: parseSize(sizeStr),
-                lastUsed: lastUsedDate(path))
+                lastUsed: nil)   // computed lazily, only when sorting by Recent
         }
     }
 
@@ -302,13 +325,18 @@ final class SoftwareModel: ObservableObject {
 
         let names = targets.map { $0.uninstallName }
         loading = true
+        // Surface the run in the menu-bar HUD's Activity section too.
+        let opId = UUID()
+        OperationCenter.shared.begin(opId, label: "Uninstalling \(targets.count) app\(targets.count == 1 ? "" : "s")")
         DispatchQueue.global(qos: .userInitiated).async {
-            _ = try? MoleCLI.run(args: ["uninstall"] + names, timeout: 300)
+            let res = try? MoleCLI.run(args: ["uninstall"] + names, timeout: 300)
             let parsed = Self.fetch()
             Task { @MainActor in
                 self.apps = parsed
                 self.selected = []
                 self.loading = false
+                OperationCenter.shared.end(opId, success: (res?.exitCode ?? 1) == 0,
+                                           detail: "\(targets.count) moved to Trash")
             }
         }
     }

--- a/Sources/StatusBarController.swift
+++ b/Sources/StatusBarController.swift
@@ -50,6 +50,12 @@ final class StatusBarController {
         }
     }
 
+    deinit {
+        // Explicitly remove the item so toggling the menu-bar setting off
+        // (AppDelegate drops its reference) clears it from the bar at once.
+        NSStatusBar.system.removeStatusItem(item)
+    }
+
     @objc private func handleClick(_ sender: Any?) {
         guard let button = self.item.button else { return }
         if self.popover.isShown {

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -79,6 +79,17 @@ enum Store {
         set { d.set(newValue, forKey: "query_server_enabled") }
     }
 
+    // MARK: - Privacy
+
+    /// Whether the user has dismissed the Full Disk Access notice that
+    /// Burrow shows before scans which walk TCC-protected directories
+    /// (issue #3). Defaults to false so first-run users see it once;
+    /// sticks once dismissed so we never nag.
+    static var fullDiskAccessNoticeDismissed: Bool {
+        get { d.object(forKey: "fda_notice_dismissed") as? Bool ?? false }
+        set { d.set(newValue, forKey: "fda_notice_dismissed") }
+    }
+
     // MARK: - History view
 
     /// Last-selected History view range, in minutes. Persisting it

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -58,6 +58,17 @@ enum Store {
         set { d.set(newValue, forKey: "auto_vacuum") }
     }
 
+    // MARK: - Menu bar
+
+    /// Whether to install the menu-bar status item (issue #4). On by
+    /// default. When off, Burrow has no menu-bar entry point, so it runs
+    /// as a regular Dock app instead (window opens on launch, Dock click
+    /// reopens it) — read once at launch, so a change needs a relaunch.
+    static var showMenuBarIcon: Bool {
+        get { d.object(forKey: "show_menu_bar_icon") as? Bool ?? true }
+        set { d.set(newValue, forKey: "show_menu_bar_icon") }
+    }
+
     // MARK: - MCP / QueryServer
 
     /// Localhost port for the JSON HTTP server. 9277 by default

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -99,6 +99,10 @@ final class CommandRunner: ObservableObject {
 
     @Published var phase: Phase = .idle
     @Published var lines: [String] = []
+    /// Parsed report, recomputed once per coalesced flush — NOT per SwiftUI
+    /// render. Views read these instead of re-parsing `lines` every frame.
+    @Published private(set) var groups: [TaskGroup] = []
+    @Published private(set) var summary: TaskSummary?
     /// Set when the user aborts via `cancel()`, so the UI can say "Stopped"
     /// rather than reporting the terminated process as a plain failure.
     @Published private(set) var wasCancelled = false
@@ -107,12 +111,14 @@ final class CommandRunner: ObservableObject {
     private var operationLabel: String?
     private var task: Process?
     private var buffer = ""
+    private var pending: [String] = []
+    private var flushScheduled = false
     private var tailTimer: Timer?
     private var logHandle: FileHandle?
 
     func run(_ args: [String], elevated: Bool = false, label: String? = nil) {
         guard let mo = MoleCLI.findExecutable() else { phase = .failed("mo not found"); return }
-        lines = []; buffer = ""; wasCancelled = false; phase = .running
+        lines = []; buffer = ""; pending = []; groups = []; summary = nil; wasCancelled = false; phase = .running
         operationLabel = label
         if let label { OperationCenter.shared.begin(opId, label: label) }
         if elevated { runElevated(mo: mo, args: args); return }
@@ -156,6 +162,13 @@ final class CommandRunner: ObservableObject {
         // immediately rather than waiting on a terminationHandler that may
         // not fire for an already-dead task.
         if task == nil || task?.isRunning == false { phase = .done(130) }
+    }
+
+    /// Return to the idle (hero) state — used by the "Back" button on a
+    /// finished report so the user can get back to the tool's menu.
+    func reset() {
+        phase = .idle
+        lines = []; buffer = ""; pending = []; groups = []; summary = nil; wasCancelled = false
     }
 
     /// Run `mo <args>` as root via ONE osascript auth prompt, instead of
@@ -206,12 +219,38 @@ final class CommandRunner: ObservableObject {
         buffer += s
         var parts = buffer.components(separatedBy: "\n")
         buffer = parts.removeLast()
-        lines.append(contentsOf: parts)
+        guard !parts.isEmpty else { return }
+        pending.append(contentsOf: parts)
         if operationLabel != nil, let last = parts.last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
             OperationCenter.shared.detail(opId, last)
         }
+        scheduleFlush()
     }
-    private func flush() { if !buffer.isEmpty { lines.append(buffer); buffer = "" } }
+
+    /// Coalesce output: batch incoming lines and update @Published state at
+    /// most ~8×/sec, so a chatty `mo` run doesn't re-render the report (and
+    /// re-parse every line) on each chunk — the GUI overhead that made the
+    /// app feel heavier and laggier than the bare CLI.
+    private func scheduleFlush() {
+        guard !flushScheduled else { return }
+        flushScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { [weak self] in self?.applyPending() }
+    }
+
+    private func applyPending() {
+        flushScheduled = false
+        guard !pending.isEmpty else { return }
+        lines.append(contentsOf: pending)
+        pending.removeAll(keepingCapacity: true)
+        let r = parseTaskReport(lines)
+        groups = r.groups; summary = r.summary
+    }
+
+    /// Final flush at end of stream (plus the trailing partial line).
+    private func flush() {
+        if !buffer.isEmpty { pending.append(buffer); buffer = "" }
+        applyPending()
+    }
 
     nonisolated static func stripAnsi(_ s: String) -> String {
         guard s.contains("\u{1B}") else { return s }

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -99,6 +99,9 @@ final class CommandRunner: ObservableObject {
 
     @Published var phase: Phase = .idle
     @Published var lines: [String] = []
+    /// Set when the user aborts via `cancel()`, so the UI can say "Stopped"
+    /// rather than reporting the terminated process as a plain failure.
+    @Published private(set) var wasCancelled = false
 
     let opId = UUID()
     private var operationLabel: String?
@@ -109,7 +112,7 @@ final class CommandRunner: ObservableObject {
 
     func run(_ args: [String], elevated: Bool = false, label: String? = nil) {
         guard let mo = MoleCLI.findExecutable() else { phase = .failed("mo not found"); return }
-        lines = []; buffer = ""; phase = .running
+        lines = []; buffer = ""; wasCancelled = false; phase = .running
         operationLabel = label
         if let label { OperationCenter.shared.begin(opId, label: label) }
         if elevated { runElevated(mo: mo, args: args); return }
@@ -146,8 +149,13 @@ final class CommandRunner: ObservableObject {
     }
 
     func cancel() {
+        wasCancelled = true
         if let t = task, t.isRunning { t.terminate() }
         tailTimer?.invalidate(); tailTimer = nil
+        // If the process already exited (or never streamed), settle the UI
+        // immediately rather than waiting on a terminationHandler that may
+        // not fire for an already-dead task.
+        if task == nil || task?.isRunning == false { phase = .done(130) }
     }
 
     /// Run `mo <args>` as root via ONE osascript auth prompt, instead of

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -179,7 +179,11 @@ final class CommandRunner: ObservableObject {
         let safe = args.map { $0.filter(\.isLetter) }.joined(separator: "-")
         let logPath = NSTemporaryDirectory() + "burrow-op-\(safe).log"
         FileManager.default.createFile(atPath: logPath, contents: Data())
-        let inner = "\(mo) \(args.joined(separator: " ")) > '\(logPath)' 2>&1"
+        // Single-quote the executable path (args are hardcoded literals) so a
+        // space or metacharacter in the resolved `mo` path can't break or
+        // inject into the `do shell script` command.
+        func shQuote(_ s: String) -> String { "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'" }
+        let inner = "\(shQuote(mo)) \(args.joined(separator: " ")) > \(shQuote(logPath)) 2>&1"
         let script = "do shell script \"\(inner)\" with administrator privileges"
 
         let t = Process()

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -47,15 +47,23 @@ struct TaskGroup: Identifiable {
 }
 
 struct TaskSummary {
-    let space: String      // "383.8MB"
-    let items: String      // "372"
-    let categories: String // "20"
+    let space: String          // "383.8MB" — potential (dry-run) or tracked (real) cleanup size
+    let items: String          // "372"
+    let categories: String     // "20"
+    var freeChange: String = "" // "+1.39GB" — real run only (disk freed)
+    var freeNow: String = ""    // "2.50GB"  — real run only (free space after)
 }
 
 func parseTaskReport(_ lines: [String]) -> (groups: [TaskGroup], summary: TaskSummary?) {
     var groups: [TaskGroup] = []
-    var summary: TaskSummary?
     let markerChars: Set<Character> = ["→", "➜", "✓", "✔", "•", "◎", "●", "✗", "✘", "✕"]
+
+    // Summary fields accumulate across lines: the dry-run preview packs
+    // them onto one "Potential space:" line, but the real run spreads
+    // "Tracked cleanup:", "Free space change:" and "Free space now:" over
+    // three separate lines.
+    var space = "", items = "", cats = "", freeChange = "", freeNow = ""
+    var sawSummary = false
 
     for raw in lines {
         let t = raw.trimmingCharacters(in: .whitespaces)
@@ -68,27 +76,46 @@ func parseTaskReport(_ lines: [String]) -> (groups: [TaskGroup], summary: TaskSu
             let text = String(t.dropFirst()).trimmingCharacters(in: .whitespaces)
             if groups.isEmpty { groups.append(TaskGroup(title: "Summary", items: [])) }
             groups[groups.count - 1].items.append(TaskItem(marker: TaskMarker(first), text: text))
-        } else if t.hasPrefix("Potential space:") {
-            summary = parseSummary(t)
+        } else if mergeSummaryFields(line: t, space: &space, items: &items, categories: &cats,
+                                     freeChange: &freeChange, freeNow: &freeNow) {
+            sawSummary = true
         } else if t == t.uppercased(), t.count > 4, t.count < 40, !t.contains(":"), !t.contains("|") {
             groups.append(TaskGroup(title: t.capitalized, items: []))
         }
     }
+    let summary = sawSummary
+        ? TaskSummary(space: space, items: items, categories: cats,
+                      freeChange: freeChange, freeNow: freeNow)
+        : nil
     return (groups.filter { !$0.items.isEmpty }, summary)
 }
 
-private func parseSummary(_ line: String) -> TaskSummary {
-    var space = "", items = "", cats = ""
+/// Recognise a summary line from either the dry-run preview ("Potential
+/// space: … | Items: … | Categories: …") or the real run's footer
+/// ("Tracked cleanup: …", "Free space change: …", "Free space now: …")
+/// and merge its fields into the accumulators. Returns whether the line
+/// was a summary line, so the caller stops matching other shapes for it.
+private func mergeSummaryFields(line: String,
+                                space: inout String, items: inout String,
+                                categories: inout String,
+                                freeChange: inout String, freeNow: inout String) -> Bool {
+    let lower = line.lowercased()
+    guard lower.contains("potential space") || lower.contains("tracked cleanup")
+       || lower.contains("free space change") || lower.contains("free space now") else {
+        return false
+    }
     for part in line.components(separatedBy: "|") {
         let kv = part.components(separatedBy: ":")
         guard kv.count >= 2 else { continue }
         let key = kv[0].trimmingCharacters(in: .whitespaces).lowercased()
-        let val = kv[1].trimmingCharacters(in: .whitespaces)
-        if key.contains("space") { space = val }
+        let val = kv[1...].joined(separator: ":").trimmingCharacters(in: .whitespaces)
+        if key.contains("potential space") || key.contains("tracked cleanup") { space = val }
+        else if key.contains("free space change") { freeChange = val }
+        else if key.contains("free space now") { freeNow = val }
         else if key.contains("item") { items = val }
-        else if key.contains("categor") { cats = val }
+        else if key.contains("categor") { categories = val }
     }
-    return TaskSummary(space: space, items: items, categories: cats)
+    return true
 }
 
 // MARK: - Streaming runner

--- a/Sources/Tool.swift
+++ b/Sources/Tool.swift
@@ -92,6 +92,7 @@ enum Pane: Equatable, Hashable {
     case tool(Tool)
     case settings
     case history
+    case activity
 
     /// Window tint scrim. Tools carry their own colour; the utilities use
     /// a neutral dark so they read as "chrome", not a sixth tool.
@@ -99,7 +100,7 @@ enum Pane: Equatable, Hashable {
         switch self {
         case .tool(let t):
             return t.scrim
-        case .settings, .history:
+        case .settings, .history, .activity:
             return LinearGradient(colors: [Color(hex: 0x16150F).opacity(0.90), Brand.nearBlack.opacity(0.97)],
                                   startPoint: .top, endPoint: .bottom)
         }

--- a/Sources/TopNav.swift
+++ b/Sources/TopNav.swift
@@ -37,6 +37,7 @@ struct TopNav: View {
 
     private var utilityGroup: some View {
         HStack(spacing: 2) {
+            utility("list.bullet.rectangle", pane: .activity)
             utility("clock.arrow.circlepath", pane: .history)
             utility("gearshape", pane: .settings)
         }

--- a/Tests/DBTests.swift
+++ b/Tests/DBTests.swift
@@ -28,6 +28,54 @@ final class DBTests: XCTestCase {
         try? FileManager.default.removeItem(at: tempDir)
     }
 
+    // MARK: - Corruption recovery (issue #5)
+
+    /// A corrupt / non-database file at the path must not brick launch.
+    /// `DB(at:)` recovers by quarantining the bad file and recreating a
+    /// fresh, usable store. Uses its own path so the setUp DB handle
+    /// isn't affected.
+    func testInit_recoversFromCorruptDatabaseFile() throws {
+        let url = tempDir.appendingPathComponent("corrupt.db")
+        try Data("this is not a sqlite database".utf8).write(to: url)
+
+        let recovered = try DB(at: url)   // must not throw
+        try recovered.insert(prefix: "p", ts: 1, json: "{\"v\":1}")
+        let row = try XCTUnwrap(recovered.findLatest(prefix: "p"))
+        XCTAssertEqual(row.json, "{\"v\":1}")
+    }
+
+    /// The error from the issue: a valid-but-non-writable file. The
+    /// non-destructive repair (restore write permission) must recover it
+    /// IN PLACE so the user's history survives — no quarantine.
+    func testInit_recoversFromReadonlyDatabaseFile() throws {
+        let url = tempDir.appendingPathComponent("ro.db")
+        var seed: DB? = try DB(at: url)
+        try seed!.insert(prefix: "p", ts: 5, json: "{\"seed\":true}")
+        seed = nil   // close + checkpoint WAL into the main file
+
+        try? FileManager.default.removeItem(atPath: url.path + "-wal")
+        try? FileManager.default.removeItem(atPath: url.path + "-shm")
+        try FileManager.default.setAttributes([.posixPermissions: 0o444],
+                                              ofItemAtPath: url.path)
+
+        let recovered = try DB(at: url)   // must not throw
+        let row = try XCTUnwrap(recovered.findLatest(prefix: "p"))
+        XCTAssertEqual(row.json, "{\"seed\":true}", "readonly recovery must preserve history")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path + ".corrupt"),
+                       "a writable-again file should be repaired in place, not quarantined")
+    }
+
+    /// A genuinely unusable file (not a database, can't be repaired) is
+    /// moved aside so the fresh db can take its place — and kept for
+    /// forensics rather than silently deleted.
+    func testInit_quarantinesUnrecoverableFile() throws {
+        let url = tempDir.appendingPathComponent("bad.db")
+        try Data("not a database".utf8).write(to: url)
+        _ = try DB(at: url)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path + ".corrupt"),
+                      "the unusable file should be preserved alongside the fresh db")
+    }
+
     // MARK: - Roundtrip
 
     func testInsertAndFindLatest_returnsMostRecent() throws {

--- a/Tests/MCPTests.swift
+++ b/Tests/MCPTests.swift
@@ -40,7 +40,8 @@ final class MCPTests: XCTestCase {
         let d = catalog.descriptors()
         let names = d.compactMap { $0["name"] as? String }
         XCTAssertEqual(Set(names),
-                       ["burrow_snapshot", "burrow_history", "burrow_top_processes", "burrow_info"])
+                       ["burrow_snapshot", "burrow_history", "burrow_top_processes",
+                        "burrow_process_usage", "burrow_info"])
         // Every tool must carry an inputSchema and a description.
         for tool in d {
             XCTAssertNotNil(tool["description"] as? String)
@@ -96,6 +97,60 @@ final class MCPTests: XCTestCase {
         XCTAssertEqual(readers[0]["prefix"] as? String, Sampler.snapshotPrefix)
     }
 
+    /// The semantic usage tool must re-rank by the requested metric — the
+    /// whole point of adding it over burrow_top_processes (which only ever
+    /// ranks by peak CPU and so calls a one-second spike the "top" process).
+    /// "heavy" runs hot the whole window; "spike" peaks once then idles.
+    func testCallProcessUsage_ranksByChosenMetric() throws {
+        // (setUp already seeded a `kernel_task` at ~110% cumulative; pick
+        // timestamps off the seed rows so we don't collide on the PK and
+        // make `heavy` out-rank it on cumulative load.)
+        let now = Int(Date().timeIntervalSince1970)
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 300,
+                      json: snapshotJSON([("heavy", 60, 5)]))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 240,
+                      json: snapshotJSON([("heavy", 60, 5)]))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 180,
+                      json: snapshotJSON([("heavy", 60, 5), ("spike", 1, 1)]))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: now - 120,
+                      json: snapshotJSON([("spike", 95, 1)]))
+
+        let byCPUTime = try names(from: catalog.call(name: "burrow_process_usage",
+                                                     arguments: ["minutes": 30, "metric": "cpu_time"]))
+        XCTAssertEqual(byCPUTime.first, "heavy", "sustained load wins cumulative CPU-time")
+
+        let byPeak = try names(from: catalog.call(name: "burrow_process_usage",
+                                                  arguments: ["minutes": 30, "metric": "peak_cpu"]))
+        XCTAssertEqual(byPeak.first, "spike", "the one-second spike wins peak CPU")
+    }
+
+    func testCallProcessUsage_reportsWindowItUsed() throws {
+        let json = try catalog.call(name: "burrow_process_usage", arguments: ["minutes": 5])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        // It must echo the window + metric so the agent isn't guessing.
+        XCTAssertEqual(obj["window_minutes"] as? Int, 5)
+        XCTAssertNotNil(obj["start_ts"]); XCTAssertNotNil(obj["end_ts"])
+        XCTAssertNotNil(obj["sample_count"]); XCTAssertNotNil(obj["metric"])
+    }
+
+    func testCallProcessUsage_rejectsUnknownMetric() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_process_usage",
+                                              arguments: ["metric": "vibes"])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    // The `burrow mcp` PATH-shim invocation must be recognised alongside
+    // the original `--mcp` flag, and ordinary launches must not be.
+    func testIsMCPInvocation_recognisesFlagAndSubcommand() {
+        XCTAssertTrue(BurrowMain.isMCPInvocation(["Burrow", "--mcp"]))
+        XCTAssertTrue(BurrowMain.isMCPInvocation(["burrow", "mcp"]))
+        XCTAssertFalse(BurrowMain.isMCPInvocation(["Burrow"]))
+        XCTAssertFalse(BurrowMain.isMCPInvocation(["Burrow", "status"]))
+    }
+
     func testCallUnknownTool_throwsUnknown() {
         XCTAssertThrowsError(try catalog.call(name: "no_such_tool", arguments: [:])) { err in
             guard case MCPToolError.unknown(let name) = err else {
@@ -106,6 +161,36 @@ final class MCPTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Pull the ordered process names out of a burrow_process_usage result.
+    private func names(from json: String) throws -> [String] {
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let procs = try XCTUnwrap(obj["processes"] as? [[String: Any]])
+        return procs.compactMap { $0["name"] as? String }
+    }
+
+    /// A snapshot whose `top_processes` is the given (name, cpu%, mem%) list.
+    private func snapshotJSON(_ procs: [(String, Double, Double)]) -> String {
+        let entries = procs.enumerated().map { i, p in
+            "{ \"pid\": \(i + 1), \"ppid\": 0, \"name\": \"\(p.0)\", \"command\": \"\(p.0)\", \"cpu\": \(p.1), \"memory\": \(p.2) }"
+        }.joined(separator: ",")
+        return """
+        {
+          "collected_at": "2026-05-31T12:00:00.000000-07:00",
+          "host": "test", "platform": "darwin", "uptime": "1h 0m",
+          "uptime_seconds": 3600, "procs": 100,
+          "hardware": {
+            "model": "Test", "cpu_model": "Test", "total_ram": "16GB",
+            "disk_size": "512GB", "os_version": "14.5", "refresh_rate": "60Hz"
+          },
+          "health_score": 80, "health_score_msg": "ok",
+          "cpu": { "usage": 10.0, "load1": 1.0, "load5": 1.0, "load15": 1.0, "core_count": 8, "logical_cpu": 8 },
+          "memory": { "used": 1000, "total": 16000, "used_percent": 50.0, "swap_used": 0, "swap_total": 0, "pressure": "normal" },
+          "disk_io": { "read_rate": 1.0, "write_rate": 2.0 },
+          "top_processes": [\(entries)]
+        }
+        """
+    }
 
     /// Minimal valid Mole snapshot JSON. Includes only what the
     /// callers we test actually decode (top_processes for the

--- a/Tests/MoleCLITests.swift
+++ b/Tests/MoleCLITests.swift
@@ -1,0 +1,29 @@
+//
+//  MoleCLITests.swift
+//  BurrowTests
+//
+//  parseVersion is the only pure piece of the Mole-engine lifecycle
+//  (install/version/update); the rest spawns `mo`. It must pull a semver
+//  out of whatever `mo --version` decorates it with.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoleCLITests: XCTestCase {
+    func testParseVersion_extractsSemverFromDecoratedOutput() {
+        XCTAssertEqual(MoleCLI.parseVersion("mole 1.41.0"), "1.41.0")
+        XCTAssertEqual(MoleCLI.parseVersion("v1.41.0\n"), "1.41.0")
+        XCTAssertEqual(MoleCLI.parseVersion("mole version 2.0.10 (build 7)"), "2.0.10")
+    }
+
+    func testParseVersion_nilWhenNoVersion() {
+        XCTAssertNil(MoleCLI.parseVersion("no version here"))
+        XCTAssertNil(MoleCLI.parseVersion(""))
+    }
+
+    func testParseVersion_ignoresLoneNumbers() {
+        // A bare integer isn't a version; needs at least major.minor.
+        XCTAssertNil(MoleCLI.parseVersion("built for macOS 14"))
+    }
+}

--- a/Tests/MoleHistoryTests.swift
+++ b/Tests/MoleHistoryTests.swift
@@ -1,0 +1,50 @@
+//
+//  MoleHistoryTests.swift
+//  BurrowTests
+//
+//  Pins the `mo history --json` parser against a real sample of Mole's
+//  output shape.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoleHistoryTests: XCTestCase {
+    private let sample = """
+    {
+      "logs": {"operations": "/x/operations.log"},
+      "limit": 20,
+      "sessions": [
+        { "command": "clean", "started_at": "2026-06-06 20:33:49", "ended_at": "2026-06-06 20:35:23",
+          "items": 118, "size": "2.93GB", "operation_count": 126,
+          "actions": {"removed": 100, "trashed": 0, "skipped": 24, "failed": 2, "rebuilt": 0, "other": 0} },
+        { "command": "optimize", "started_at": "2026-06-06 20:32:46", "ended_at": "",
+          "items": 0, "size": "0B", "operation_count": 0,
+          "actions": {"removed": 0, "trashed": 0, "skipped": 0, "failed": 0} }
+      ]
+    }
+    """
+
+    func testParse_mapsSessionsAndActions() {
+        let sessions = MoleHistory.parse(Data(sample.utf8))
+        XCTAssertEqual(sessions.count, 2)
+        let clean = sessions[0]
+        XCTAssertEqual(clean.command, "clean")
+        XCTAssertEqual(clean.items, 118)
+        XCTAssertEqual(clean.size, "2.93GB")
+        XCTAssertEqual(clean.removed, 100)
+        XCTAssertEqual(clean.skipped, 24)
+        XCTAssertEqual(clean.failed, 2)
+        XCTAssertTrue(clean.isComplete)
+    }
+
+    func testParse_emptyEndedAtMeansIncomplete() {
+        let sessions = MoleHistory.parse(Data(sample.utf8))
+        XCTAssertFalse(sessions[1].isComplete, "blank ended_at → session didn't finish")
+    }
+
+    func testParse_toleratesGarbage() {
+        XCTAssertEqual(MoleHistory.parse(Data("not json".utf8)).count, 0)
+        XCTAssertEqual(MoleHistory.parse(Data("{}".utf8)).count, 0)
+    }
+}

--- a/Tests/PrivacyTests.swift
+++ b/Tests/PrivacyTests.swift
@@ -1,0 +1,28 @@
+//
+//  PrivacyTests.swift
+//  BurrowTests
+//
+//  The permission-flood fix (issue #3) hinges on one decision: should
+//  Burrow surface the Full Disk Access notice before a scan that walks
+//  TCC-protected directories? The probe for whether we *have* access is
+//  environment-dependent and not unit-testable, so the decision is split
+//  into a pure function that these tests pin down.
+//
+
+import XCTest
+@testable import Burrow
+
+final class PrivacyTests: XCTestCase {
+    // The rule: only nag when access is missing AND the user hasn't
+    // already dismissed the notice. Granting access or dismissing both
+    // silence it — we never want to flood the user with our own banner
+    // any more than with the OS prompts.
+    func testOffersAccessOnlyWhenMissingAndNotDismissed() {
+        XCTAssertTrue(Privacy.shouldOfferFullDiskAccess(hasAccess: false, dismissed: false))
+        XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: true, dismissed: false),
+                       "no notice when we already have access")
+        XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: false, dismissed: true),
+                       "respect a prior dismissal")
+        XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: true, dismissed: true))
+    }
+}

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -23,6 +23,7 @@ final class StoreTests: XCTestCase {
             "query_server_port",
             "query_server_enabled",
             "last_history_range_minutes",
+            "fda_notice_dismissed",
         ] {
             UserDefaults.standard.removeObject(forKey: k)
         }
@@ -72,6 +73,15 @@ final class StoreTests: XCTestCase {
 
     func testLastHistoryRangeMinutes_defaultsToOneHour() {
         XCTAssertEqual(Store.lastHistoryRangeMinutes, 60)
+    }
+
+    // The Full Disk Access notice (issue #3) must default to "not
+    // dismissed" so first-run users see it, and stick once dismissed so
+    // we don't nag.
+    func testFullDiskAccessNoticeDismissed_defaultsFalseAndPersists() {
+        XCTAssertFalse(Store.fullDiskAccessNoticeDismissed)
+        Store.fullDiskAccessNoticeDismissed = true
+        XCTAssertTrue(Store.fullDiskAccessNoticeDismissed)
     }
 
     func testRoundtripBoolAndInt() {

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -23,9 +23,18 @@ final class StoreTests: XCTestCase {
             "query_server_port",
             "query_server_enabled",
             "last_history_range_minutes",
+            "show_menu_bar_icon",
         ] {
             UserDefaults.standard.removeObject(forKey: k)
         }
+    }
+
+    // Issue #4: the menu-bar icon is on by default; the off-switch must
+    // persist (it's read once at launch to decide menu-bar vs Dock mode).
+    func testShowMenuBarIcon_defaultsTrueAndPersists() {
+        XCTAssertTrue(Store.showMenuBarIcon)
+        Store.showMenuBarIcon = false
+        XCTAssertFalse(Store.showMenuBarIcon)
     }
 
     func testSampleInterval_defaultsTo60() {

--- a/Tests/TaskReportTests.swift
+++ b/Tests/TaskReportTests.swift
@@ -1,0 +1,53 @@
+//
+//  TaskReportTests.swift
+//  BurrowTests
+//
+//  parseTaskReport turns streamed `mo clean`/`mo optimize` output into
+//  themed cards plus a summary. Two summary shapes exist: the dry-run
+//  preview ("Potential space: …") and the real run's footer ("Tracked
+//  cleanup: … / Free space change: … / Free space now: …"). The real-run
+//  footer was previously unparsed, so the "Cleaned" banner came up blank.
+//
+
+import XCTest
+@testable import Burrow
+
+final class TaskReportTests: XCTestCase {
+    // Real `mo clean` footer — the numbers users actually care about
+    // post-run are how much was freed and how much is now free.
+    func testParsesRealRunSummary() throws {
+        let lines = [
+            "======================================================================",
+            "Cleanup complete",
+            "Tracked cleanup: 1.02GB | Items cleaned: 337 | Categories: 35",
+            "Free space change: +1.39GB",
+            "Free space now: 2.50GB",
+            "======================================================================",
+        ]
+        let summary = try XCTUnwrap(parseTaskReport(lines).summary)
+        XCTAssertEqual(summary.space, "1.02GB")
+        XCTAssertEqual(summary.items, "337")
+        XCTAssertEqual(summary.categories, "35")
+        XCTAssertEqual(summary.freeChange, "+1.39GB")
+        XCTAssertEqual(summary.freeNow, "2.50GB")
+    }
+
+    // The dry-run preview packs everything onto one line and has no
+    // free-space figures (nothing was actually deleted). Guards the
+    // refactor that unified both summary shapes.
+    func testParsesDryRunSummary() throws {
+        let lines = [
+            "➤ Developer tools",
+            "  → npm cache, 191.8MB",
+            "Potential space: 383.8MB | Items: 372 | Categories: 20",
+        ]
+        let result = parseTaskReport(lines)
+        let summary = try XCTUnwrap(result.summary)
+        XCTAssertEqual(summary.space, "383.8MB")
+        XCTAssertEqual(summary.items, "372")
+        XCTAssertEqual(summary.categories, "20")
+        XCTAssertEqual(summary.freeChange, "", "dry-run frees nothing yet")
+        XCTAssertEqual(summary.freeNow, "")
+        XCTAssertEqual(result.groups.count, 1)
+    }
+}

--- a/packaging/burrow.rb
+++ b/packaging/burrow.rb
@@ -20,6 +20,11 @@ cask "burrow" do
 
   app "Burrow.app"
 
+  # PATH shim so coding agents can spawn the MCP server as `burrow mcp`
+  # without hardcoding the .app bundle path. The same binary serves the
+  # GUI (no args) and the stdio MCP server (`mcp` / `--mcp`).
+  binary "#{appdir}/Burrow.app/Contents/MacOS/Burrow", target: "burrow"
+
   # Pre-1.0 builds aren't notarized yet, so clear the quarantine flag to
   # avoid a Gatekeeper block on first launch. Remove this once the app
   # ships signed + notarized.

--- a/project.yml
+++ b/project.yml
@@ -37,6 +37,13 @@ targets:
         CFBundleShortVersionString: "0.4.0"
         CFBundleVersion: "1"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
+        # Friendly, one-time prompts for the standard folders Mole scans
+        # (purge/installer touch these). Full Disk Access still covers the
+        # cache/container locations — see the in-app FDA gate.
+        NSDesktopFolderUsageDescription: "Burrow scans your Desktop for reclaimable artifacts and leftover installers."
+        NSDocumentsFolderUsageDescription: "Burrow scans your Documents for reclaimable project artifacts."
+        NSDownloadsFolderUsageDescription: "Burrow scans your Downloads for leftover installer files (.dmg, .pkg)."
+        NSRemovableVolumesUsageDescription: "Burrow analyzes external drives when you point it at them."
     entitlements:
       path: Resources/Burrow.entitlements
       properties:


### PR DESCRIPTION
Single integration PR for **v0.4.0**. Merges the ready feature/fix PRs onto current `main` (preserving the zh-Hans localization), with the hotfixes from testing folded in. Merging this auto-closes the included PRs.

**Deferred — NOT in this release:** the **Purge** and **Installers** tabs (#13, #20) and the **Explain lens** (#14) stay **open** for more work.

31 files, ~+1761 / −122. Built (Release) + full `xcodebuild test` green.

## Issues closed
- **#5** — recover from an unreadable history DB (no more "readonly database" crash on launch).
- **#3** — tame the macOS permission-prompt flood (Full Disk Access gate on the flood-prone scans).
- **#4** — option to run without the menu-bar icon.
- **#2** — "can I use it with my AI?" — MCP how-to + drop-in config in Settings.

## What's in it (included PRs)
**Clean / Optimize / Analyze / Software** (#7, #8, #17)
- FDA gate + Stop + coalesced streaming (lighter than per-frame re-render), real freed-space banner, **Back on done *and* failed** runs.
- Analyze caches scans for instant back/drill; Software computes "last used" lazily and surfaces uninstall in the HUD.

**AI / MCP** (#9, #12)
- Settings "Ask your AI about your Mac (MCP)" — drop-in config + copyable example prompts for Claude Code / Cursor / Codex / Cline.
- `burrow_process_usage` MCP tool + `burrow mcp` PATH shim.

**Menu bar & HUD** (#11, #16, #17)
- Run without the menu-bar icon (live toggle, Dock fallback).
- Richer menu-bar HUD: running-job Activity at top with elapsed/status, tinted icon-pill nav, fixed port rendering.
- `mo history` Activity pane.

**Mole lifecycle & Touch ID** (#15, #21)
- Guided install onboarding + `mo` version + `mo update` in-app.
- Touch ID for sudo via `mo touchid` (real `LocalAuthentication` hardware detection).

**DB / CI** (#6, plus the release CI already on main)
- Staged history-DB recovery (repair-in-place → quarantine).
- Tagging `v0.4.0` triggers the existing signed-release + Homebrew-tap workflow.

## Notes
- **Purge / Installers (#13, #20)** and **Explain (#14)** intentionally excluded — left open.
- A few strings the feature PRs rewrote fell back to English where they collided with the new zh-Hans localization; functionality unaffected, easy re-localize follow-up.
- After merge: tag `v0.4.0` to cut the signed release (needs CI secrets `MACOS_CERT_P12` / `AC_API_KEY_*` / `TAP_PAT`).