### PR TITLE
MCP: itemised cleanup history + exact deleted file paths (issue #2)

### DIFF
--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -139,7 +139,7 @@ final class MCPServer {
                 "capabilities": ["tools": [String: Any]()],
                 "serverInfo": [
                     "name": "burrow",
-                    "version": "0.2.0",
+                    "version": "0.3.0",
                 ],
             ],
         ]
@@ -272,6 +272,28 @@ struct ToolCatalog {
                     "additionalProperties": false,
                 ] as [String: Any],
             ],
+            [
+                "name": "burrow_cleanup_history",
+                "description": "Mole's itemised record of past cleanup activity: each clean/optimize/purge/uninstall session with when it ran, how many items, bytes freed, and an actions breakdown (removed/trashed/skipped/failed). `limit` caps how many recent sessions (default 20, max 200). This is Mole's CLEANUP log — distinct from burrow_history, which is the system-metrics time series. Read-only.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "limit": ["type": "integer", "minimum": 1, "maximum": 200],
+                    ],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_deleted_files",
+                "description": "The exact filesystem paths Mole has removed or trashed, newest first, from Mole's deletion log. Each entry has a timestamp, action (trash/remove), category, status (ok/failed), and the absolute path. `limit` caps how many recent paths (default 100, max 5000). Answers 'what exactly did the last cleanup delete?'. Read-only — this reports history, it does not delete anything.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "limit": ["type": "integer", "minimum": 1, "maximum": 5000],
+                    ],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
         ]
     }
 
@@ -287,6 +309,10 @@ struct ToolCatalog {
             return try self.callProcessUsage(arguments)
         case "burrow_info":
             return self.callInfo()
+        case "burrow_cleanup_history":
+            return self.callCleanupHistory(arguments)
+        case "burrow_deleted_files":
+            return self.callDeletedFiles(arguments)
         default:
             throw MCPToolError.unknown(name)
         }
@@ -433,5 +459,75 @@ struct ToolCatalog {
             }
         }
         return "{\"now\":\(now),\"retention_days\":\(Store.retentionDays),\"sample_interval_seconds\":\(Store.sampleIntervalSeconds),\"readers\":[\(pieces.joined(separator: ","))]}"
+    }
+
+    /// Itemised cleanup history (issue #2). Passes through `mo history
+    /// --json` — already the exact shape an agent wants (sessions[] with
+    /// command/time/items/size/actions). We don't reshape it so the
+    /// contract tracks Mole's, not ours. Degrades to a valid empty/error
+    /// object when `mo` isn't installed so the tool never throws.
+    private func callCleanupHistory(_ args: [String: Any]) -> String {
+        let limit = max(1, min((args["limit"] as? Int) ?? 20, 200))
+        guard let res = try? MoleCLI.run(args: ["history", "--json", "--limit", "\(limit)"],
+                                         timeout: 15),
+              res.exitCode == 0 else {
+            return "{\"error\":\"mo history unavailable\",\"sessions\":[]}"
+        }
+        let out = res.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return out.isEmpty ? "{\"sessions\":[]}" : out
+    }
+
+    /// Exact deleted file paths (issue #2). Reads Mole's append-only
+    /// deletion log and returns the most recent `limit` rows, newest
+    /// first. Read-only: this surfaces what Mole already deleted; it
+    /// never removes anything. Graceful when the log is absent.
+    private func callDeletedFiles(_ args: [String: Any]) -> String {
+        let limit = max(1, min((args["limit"] as? Int) ?? 100, 5000))
+        let logPath = Self.deletionsLogPath()
+        let text = (try? String(contentsOfFile: logPath, encoding: .utf8)) ?? ""
+        let files = Self.parseDeletionLog(text, limit: limit)
+        let out: [String: Any] = ["count": files.count, "log": logPath, "files": files]
+        if let data = try? JSONSerialization.data(withJSONObject: out,
+                                                  options: [.withoutEscapingSlashes]),
+           let s = String(data: data, encoding: .utf8) {
+            return s
+        }
+        return "{\"count\":0,\"files\":[]}"
+    }
+
+    /// Parse Mole's tab-separated deletion log into newest-first entries.
+    /// Each line is `ts \t action \t category \t status \t path`; the path
+    /// is the remainder so an (unlikely) tab inside it survives. Malformed
+    /// lines are skipped. Pure → unit-tested.
+    static func parseDeletionLog(_ text: String, limit: Int) -> [[String: Any]] {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: true)
+        var entries: [[String: Any]] = []
+        for line in lines.suffix(max(1, limit)) {
+            let parts = line.split(separator: "\t", maxSplits: 4,
+                                   omittingEmptySubsequences: false).map(String.init)
+            guard parts.count >= 5 else { continue }
+            entries.append([
+                "ts": parts[0], "action": parts[1], "category": parts[2],
+                "status": parts[3], "path": parts[4],
+            ])
+        }
+        return entries.reversed()
+    }
+
+    /// Resolve Mole's deletion-log path from `mo history --json` (the
+    /// source of truth), falling back to the standard location when `mo`
+    /// isn't reachable.
+    private static func deletionsLogPath() -> String {
+        let fallback = (NSHomeDirectory() as NSString)
+            .appendingPathComponent("Library/Logs/mole/deletions.log")
+        guard let res = try? MoleCLI.run(args: ["history", "--json"], timeout: 10),
+              res.exitCode == 0,
+              let data = res.stdout.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let logs = obj["logs"] as? [String: Any],
+              let p = logs["deletions"] as? String, !p.isEmpty else {
+            return fallback
+        }
+        return p
     }
 }

