### PR TITLE
Fix: Full Disk Access grants now take effect (ad-hoc sign releases)

### DIFF
--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -24,7 +24,7 @@ struct CleanView: View {
             if pendingRun != nil {
                 FullDiskAccessRequired(
                     accent: Tool.clean.accent,
-                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false) } },
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false); return true }; return false },
                     onRunAnyway: { runPending(elevate: true) },   // root bypasses TCC → no flood
                     onCancel: { pendingRun = nil })
             } else {

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -21,7 +21,7 @@ struct OptimizeView: View {
             if pendingRun != nil {
                 FullDiskAccessRequired(
                     accent: Tool.optimize.accent,
-                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false) } },
+                    onRecheck: { if Privacy.hasFullDiskAccess() { runPending(elevate: false); return true }; return false },
                     onRunAnyway: { runPending(elevate: true) },
                     onCancel: { pendingRun = nil })
             } else {

--- a/Sources/Privacy.swift
+++ b/Sources/Privacy.swift
@@ -63,6 +63,20 @@ enum Privacy {
     static func openFullDiskAccessSettings() {
         NSWorkspace.shared.open(fullDiskAccessSettingsURL)
     }
+
+    /// Relaunch Burrow. macOS binds a Full Disk Access grant to the app at
+    /// process launch, so a grant flipped on while the app is running often
+    /// isn't visible to the live process — quitting and reopening is the
+    /// reliable way to pick it up. Spawns a fresh instance, then terminates
+    /// this one once the new one is on its way.
+    static func relaunch() {
+        let url = Bundle.main.bundleURL
+        let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(at: url, configuration: config) { _, _ in
+            DispatchQueue.main.async { NSApp.terminate(nil) }
+        }
+    }
 }
 
 /// Dismissible banner shown before scans that walk TCC-protected
@@ -119,9 +133,16 @@ struct FullDiskAccessNotice: View {
 struct FullDiskAccessRequired: View {
     var accent: Color
     var onOpenSettings: () -> Void = { Privacy.openFullDiskAccessSettings() }
-    var onRecheck: () -> Void
+    /// Re-probe access. Returns `true` when access is now visible (the
+    /// parent proceeds with the scan and navigates away); `false` keeps us
+    /// on the gate and reveals the relaunch hint — macOS frequently only
+    /// applies a freshly-flipped grant at the app's next launch.
+    var onRecheck: () -> Bool
     var onRunAnyway: () -> Void
     var onCancel: () -> Void
+    var onRelaunch: () -> Void = { Privacy.relaunch() }
+
+    @State private var stillBlocked = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -141,12 +162,23 @@ struct FullDiskAccessRequired: View {
             VStack(spacing: 12) {
                 PillButton(title: "Open Full Disk Access settings") { onOpenSettings() }
                 HStack(spacing: 18) {
-                    Button("I've granted it — scan") { onRecheck() }
+                    Button("I've granted it — scan") { stillBlocked = !onRecheck() }
                         .buttonStyle(.plain).font(Brand.sans(12, .semibold)).foregroundStyle(accent)
                     Button("Scan with admin") { onRunAnyway() }
                         .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                     Button("Cancel") { onCancel() }
                         .buttonStyle(.plain).font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
+                }
+                if stillBlocked {
+                    VStack(spacing: 6) {
+                        Text("Still blocked? macOS only applies Full Disk Access the next time Burrow launches. Quit and reopen, then scan.")
+                            .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                            .multilineTextAlignment(.center).fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: 420)
+                        Button("Quit & Reopen Burrow") { onRelaunch() }
+                            .buttonStyle(.plain).font(Brand.sans(11, .semibold)).foregroundStyle(accent)
+                    }
+                    .padding(.top, 4)
                 }
             }
             Spacer(); Spacer()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 #
 # Build a Release Burrow.app and package it as a distributable .zip, then
-# print the sha256 for the Homebrew cask. The build is UNSIGNED — notarize
-# separately (see scripts/notarize.sh notes) for a Gatekeeper-clean release.
+# print the sha256 for the Homebrew cask. The build carries no Developer ID
+# and isn't notarized — but it IS ad-hoc signed (see below), which is what
+# lets macOS Full Disk Access grants actually take effect. For a fully
+# Gatekeeper-clean release, sign + notarize with a Developer ID on top (the
+# CI release workflow does this when the signing secrets are present).
 #
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -12,7 +15,7 @@ command -v xcodegen >/dev/null 2>&1 || { echo "need xcodegen — brew install xc
 echo "==> xcodegen generate"
 xcodegen generate >/dev/null
 
-echo "==> building Release (unsigned)"
+echo "==> building Release (no Developer ID; ad-hoc signed below)"
 rm -rf build_dist
 xcodebuild -project Burrow.xcodeproj -scheme Burrow \
   -configuration Release -destination 'generic/platform=macOS' \
@@ -22,6 +25,20 @@ xcodebuild -project Burrow.xcodeproj -scheme Burrow \
 
 APP="build_dist/Build/Products/Release/Burrow.app"
 [ -d "$APP" ] || { echo "build failed: $APP missing"; exit 1; }
+
+# Ad-hoc sign the bundle. CODE_SIGNING_ALLOWED=NO above leaves only the
+# linker's automatic signature (codesign flags: adhoc,linker-signed), which
+# `codesign --verify` rejects as "not signed at all". macOS TCC won't bind a
+# Full Disk Access grant to a code identity it considers invalid, so on the
+# unsigned build, granting FDA silently does nothing — the app keeps asking.
+# An explicit `codesign --sign -` gives the bundle a real, stable cdhash that
+# the FDA grant attaches to. (The cdhash still changes every rebuild, so each
+# new version must be re-granted — only a Developer ID identity avoids that.)
+echo "==> ad-hoc signing (stable code identity so Full Disk Access grants stick)"
+codesign --force --sign - \
+  --entitlements Resources/Burrow.entitlements \
+  "$APP"
+codesign --verify --strict --verbose=2 "$APP"
 
 VERSION=$(defaults read "$PWD/$APP/Contents/Info" CFBundleShortVersionString)
 mkdir -p dist


### PR DESCRIPTION
## The bug
You granted Full Disk Access to 0.5.0 and **nothing happened** — the app kept asking. This is a distribution bug, not a detection bug.

The shipped 0.5.0 build carries **only the linker's automatic signature**:
```
$ codesign -dvvv /Applications/Burrow.app
Identifier=Burrow                       ← bare, wrong
flags=0x20002(adhoc,linker-signed)      ← linker-signed
$ codesign --verify /Applications/Burrow.app
…code object is not signed at all       ← macOS considers it UNSIGNED
```
macOS TCC binds a Full Disk Access grant to an app's **code identity (cdhash)**. With a signature macOS treats as invalid, tccd can't match the running process to the grant — so you flip the switch and it's inert. (`release.sh` built with `CODE_SIGNING_ALLOWED=NO`, leaving only that linker signature.)

The detection probe itself is fine — both probe files exist on the machine, and the app isn't quarantined/translocated.

## The fix
Explicitly **ad-hoc sign** the bundle in `scripts/release.sh` (with entitlements). Verified on a fresh build:
```
flags=0x2(adhoc)                        ← linker-signed flag gone
Identifier=dev.caezium.Burrow           ← correct bundle id
$ codesign --verify --strict …          ← PASS, "satisfies its Designated Requirement"
```
Now there's a real, stable cdhash for the FDA grant to attach to. (The cdhash still changes on every rebuild, so each *new version* must be re-granted — only a Developer ID identity removes that. CI re-signs with Developer ID on top when the cert secrets are present.)

## Also fixed: the re-check dead-end
`FullDiskAccessRequired`'s "I've granted it — scan" silently did nothing when the re-probe still returned false (macOS often only applies a fresh grant at the **next launch**). `onRecheck` now reports success; on failure the gate explains this and offers a **Quit & Reopen Burrow** button (`Privacy.relaunch()`). Updated both consumers (Clean, Optimize).

## Verification
- `bash scripts/release.sh` → app passes `codesign --verify --strict`, `linker-signed` flag gone, identifier corrected.
- Full `xcodebuild test` suite green.

## To reach you
This corrects the *build*, so it needs a new release (e.g. **0.5.1**) — the installed 0.5.0 stays broken until then. Happy to cut it once this merges; it pulls only `main`, so the still-open Purge/Installers/Explain PRs are **not** included.