### PR TITLE
perf(software): drop per-app Spotlight query (energy/mds spike)

### DIFF
--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -14,7 +14,6 @@
 
 import SwiftUI
 import AppKit
-import CoreServices
 
 struct InstalledApp: Identifiable {
     let id: String
@@ -294,13 +293,12 @@ final class SoftwareModel: ObservableObject {
         }
     }
 
-    /// Best-effort "last used": Spotlight's kMDItemLastUsedDate when it's
-    /// available, else the bundle's access/modification date.
+    /// Best-effort "last used" from the filesystem (access date, falling back to
+    /// modification date). Deliberately NOT Spotlight (`kMDItemLastUsedDate`):
+    /// querying metadata for every installed app woke `mds`/`mdworker` and spiked
+    /// CPU/energy. Filesystem dates are close enough for the Recent sort and cost
+    /// nothing — no metadata server, no indexing.
     private static func lastUsedDate(_ path: String) -> Date? {
-        if let item = MDItemCreate(nil, path as CFString),
-           let v = MDItemCopyAttribute(item, kMDItemLastUsedDate) as? Date {
-            return v
-        }
         let url = URL(fileURLWithPath: path)
         if let vals = try? url.resourceValues(forKeys: [.contentAccessDateKey, .contentModificationDateKey]) {
             return vals.contentAccessDate ?? vals.contentModificationDate


### PR DESCRIPTION
The Software (Uninstall) tab's "Recent" sort called Spotlight's `kMDItemLastUsedDate` **once per installed app** — hundreds of metadata queries that wake `mds`/`mdworker` and spike CPU/energy (visible as a high-energy "Spotlight" process).

Switch to the **filesystem access date** (`URLResourceValues.contentAccessDate`, already the fallback path): close enough for ordering, and it touches **no metadata server / no indexing**. Removes the now-unused `CoreServices` import.

- Built (Release) + full test suite green.
- Behaviour: "Recent" sort still orders by recency, just from fs dates instead of Spotlight's tracked last-used.