--- a/Tests/MCPTests.swift
+++ b/Tests/MCPTests.swift
@@ -41,7 +41,8 @@ final class MCPTests: XCTestCase {
         let names = d.compactMap { $0["name"] as? String }
         XCTAssertEqual(Set(names),
                        ["burrow_snapshot", "burrow_history", "burrow_top_processes",
-                        "burrow_process_usage", "burrow_info"])
+                        "burrow_process_usage", "burrow_info",
+                        "burrow_cleanup_history", "burrow_deleted_files"])
         // Every tool must carry an inputSchema and a description.
         for tool in d {
             XCTAssertNotNil(tool["description"] as? String)
@@ -149,6 +150,51 @@ final class MCPTests: XCTestCase {
         XCTAssertTrue(BurrowMain.isMCPInvocation(["burrow", "mcp"]))
         XCTAssertFalse(BurrowMain.isMCPInvocation(["Burrow"]))
         XCTAssertFalse(BurrowMain.isMCPInvocation(["Burrow", "status"]))
+    }
+
+    // The two issue-#2 tools shell out to `mo`/read its log, which may be
+    // absent on a CI runner. They must still return parseable JSON (real
+    // data when Mole is present, a graceful empty object otherwise) and
+    // never throw — an agent should never get a -32603 for "Mole isn't here".
+    func testCleanupHistory_alwaysReturnsValidJSON() throws {
+        let json = try catalog.call(name: "burrow_cleanup_history", arguments: ["limit": 5])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        XCTAssertTrue(obj["sessions"] != nil || obj["error"] != nil,
+                      "must carry sessions (mo present) or an error marker")
+    }
+
+    func testDeletedFiles_alwaysReturnsValidJSON() throws {
+        let json = try catalog.call(name: "burrow_deleted_files", arguments: ["limit": 10])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        XCTAssertNotNil(obj["count"] as? Int)
+        XCTAssertNotNil(obj["files"] as? [[String: Any]])
+    }
+
+    func testParseDeletionLog_parsesRowsNewestFirst() {
+        let log = """
+        2026-06-07T10:00:00+0800\ttrash\tcache\tok\t/Users/x/Library/Caches/a
+        2026-06-07T10:00:01+0800\tremove\tlog\tok\t/Users/x/Library/Logs/b.log
+        2026-06-07T10:00:02+0800\ttrash\tunknown\tfailed\t/Users/x/c
+        """
+        let e = ToolCatalog.parseDeletionLog(log, limit: 10)
+        XCTAssertEqual(e.count, 3)
+        XCTAssertEqual(e.first?["path"] as? String, "/Users/x/c", "newest first")
+        XCTAssertEqual(e.first?["status"] as? String, "failed")
+        XCTAssertEqual(e.last?["action"] as? String, "trash")
+    }
+
+    func testParseDeletionLog_skipsMalformedLines() {
+        let log = "garbage with no tabs\n2026\ttrash\tc\tok\t/a\n2026\ttrash\tc\tok\t/b"
+        let e = ToolCatalog.parseDeletionLog(log, limit: 10)
+        XCTAssertEqual(e.count, 2, "the tab-less line is dropped")
+    }
+
+    func testParseDeletionLog_respectsLimit() {
+        let log = (1...5).map { "2026\ttrash\tc\tok\t/\($0)" }.joined(separator: "\n")
+        let e = ToolCatalog.parseDeletionLog(log, limit: 2)
+        XCTAssertEqual(e.count, 2)
+        XCTAssertEqual(e.first?["path"] as? String, "/5", "keeps the 2 most recent, newest first")
+        XCTAssertEqual(e.last?["path"] as? String, "/4")
     }
 
     func testCallUnknownTool_throwsUnknown() {


### PR DESCRIPTION
Closes part of #2 — the two **data** asks (itemised cleanup history, exact deleted file paths). Both are **read-only**: they report Mole's own history, they never delete, kill, or clean. The four *action* asks from #2 (clean/uninstall/kill/delete) are deliberately **not** included — those would break the "agents can read metrics but never act" safety posture.

## New tools
| tool | answers | source |
|---|---|---|
| `burrow_cleanup_history` | "what cleanups have run, and how much did each free?" | `mo history --json` (sessions: command, time, items, bytes, removed/trashed/skipped/failed) |
| `burrow_deleted_files` | "what exact files did the last cleanup delete?" | Mole's deletion log, newest-first (ts, action, category, status, absolute path) |

Both take an optional `limit`. Both degrade to valid empty/error JSON when `mo` isn't installed, so an agent never gets a `-32603` just because Mole is absent. MCP `serverInfo` bumped 0.2.0 → 0.3.0.

## Verification
- Full `xcodebuild test` suite green, including new cases: descriptor set, graceful-without-mole behaviour, and the pure deletion-log parser (newest-first ordering, malformed-line skip, limit).
- Smoke-tested end-to-end through the real `--mcp` stdio loop:
  - `cleanup_history` → 2 sessions returned
  - `deleted_files` → exact paths, newest-first, with the resolved log path

## Not included
Action tools (clean these files / uninstall / kill process / delete file) — flagged in #2 as a product decision; they cross the read-only line and are left out by design.