### PR TITLE
Fix installer/uninstall flows, system trackers, and settings persistence

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -140,6 +140,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         self.sampler?.stop()
         self.queryServer?.stop()
         self.maintenance?.stop()
+        // Final flush so any just-changed setting survives an app replacement
+        // during an update.
+        UserDefaults.standard.synchronize()
     }
 
     // MARK: - Window
@@ -214,6 +217,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if statusBar != nil {
             NSApp.setActivationPolicy(.accessory)
         }
+        // No live chart on screen → drop back to the idle sample cadence.
+        self.sampler?.setForeground(false)
     }
 
     /// Clicking the Dock icon (menu-bar-disabled mode) reopens the window.

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -46,6 +46,16 @@ struct ProcessRow: Identifiable {
     let name: String
     let peakCPU: Double
     let peakMem: Double
+    let peakMemBytes: UInt64
+}
+
+/// Which resource the Top Processes table ranks by. Mole's `top_processes`
+/// only carries CPU + memory per process (no per-process network/disk), so
+/// those are the two axes we can honestly rank.
+enum ProcMetric: String, CaseIterable, Identifiable {
+    case cpu = "CPU"
+    case ram = "RAM"
+    var id: String { rawValue }
 }
 
 /// Splits a series into segments wherever consecutive samples are farther
@@ -81,6 +91,11 @@ private struct HistorySnapshot {
     var netTx: [ChartPoint] = []
     var thermalCPU: [ChartPoint] = []
     var thermalGPU: [ChartPoint] = []
+    var thermalBattery: [ChartPoint] = []
+    var fanSpeed: [ChartPoint] = []
+    var fanCount: Int = 0
+    var batteryPercent: [ChartPoint] = []
+    var gpuUsage: [ChartPoint] = []
     var healthScore: [ChartPoint] = []
 
     var topProcesses: [ProcessRow] = []
@@ -111,6 +126,7 @@ private enum HistoryLoader {
         let dec = JSONDecoder()
         var peakCPU: [String: Double] = [:]
         var peakMem: [String: Double] = [:]
+        var peakMemBytes: [String: UInt64] = [:]
 
         for row in rows {
             guard let data = row.json.data(using: .utf8) else { continue }
@@ -129,24 +145,31 @@ private enum HistoryLoader {
             if let thermal = s.thermal {
                 if thermal.cpuTemp > 0 { snap.thermalCPU.append(.init(time: t, value: thermal.cpuTemp)) }
                 if thermal.gpuTemp > 0 { snap.thermalGPU.append(.init(time: t, value: thermal.gpuTemp)) }
+                if let bt = thermal.batteryTemp, bt > 0 { snap.thermalBattery.append(.init(time: t, value: bt)) }
+                if thermal.fanSpeed > 0 { snap.fanSpeed.append(.init(time: t, value: Double(thermal.fanSpeed))) }
+                snap.fanCount = max(snap.fanCount, thermal.fanCount ?? 0)
             }
+            if let b = s.batteries?.first { snap.batteryPercent.append(.init(time: t, value: b.percent)) }
+            if let g = s.gpu?.first, g.usage >= 0 { snap.gpuUsage.append(.init(time: t, value: g.usage)) }
             snap.healthScore.append(.init(time: t, value: Double(s.healthScore)))
 
             for p in (s.topProcesses ?? []) {
                 if p.cpu > (peakCPU[p.name] ?? 0)    { peakCPU[p.name] = p.cpu }
                 if p.memory > (peakMem[p.name] ?? 0) { peakMem[p.name] = p.memory }
+                if let mb = p.memoryBytes, mb > (peakMemBytes[p.name] ?? 0) { peakMemBytes[p.name] = mb }
             }
             snap.memoryPressure = s.memory.pressure
         }
 
-        let topByCPU = peakCPU.sorted { $0.value > $1.value }.prefix(15).map(\.key)
-        let topByMem = peakMem.sorted { $0.value > $1.value }.prefix(15).map(\.key)
+        let topByCPU = peakCPU.sorted { $0.value > $1.value }.prefix(20).map(\.key)
+        let topByMem = peakMem.sorted { $0.value > $1.value }.prefix(20).map(\.key)
         var seen = Set<String>()
         var rows2: [ProcessRow] = []
         for name in topByCPU + topByMem where seen.insert(name).inserted {
             rows2.append(ProcessRow(name: name,
                                     peakCPU: peakCPU[name] ?? 0,
-                                    peakMem: peakMem[name] ?? 0))
+                                    peakMem: peakMem[name] ?? 0,
+                                    peakMemBytes: peakMemBytes[name] ?? 0))
         }
         snap.topProcesses = rows2.sorted { $0.peakCPU > $1.peakCPU }
 
@@ -187,6 +210,7 @@ struct HistoryView: View {
     @State private var snapshot: HistorySnapshot = HistorySnapshot()
     @State private var loading: Bool = false
     @State private var loadGen: Int = 0
+    @State private var procMetric: ProcMetric = .cpu
 
     private let autoRefreshTimer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
@@ -200,12 +224,17 @@ struct HistoryView: View {
                         chartCard("CPU load", "1m avg", [("load1", snapshot.cpuLoad1, Brand.orange)])
                         chartCard("Memory", snapshot.memoryPressure.isEmpty ? "% used" : snapshot.memoryPressure,
                                   [("used", snapshot.memoryUsed, Brand.amber)])
+                        chartCard("GPU usage", "%", [("gpu", snapshot.gpuUsage, Brand.orange)])
                         chartCard("Disk I/O", "MB/s", [("read", snapshot.diskRead, Brand.blue),
                                                        ("write", snapshot.diskWrite, Color(hex: 0x6E8BEA))])
                         chartCard("Network", "MB/s", [("rx", snapshot.netRx, Brand.green),
                                                       ("tx", snapshot.netTx, Color(hex: 0x57C2A5))])
                         chartCard("Thermal", "°C", [("cpu", snapshot.thermalCPU, Brand.red),
-                                                    ("gpu", snapshot.thermalGPU, Brand.orange)])
+                                                    ("gpu", snapshot.thermalGPU, Brand.orange),
+                                                    ("battery", snapshot.thermalBattery, Brand.gold)])
+                        chartCard("Fans", snapshot.fanCount > 0 ? "RPM" : "not reported",
+                                  [("fan", snapshot.fanSpeed, Color(hex: 0x6EC1E4))])
+                        chartCard("Battery", "%", [("charge", snapshot.batteryPercent, Brand.green)])
                         chartCard("Health score", "0–100", [("health", snapshot.healthScore, Brand.gold)])
                         topProcessesCard
                     }
@@ -305,36 +334,87 @@ struct HistoryView: View {
         }
     }
 
+    /// Processes ranked by the selected metric (CPU or RAM), peak across the
+    /// window. The same rows carry both peaks, so switching the toggle just
+    /// re-sorts in place — no reload.
+    private var rankedProcesses: [ProcessRow] {
+        switch procMetric {
+        case .cpu: return snapshot.topProcesses.sorted { $0.peakCPU > $1.peakCPU }
+        case .ram: return snapshot.topProcesses.sorted {
+            ($0.peakMemBytes, $0.peakMem) > ($1.peakMemBytes, $1.peakMem)
+        }
+        }
+    }
+
     private var topProcessesCard: some View {
         GlassCard {
             VStack(alignment: .leading, spacing: 8) {
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
                     Text(NSLocalizedString("Top processes", comment: "").uppercased()).font(Brand.mono(10, .bold)).tracking(0.7).foregroundStyle(Brand.textSecondary)
                     Text("peak across window").font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    Spacer()
+                    procMetricToggle
                 }
                 if snapshot.topProcesses.isEmpty {
                     Text("No processes recorded")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
                         .frame(maxWidth: .infinity, minHeight: 170)
                 } else {
+                    // Column header makes it clear which number is which once the
+                    // ranking can change what's on top.
+                    HStack {
+                        Text("").frame(maxWidth: .infinity, alignment: .leading)
+                        Text("CPU").font(Brand.mono(8, .bold)).tracking(0.5)
+                            .foregroundStyle(procMetric == .cpu ? Brand.green : Brand.textTertiary)
+                            .frame(width: 52, alignment: .trailing)
+                        Text("RAM").font(Brand.mono(8, .bold)).tracking(0.5)
+                            .foregroundStyle(procMetric == .ram ? Brand.amber : Brand.textTertiary)
+                            .frame(width: 70, alignment: .trailing)
+                    }
                     ScrollView {
                         VStack(spacing: 3) {
-                            ForEach(snapshot.topProcesses.prefix(18)) { row in
+                            ForEach(rankedProcesses.prefix(20)) { row in
                                 HStack {
                                     Text(row.name).font(Brand.sans(11)).foregroundStyle(Brand.textPrimary).lineLimit(1)
                                     Spacer(minLength: 8)
                                     Text(String(format: "%.1f%%", row.peakCPU)).font(Brand.mono(10))
-                                        .foregroundStyle(Brand.green).frame(width: 52, alignment: .trailing)
-                                    Text(String(format: "%.1f%%", row.peakMem)).font(Brand.mono(10))
-                                        .foregroundStyle(Brand.amber).frame(width: 52, alignment: .trailing)
+                                        .foregroundStyle(procMetric == .cpu ? Brand.green : Brand.textTertiary)
+                                        .frame(width: 52, alignment: .trailing)
+                                    Text(ramLabel(row)).font(Brand.mono(10))
+                                        .foregroundStyle(procMetric == .ram ? Brand.amber : Brand.textTertiary)
+                                        .frame(width: 70, alignment: .trailing)
                                 }
                             }
                         }
                     }
-                    .frame(height: 170)
+                    .frame(height: 148)
                 }
             }
         }
+    }
+
+    /// RAM column shows an absolute size when Mole reported bytes, else the
+    /// percent it always carries.
+    private func ramLabel(_ row: ProcessRow) -> String {
+        row.peakMemBytes > 0 ? Fmt.bytes(Int64(row.peakMemBytes)) : String(format: "%.1f%%", row.peakMem)
+    }
+
+    private var procMetricToggle: some View {
+        HStack(spacing: 2) {
+            ForEach(ProcMetric.allCases) { m in
+                let on = m == procMetric
+                Button { procMetric = m } label: {
+                    Text(m.rawValue).font(Brand.mono(9, on ? .bold : .regular))
+                        .foregroundStyle(on ? Color.black : Brand.textSecondary)
+                        .padding(.horizontal, 7).padding(.vertical, 2)
+                        .background { if on { Capsule().fill(.white) } }
+                        .contentShape(Capsule())
+                }.buttonStyle(.plain)
+            }
+        }
+        .padding(2)
+        .background(Capsule().fill(Color.black.opacity(0.22)))
+        .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
     // MARK: - Load lifecycle

--- a/Sources/InstallerView.swift
+++ b/Sources/InstallerView.swift
@@ -26,6 +26,10 @@ final class MoInteractiveRunner: ObservableObject {
     /// Total Mole reported in its "[n/total]" header. When it exceeds
     /// `items.count`, Mole capped the visible rows and the UI says so.
     @Published var totalCount: Int = 0
+    /// "Show all" pulled in every row past Mole's ≈50-row viewport cap.
+    @Published var fullyLoaded = false
+    /// Scroll-capture in progress (drives the "Loading all N…" affordance).
+    @Published var loadingAll = false
 
     let title: String
     private let subcommand: String
@@ -37,6 +41,7 @@ final class MoInteractiveRunner: ObservableObject {
     private var pressedProceed = false   // first Enter sent → capturing Mole's "Remove N?" screen
     private var confirmScreen = ""       // output between the first and second Enter
     private var wantedCount = 0          // how many we intend to remove (verified on the confirm screen)
+    private var viewportCount = 0        // rows in the FIRST frame — Mole's viewport cap (≈50)
 
     init(subcommand: String, title: String) {
         self.subcommand = subcommand; self.title = title
@@ -60,6 +65,7 @@ final class MoInteractiveRunner: ObservableObject {
         screen = ""; result = ""; confirmScreen = ""
         confirmed = false; listReady = false; pressedProceed = false
         items = []; resultText = ""; totalCount = 0; wantedCount = 0
+        viewportCount = 0; fullyLoaded = false; loadingAll = false
         phase = .scanning
         pty.onExit = { [weak self] in Task { @MainActor in self?.handleExit() } }
         do { try pty.launch(mo, [subcommand]) }
@@ -73,6 +79,39 @@ final class MoInteractiveRunner: ObservableObject {
 
     func rescan() { start() }
 
+    // MARK: - Show all (scroll past Mole's viewport cap)
+
+    /// Pull in every row past Mole's ≈50-row viewport cap. Mole renders only a
+    /// window of the list but the cursor scrolls through ALL of it, so we walk
+    /// to the bottom one row at a time, stitching each overlapping frame into
+    /// one ordered list, then return the cursor to the top so a later selection
+    /// walk still starts at row 0. Append-only, so indices the user already
+    /// selected stay valid. Validated against `mo purge --dry-run`.
+    func loadAll() {
+        guard phase == .choosing, !fullyLoaded, !loadingAll else { return }
+        guard totalCount > items.count else { fullyLoaded = true; return }
+        loadingAll = true
+        scrollCapture(pressesLeft: totalCount + 20)
+    }
+
+    private func scrollCapture(pressesLeft: Int) {
+        guard loadingAll, phase == .choosing else { loadingAll = false; return }
+        let vp = MoTUI.parse(screen).items
+        if !vp.isEmpty { items = MoTUI.mergeItems(items, vp) }
+        if items.count >= totalCount || pressesLeft <= 0 {
+            // Return cursor to the top (over-send; Mole clamps at row 0).
+            for _ in 0..<(items.count + 5) { pty.send(MoTUI.up) }
+            fullyLoaded = true
+            loadingAll = false
+            return
+        }
+        pty.send(MoTUI.down)
+        if screen.count > 80_000 { screen = String(screen.suffix(40_000)) }  // keep parse cheap
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { [weak self] in
+            self?.scrollCapture(pressesLeft: pressesLeft - 1)
+        }
+    }
+
     /// Apply selection: toggle the wanted rows, then poll the screen until the
     /// redraw settles and confirm ONLY if the checked rows match the wanted
     /// items BY NAME (not just by index) and the list didn't shift/scroll —
@@ -84,9 +123,67 @@ final class MoInteractiveRunner: ObservableObject {
         phase = .applying
         wantedCount = wanted.count
         let wantedNames = Set(wanted.compactMap { items.indices.contains($0) ? items[$0].name : nil })
+        let wantedSigs = Set(wanted.compactMap { items.indices.contains($0) ? Self.sig(items[$0]) : nil })
         let expectedCount = items.count
         pty.send(MoTUI.keystrokesToSelect(wanted, count: items.count, confirm: false))
-        verifyThenConfirm(wanted: wanted, wantedNames: wantedNames, expectedCount: expectedCount, attempt: 0, last: nil)
+        if items.count > viewportCount {
+            // Selection spans more rows than Mole renders at once (the user
+            // pulled in everything via "Show all"). Verifying by re-reading a
+            // single frame can't see them all, so we scroll through and confirm
+            // the checked rows match BY IDENTITY before letting Mole proceed.
+            scrollVerifyThenConfirm(wantedSigs: wantedSigs)
+        } else {
+            verifyThenConfirm(wanted: wanted, wantedNames: wantedNames, expectedCount: expectedCount, attempt: 0, last: nil)
+        }
+    }
+
+    /// Row identity for safe comparison — full path/name plus size and location,
+    /// so two projects sharing a basename can't be confused.
+    private static func sig(_ i: MoTUIItem) -> String { "\(i.name)\u{1}\(i.size)\u{1}\(i.location)" }
+
+    /// Verify a selection that spans more than one viewport: scroll from the
+    /// top to the bottom accumulating the CHECKED rows, then proceed only if
+    /// that set exactly equals what the user picked. Any mismatch or timeout →
+    /// quit, remove nothing. Mole's own "Remove N?" count is the final backstop
+    /// in `awaitFinalConfirm`.
+    private func scrollVerifyThenConfirm(wantedSigs: Set<String>) {
+        guard phase == .applying else { return }
+        for _ in 0..<(items.count + 5) { pty.send(MoTUI.up) }   // back to the top
+        screen = ""                                              // read only post-selection frames
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self else { return }
+            self.scrollVerifyStep(wantedSigs: wantedSigs, checked: [], seen: [],
+                                  pressesLeft: self.items.count + 20)
+        }
+    }
+
+    private func scrollVerifyStep(wantedSigs: Set<String>, checked: Set<String>,
+                                  seen: Set<String>, pressesLeft: Int) {
+        guard phase == .applying else { return }
+        var checked = checked, seen = seen
+        for it in MoTUI.parse(screen).items {
+            let s = Self.sig(it)
+            seen.insert(s)
+            if it.selected { checked.insert(s) }
+        }
+        if seen.count >= items.count || pressesLeft <= 0 {
+            if checked == wantedSigs {
+                pressedProceed = true
+                confirmScreen = ""
+                pty.send([0x0d])              // proceed to Mole's final "Remove N?" screen
+                awaitFinalConfirm(attempt: 0)
+            } else {
+                pty.send(MoTUI.quit)
+                phase = .failed("Couldn't verify the full selection safely (\(checked.count)/\(wantedSigs.count) confirmed). Nothing was removed — please try again.")
+            }
+            return
+        }
+        pty.send(MoTUI.down)
+        if screen.count > 80_000 { screen = String(screen.suffix(40_000)) }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { [weak self] in
+            self?.scrollVerifyStep(wantedSigs: wantedSigs, checked: checked, seen: seen,
+                                   pressesLeft: pressesLeft - 1)
+        }
     }
 
     /// Re-read every 0.15s (up to ~2s) until the on-screen selection is stable
@@ -177,6 +274,7 @@ final class MoInteractiveRunner: ObservableObject {
             if !parsed.items.isEmpty {
                 listReady = true
                 items = parsed.items
+                viewportCount = parsed.items.count
                 totalCount = max(MoTUI.totalCount(screen) ?? parsed.items.count, parsed.items.count)
                 phase = .choosing
             }
@@ -336,11 +434,26 @@ struct MoInteractiveView: View {
             }
             .scrollIndicators(.visible)
 
-            if runner.totalCount > runner.items.count {
-                Text("Showing the \(runner.items.count) biggest of \(runner.totalCount). For the rest, run `mo \(cfg.subcommand)` in a terminal.")
-                    .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 18).padding(.bottom, 4)
+            if runner.loadingAll {
+                HStack(spacing: 7) {
+                    ProgressView().controlSize(.small).tint(cfg.tool.accent)
+                    Text("Loading all \(runner.totalCount)… (\(runner.items.count) so far)")
+                        .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 18).padding(.bottom, 4)
+            } else if runner.totalCount > runner.items.count {
+                HStack(spacing: 8) {
+                    Text("Showing the \(runner.items.count) biggest of \(runner.totalCount).")
+                        .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    Button { runner.loadAll() } label: {
+                        Text("Show all \(runner.totalCount)")
+                            .font(Brand.mono(9, .semibold)).foregroundStyle(cfg.tool.accent)
+                    }.buttonStyle(.plain)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 18).padding(.bottom, 4)
             }
 
             Rectangle().fill(Brand.hairline).frame(height: 1)

--- a/Sources/LocalMetrics.swift
+++ b/Sources/LocalMetrics.swift
@@ -1,0 +1,148 @@
+//
+//  LocalMetrics.swift
+//  Burrow
+//
+//  Native IOKit readers for the two metrics Mole's `status --json` can't
+//  deliver on Apple Silicon / macOS 26:
+//
+//    * Disk I/O throughput — `mo status` reports `disk_io.read_rate` and
+//      `write_rate` as 0 even under heavy load here, so the chart was a flat
+//      line. We sum IOBlockStorageDriver byte counters and differentiate
+//      across sampler ticks to get MB/s.
+//    * GPU utilisation — `mo status` reports `gpu[].usage == -1` (unavailable)
+//      on Apple Silicon, so the GPU tile read "—". The IOAccelerator registry
+//      entry exposes `Device Utilization %`, which is exactly what Activity
+//      Monitor and istatistics-style tools read.
+//
+//  These are *fallbacks*: the Sampler only injects them into the snapshot when
+//  Mole's own values are missing (0 disk rate / negative GPU usage), so on a
+//  platform where Mole reports them we keep Mole's numbers and the contract
+//  stays "the snapshot is whatever the sampler stored".
+//
+
+import Foundation
+import IOKit
+
+/// Stateful reader: disk throughput is a rate, so it needs the previous byte
+/// counters + timestamp to differentiate. One instance lives on the Sampler.
+final class LocalMetrics {
+    private var lastDiskRead: UInt64 = 0
+    private var lastDiskWrite: UInt64 = 0
+    private var lastDiskAt: Date?
+
+    init() {}
+
+    // MARK: - Disk I/O
+
+    /// Cumulative bytes read/written across every IOBlockStorageDriver. These
+    /// are monotonic since boot; the rate is their delta over time.
+    private func diskByteCounters() -> (read: UInt64, write: UInt64)? {
+        var iter: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault,
+                                           IOServiceMatching("IOBlockStorageDriver"),
+                                           &iter) == KERN_SUCCESS else { return nil }
+        defer { IOObjectRelease(iter) }
+
+        var totalR: UInt64 = 0, totalW: UInt64 = 0, found = false
+        var svc = IOIteratorNext(iter)
+        while svc != 0 {
+            var props: Unmanaged<CFMutableDictionary>?
+            if IORegistryEntryCreateCFProperties(svc, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+               let dict = props?.takeRetainedValue() as? [String: Any],
+               let stats = dict["Statistics"] as? [String: Any] {
+                if let r = (stats["Bytes (Read)"] as? NSNumber)?.uint64Value { totalR += r; found = true }
+                if let w = (stats["Bytes (Write)"] as? NSNumber)?.uint64Value { totalW += w; found = true }
+            }
+            IOObjectRelease(svc)
+            svc = IOIteratorNext(iter)
+        }
+        return found ? (totalR, totalW) : nil
+    }
+
+    /// Read/write throughput in MB/s since the previous call. Returns nil on the
+    /// first call (no baseline yet) or if the counters are unreadable. Averaged
+    /// over the inter-tick interval — for a 60 s sampler that's a windowed
+    /// average, which reads more honestly on a chart than an instantaneous spike.
+    func diskRateMBs() -> (read: Double, write: Double)? {
+        guard let now = diskByteCounters() else { return nil }
+        let at = Date()
+        defer { lastDiskRead = now.read; lastDiskWrite = now.write; lastDiskAt = at }
+        guard let prevAt = lastDiskAt else { return nil }
+        let dt = at.timeIntervalSince(prevAt)
+        guard dt > 0.05 else { return nil }
+        // Counters reset (reboot / driver replug) → skip this delta.
+        guard now.read >= lastDiskRead, now.write >= lastDiskWrite else { return nil }
+        let mb = 1_048_576.0
+        return (Double(now.read - lastDiskRead) / mb / dt,
+                Double(now.write - lastDiskWrite) / mb / dt)
+    }
+
+    // MARK: - GPU
+
+    /// GPU busy percent (0–100) from the IOAccelerator `Device Utilization %`
+    /// performance counter, or nil if no accelerator exposes it. Takes the max
+    /// across accelerators (a Mac with discrete + integrated reports both).
+    func gpuUtilization() -> Double? {
+        var iter: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault,
+                                           IOServiceMatching("IOAccelerator"),
+                                           &iter) == KERN_SUCCESS else { return nil }
+        defer { IOObjectRelease(iter) }
+
+        var best: Double? = nil
+        var svc = IOIteratorNext(iter)
+        while svc != 0 {
+            var props: Unmanaged<CFMutableDictionary>?
+            if IORegistryEntryCreateCFProperties(svc, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+               let dict = props?.takeRetainedValue() as? [String: Any],
+               let perf = dict["PerformanceStatistics"] as? [String: Any],
+               let util = (perf["Device Utilization %"] as? NSNumber)?.doubleValue {
+                best = max(best ?? 0, util)
+            }
+            IOObjectRelease(svc)
+            svc = IOIteratorNext(iter)
+        }
+        return best
+    }
+
+    // MARK: - Snapshot patching
+
+    /// Inject native disk-I/O and GPU readings into Mole's `status --json` text,
+    /// but only where Mole left a hole: disk rate is overwritten only when Mole
+    /// reports 0/0 (so a platform where `mo` works keeps its values), and GPU
+    /// usage only when Mole reports a negative ("unavailable") number. Returns
+    /// the patched JSON string, or the original if nothing needed patching /
+    /// the JSON couldn't be parsed.
+    func patched(json: String) -> String {
+        guard let data = json.data(using: .utf8),
+              var root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else { return json }
+
+        var changed = false
+
+        // Disk I/O — only when Mole reports nothing.
+        let io = root["disk_io"] as? [String: Any]
+        let moRead = (io?["read_rate"] as? NSNumber)?.doubleValue ?? 0
+        let moWrite = (io?["write_rate"] as? NSNumber)?.doubleValue ?? 0
+        if moRead == 0, moWrite == 0, let rate = diskRateMBs() {
+            root["disk_io"] = ["read_rate": rate.read, "write_rate": rate.write]
+            changed = true
+        }
+
+        // GPU usage — only when Mole reports it as unavailable (-1).
+        if var gpus = root["gpu"] as? [[String: Any]], !gpus.isEmpty {
+            let moUsage = (gpus[0]["usage"] as? NSNumber)?.doubleValue ?? -1
+            if moUsage < 0, let util = gpuUtilization() {
+                gpus[0]["usage"] = util
+                root["gpu"] = gpus
+                changed = true
+            }
+        }
+
+        guard changed,
+              let out = try? JSONSerialization.data(withJSONObject: root),
+              let str = String(data: out, encoding: .utf8)
+        else { return json }
+        return str
+    }
+}

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -707,7 +707,10 @@ struct ToolCatalog {
         var moArgs = ["uninstall"]
         if permanent { moArgs.append("--permanent") }
         moArgs += apps
-        let res = Self.runMo(moArgs, timeout: 600)
+        // mo uninstall is interactive ("Proceed? [y/N]" + "Enter confirm"); feed
+        // yes so it doesn't block forever on a non-TTY. The Settings opt-in +
+        // confirm:true above are the real gate.
+        let res = Self.runMo(moArgs, stdin: String(repeating: "y\n", count: 16), timeout: 600)
         return Self.actionResult(command: "uninstall", dryRun: false, ran: res.exitCode == 0, res: res,
                                  extra: ["apps": apps, "permanent": permanent])
     }
@@ -735,8 +738,8 @@ struct ToolCatalog {
 
     /// Run `mo` with the given args, never throwing — a missing binary
     /// becomes exit code 127 so callers can degrade gracefully.
-    private static func runMo(_ args: [String], timeout: TimeInterval) -> MoleCLI.Result {
-        (try? MoleCLI.run(args: args, timeout: timeout))
+    private static func runMo(_ args: [String], stdin: String? = nil, timeout: TimeInterval) -> MoleCLI.Result {
+        (try? MoleCLI.run(args: args, stdin: stdin, timeout: timeout))
             ?? MoleCLI.Result(stdout: "", stderr: "mo not found", exitCode: 127)
     }
 

--- a/Sources/MoInteractive.swift
+++ b/Sources/MoInteractive.swift
@@ -89,6 +89,26 @@ enum MoTUI {
     }
 
     static let quit: [UInt8] = [0x71]  // 'q'
+    static let down: [UInt8] = [0x1b, 0x5b, 0x42]  // ESC [ B
+    static let up: [UInt8] = [0x1b, 0x5b, 0x41]    // ESC [ A
+
+    /// Merge a freshly-parsed viewport into the running ordered list, appending
+    /// only rows we haven't seen yet (identity = name+size+location). Mole's
+    /// selection TUI renders a fixed-height scrolling window (≈50 rows max), so
+    /// reaching every item on a long list means scrolling and stitching the
+    /// overlapping frames back into one ordered list. Pure → unit-tested.
+    static func mergeItems(_ acc: [MoTUIItem], _ viewport: [MoTUIItem]) -> [MoTUIItem] {
+        var out = acc
+        var seen = Set(acc.map(identity))
+        for item in viewport where seen.insert(identity(item)).inserted {
+            out.append(item)
+        }
+        return out
+    }
+
+    private static func identity(_ i: MoTUIItem) -> String {
+        "\(i.name)\u{1}\(i.size)\u{1}\(i.location)"
+    }
 
     /// Total item count from a "[current/total]" header. Mole caps how many
     /// rows it renders (≈50), so on a long list the header total exceeds the
@@ -100,11 +120,16 @@ enum MoTUI {
         return Int(inside.split(separator: "/").last.map(String.init) ?? "")
     }
 
-    /// The N from Mole's final confirm screen ("Remove 3 artifacts, 1.2GB" /
-    /// "Remove 1 installer"). Used to verify the count before the second Enter.
+    /// The N from Mole's final confirm screen. Mole's wording varies by tool
+    /// and version: `purge` says "Remove 3 artifacts, 1.2GB", `installer` says
+    /// "Delete 1 installers, 771KB". Matching only "Remove" silently broke the
+    /// installer flow (the count never parsed, so we timed out at the confirm
+    /// screen — "didn't reach its confirm screen in time"). Accept any of the
+    /// verbs Mole uses, taking the integer that immediately follows.
     static func removalCount(_ raw: String) -> Int? {
         let text = stripANSI(raw)
-        guard let r = text.range(of: #"Remove\s+\d+"#, options: .regularExpression) else { return nil }
+        guard let r = text.range(of: #"(?:Remove|Delete|Clean|Trash|Free)\s+(\d+)"#,
+                                 options: .regularExpression) else { return nil }
         return Int(text[r].filter(\.isNumber))
     }
 

--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -113,9 +113,15 @@ enum MoleCLI {
     /// seconds; on timeout the process is terminated and we throw, rather
     /// than returning a partial result, because callers always want
     /// either a complete snapshot or to retry.
+    ///
+    /// `stdin` feeds the child's standard input then closes it (EOF). This
+    /// is how the uninstall flow answers Mole's `Proceed? [y/N]` and
+    /// `Enter confirm` prompts — a GUI app's inherited stdin is closed, so
+    /// without this `mo uninstall <app>` blocks forever on the prompt.
     @discardableResult
     static func run(args: [String],
                     executable: String? = nil,
+                    stdin: String? = nil,
                     timeout: TimeInterval = 10) throws -> Result {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: executable ?? (findExecutable() ?? "/usr/bin/false"))
@@ -126,7 +132,19 @@ enum MoleCLI {
         task.standardOutput = outPipe
         task.standardError = errPipe
 
+        let inPipe: Pipe? = stdin != nil ? Pipe() : nil
+        if let inPipe { task.standardInput = inPipe }
+
         try task.run()
+
+        // Write the canned input and close the write end so the child sees
+        // EOF after consuming it. Ignore write failures: if Mole exits before
+        // reading everything, the pipe write fails with EPIPE, which is fine.
+        if let inPipe, let stdin, let data = stdin.data(using: .utf8) {
+            let h = inPipe.fileHandleForWriting
+            try? h.write(contentsOf: data)
+            try? h.close()
+        }
 
         // Kill the task after `timeout` if it's still running. The
         // termination handler clears the timer so we don't fire stale

--- a/Sources/MoleStatus.swift
+++ b/Sources/MoleStatus.swift
@@ -233,24 +233,55 @@ struct BatteryStatus: Codable {
 struct ThermalStatus: Codable {
     let cpuTemp: Double
     let gpuTemp: Double
+    /// Battery temperature (°C). On Apple Silicon, `cpu_temp`/`gpu_temp` are
+    /// usually 0 (no unprivileged SMC die-temp), but battery temp IS reported
+    /// — so it's the one thermal series that actually has data on these Macs.
+    let batteryTemp: Double?
     let fanSpeed: Int
+    /// Number of fans Mole detected. 0 means Mole couldn't read any fan (common
+    /// on Apple Silicon) — the UI treats 0 as "no fan data" rather than "idle".
+    let fanCount: Int?
     let systemPower: Double
+    let adapterPower: Double?
+    let batteryPower: Double?
 
     private enum CodingKeys: String, CodingKey {
         case cpuTemp = "cpu_temp"
         case gpuTemp = "gpu_temp"
+        case batteryTemp = "battery_temp"
         case fanSpeed = "fan_speed"
+        case fanCount = "fan_count"
         case systemPower = "system_power"
+        case adapterPower = "adapter_power"
+        case batteryPower = "battery_power"
+    }
+
+    /// The best temperature reading available, in °C — CPU first, then GPU,
+    /// then battery. Returns nil only when nothing is reported (all 0/absent).
+    var bestTemp: Double? {
+        if cpuTemp > 0 { return cpuTemp }
+        if gpuTemp > 0 { return gpuTemp }
+        if let b = batteryTemp, b > 0 { return b }
+        return nil
     }
 }
 
 /// Avoid the name `Process` to not collide with `Foundation.Process`.
 struct ProcessInfo: Codable {
     let pid: Int
+    let ppid: Int?
     let name: String
     let command: String
     let cpu: Double
     let memory: Double
+    /// Resident memory in bytes, when Mole reports it. Lets the UI rank by
+    /// absolute RAM (not just percent) and show a human size.
+    let memoryBytes: UInt64?
+
+    private enum CodingKeys: String, CodingKey {
+        case pid, ppid, name, command, cpu, memory
+        case memoryBytes = "memory_bytes"
+    }
 }
 
 struct GPUStatus: Codable {

--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -39,6 +39,15 @@ struct RootView: View {
         .frame(minWidth: 940, minHeight: 640)
         .environment(\.colorScheme, .dark)
         .animation(.easeInOut(duration: 0.22), value: pane)
+        // Sample fast only while a live metrics pane is on screen.
+        .onAppear { sampler.setForeground(Self.isMetricsPane(pane)) }
+        .onChange(of: pane) { _, p in sampler.setForeground(Self.isMetricsPane(p)) }
+        .onDisappear { sampler.setForeground(false) }
+    }
+
+    /// Panes whose charts want live, high-cadence data.
+    static func isMetricsPane(_ p: Pane) -> Bool {
+        p == .tool(.status) || p == .history
     }
 
     // Tools stay alive (preserving in-flight `mo` jobs); the two utility

--- a/Sources/Sampler.swift
+++ b/Sources/Sampler.swift
@@ -31,6 +31,16 @@ final class Sampler {
     private var timer: DispatchSourceTimer?
     private let queue = DispatchQueue(label: "dev.caezium.burrow.sampler", qos: .utility)
     private let dec = JSONDecoder()
+    /// Fills the gaps Mole leaves on Apple Silicon (disk I/O, GPU usage) by
+    /// reading them natively and patching them into the snapshot JSON.
+    private let local = LocalMetrics()
+
+    /// While a live metrics view (Status / History) is on screen we sample
+    /// much faster so network spikes and disk-I/O bursts actually land on the
+    /// chart instead of being missed between the slow background ticks. Off
+    /// screen we fall back to the configured interval to keep the app idle.
+    private var foreground = false
+    private let foregroundInterval: TimeInterval = 5
 
     /// Wall-clock time of the most recent successful sample. Exposed for
     /// the menu-bar status surface so we can show "12s ago" without
@@ -61,14 +71,36 @@ final class Sampler {
         self.timer = nil
     }
 
+    /// Switch between background and live (foreground) cadence. Called by the
+    /// metrics views as they appear/disappear. Turning it on takes a fresh
+    /// sample immediately so the view isn't waiting a whole interval for data.
+    func setForeground(_ on: Bool) {
+        self.queue.async {
+            guard self.foreground != on else { return }
+            self.foreground = on
+            if on { self.tick() }     // immediate fresh sample for the opening view
+            self.scheduleNext()        // re-arm at the new cadence right away
+        }
+    }
+
+    /// The cadence for the next fire. Foreground uses the faster of the live
+    /// interval and the user's configured one (so a user who set 5 s keeps it).
+    private func currentInterval() -> TimeInterval {
+        let slow = TimeInterval(Store.sampleIntervalSeconds)
+        return self.foreground ? min(self.foregroundInterval, slow) : slow
+    }
+
     /// One-shot timer that re-arms after each tick. This is what lets
-    /// the Sampler honor a Settings change at runtime without us
-    /// teaching it to observe UserDefaults — we just re-pull the value
-    /// at the moment we schedule the next fire.
+    /// the Sampler honor a Settings change (or a foreground switch) at runtime
+    /// — we re-pull the interval at the moment we schedule the next fire.
+    /// Cancels any pending timer first so a mid-wait `setForeground` re-arm
+    /// can't leave two timers running.
     private func scheduleNext() {
-        let interval = TimeInterval(Store.sampleIntervalSeconds)
+        self.timer?.cancel()
+        let interval = self.currentInterval()
         let t = DispatchSource.makeTimerSource(queue: self.queue)
-        t.schedule(deadline: .now() + interval, repeating: .never, leeway: .seconds(2))
+        t.schedule(deadline: .now() + interval, repeating: .never,
+                   leeway: .milliseconds(self.foreground ? 250 : 2000))
         t.setEventHandler { [weak self] in
             self?.tick()
             self?.scheduleNext()
@@ -93,7 +125,10 @@ final class Sampler {
             NSLog("Burrow.Sampler: mo status exit=\(result.exitCode) stderr=\(result.stderr.prefix(200))")
             return
         }
-        guard let data = result.stdout.data(using: .utf8) else { return }
+        // Patch in natively-read disk I/O + GPU usage where Mole reports none,
+        // then treat the patched text as the canonical snapshot (decode + store).
+        let json = self.local.patched(json: result.stdout)
+        guard let data = json.data(using: .utf8) else { return }
 
         // Parse first — a malformed snapshot shouldn't pollute the DB.
         let snapshot: MoleStatus
@@ -129,7 +164,7 @@ final class Sampler {
         // captures the sample window, not the JSON-emit time.
         let ts = Int(snapshot.collectedAt.timeIntervalSince1970)
         do {
-            try self.db.insert(prefix: Sampler.snapshotPrefix, ts: ts, json: result.stdout)
+            try self.db.insert(prefix: Sampler.snapshotPrefix, ts: ts, json: json)
         } catch {
             NSLog("Burrow.Sampler: DB insert failed: \(error.localizedDescription)")
             return

--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -338,7 +338,15 @@ final class SoftwareModel: ObservableObject {
         let opId = UUID()
         OperationCenter.shared.begin(opId, label: "Uninstalling \(targets.count) app\(targets.count == 1 ? "" : "s")")
         DispatchQueue.global(qos: .userInitiated).async {
-            let res = try? MoleCLI.run(args: ["uninstall"] + names, timeout: 300)
+            // `mo uninstall <app>` is interactive: it prints the matched apps,
+            // asks "Proceed with uninstallation? [y/N]", then a final "Enter
+            // confirm" screen. A GUI app has no TTY/stdin, so without feeding
+            // answers it blocks until the timeout and nothing happens. Burrow
+            // already gated this behind its own confirm sheet above, so it's
+            // safe to auto-answer yes. The repeated lines cover both prompts
+            // (and any per-app variation); extra input is harmless once mo exits.
+            let answers = String(repeating: "y\n", count: 16)
+            let res = try? MoleCLI.run(args: ["uninstall"] + names, stdin: answers, timeout: 300)
             let parsed = Self.fetch()
             Task { @MainActor in
                 self.apps = parsed

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -100,8 +100,8 @@ struct StatusView: View {
 
     private func cpuTile(_ s: MoleStatus) -> MetricTile {
         let chip: (String, Color)
-        if let t = s.thermal, t.cpuTemp > 0 {
-            chip = (String(format: "%.0f°C", t.cpuTemp), Brand.orange)
+        if let temp = s.thermal?.bestTemp {
+            chip = (String(format: "%.0f°C", temp), Brand.orange)
         } else {
             chip = (String(format: NSLocalizedString("%d cores", comment: ""), s.cpu.coreCount), Brand.textSecondary)
         }

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -19,6 +19,16 @@ import Foundation
 enum Store {
     private static let d = UserDefaults.standard
 
+    /// Persist a value AND flush it to disk immediately. UserDefaults writes
+    /// are normally batched by cfprefsd, so a setting changed seconds before
+    /// the app is replaced/killed by an updater could be lost — which is what
+    /// "my menu-bar / retention setting resets after an update" looks like.
+    /// Flushing on write closes that window for the user-facing toggles.
+    private static func write(_ value: Any?, _ key: String) {
+        d.set(value, forKey: key)
+        d.synchronize()
+    }
+
     // MARK: - Sampler
 
     /// Seconds between `mo status --json` invocations. Clamp to [5, 3600]
@@ -30,7 +40,7 @@ enum Store {
             return raw == 0 ? 60 : max(5, min(raw, 3600))
         }
         set {
-            d.set(max(5, min(newValue, 3600)), forKey: "sample_interval_seconds")
+            write(max(5, min(newValue, 3600)), "sample_interval_seconds")
         }
     }
 
@@ -45,7 +55,7 @@ enum Store {
             return raw == 0 ? 30 : max(1, raw)
         }
         set {
-            d.set(max(1, newValue), forKey: "retention_days")
+            write(max(1, newValue), "retention_days")
         }
     }
 
@@ -55,7 +65,7 @@ enum Store {
     /// snapshot/minute) the freelist reclaim isn't worth the I/O.
     static var autoVacuum: Bool {
         get { d.object(forKey: "auto_vacuum") as? Bool ?? false }
-        set { d.set(newValue, forKey: "auto_vacuum") }
+        set { write(newValue, "auto_vacuum") }
     }
 
     // MARK: - Menu bar
@@ -66,7 +76,7 @@ enum Store {
     /// reopens it) — read once at launch, so a change needs a relaunch.
     static var showMenuBarIcon: Bool {
         get { d.object(forKey: "show_menu_bar_icon") as? Bool ?? true }
-        set { d.set(newValue, forKey: "show_menu_bar_icon") }
+        set { write(newValue, "show_menu_bar_icon") }
     }
 
     // MARK: - AI (Explain lens)
@@ -76,7 +86,7 @@ enum Store {
     /// leaves the Mac.
     static var aiEnabled: Bool {
         get { d.object(forKey: "ai_enabled") as? Bool ?? false }
-        set { d.set(newValue, forKey: "ai_enabled") }
+        set { write(newValue, "ai_enabled") }
     }
 
     /// Which Explain backend to use: "ollama" (local, default) or "openai"
@@ -146,7 +156,7 @@ enum Store {
     /// a localhost listener.
     static var queryServerEnabled: Bool {
         get { d.object(forKey: "query_server_enabled") as? Bool ?? true }
-        set { d.set(newValue, forKey: "query_server_enabled") }
+        set { write(newValue, "query_server_enabled") }
     }
 
     /// Key for the destructive-MCP opt-in. Shared so the MCP process can

--- a/Tests/MoInteractiveTests.swift
+++ b/Tests/MoInteractiveTests.swift
@@ -99,6 +99,33 @@ final class MoInteractiveTests: XCTestCase {
         XCTAssertNil(MoTUI.totalCount(frame), "installer frame has no [n/M] header")
     }
 
+    func testMergeItems_stitchesOverlappingScrolledFrames() {
+        // Two overlapping viewports as the list scrolls down by one row: the
+        // first shows rows 0–2, the second rows 1–3. Merged in order, only the
+        // genuinely-new row 3 is appended.
+        let a = MoTUI.parse(purgeFrame).items
+        let scrolled = """
+        Select Categories to Clean [2/53], 0B, 0 selected
+          \u{25CB} ~/Desktop/the-ripples                    1.20GB | node_modules      | <1d
+          \u{25CB} ~/Desktop/devport                        1.05GB | node_modules      | 2d
+        \u{27A4} \u{25CB} ~/Desktop/newproj                        900MB | .build            | 3d
+        \u{2191}\u{2193} | Space Select | Enter Confirm | A All | I Invert | Q Quit
+        """
+        let b = MoTUI.parse(scrolled).items
+        let merged = MoTUI.mergeItems(a, b)
+        XCTAssertEqual(merged.map { $0.name },
+                       ["~/Desktop/Wisp", "~/Desktop/the-ripples", "~/Desktop/devport", "~/Desktop/newproj"])
+    }
+
+    func testMergeItems_dedupesByFullIdentityNotJustName() {
+        // Same basename, different size/location → two distinct rows, both kept.
+        let one = [MoTUIItem(name: "receipts", size: "10MB", location: "node_modules", selected: false)]
+        let two = [MoTUIItem(name: "receipts", size: "20MB", location: ".venv", selected: false),
+                   MoTUIItem(name: "receipts", size: "10MB", location: "node_modules", selected: false)]
+        let merged = MoTUI.mergeItems(one, two)
+        XCTAssertEqual(merged.count, 2, "the 20MB/.venv 'receipts' is a different row; the duplicate is dropped")
+    }
+
     // Mole's SECOND (final) confirm screen, captured from a real `mo purge`.
     private let confirmScreen = """
     Selected paths:
@@ -110,5 +137,16 @@ final class MoInteractiveTests: XCTestCase {
         XCTAssertEqual(MoTUI.removalCount(confirmScreen), 1)
         XCTAssertEqual(MoTUI.removalCount("➤ Remove 12 artifacts, 4.1GB  Enter confirm, ESC cancel:"), 12)
         XCTAssertNil(MoTUI.removalCount(frame), "the selection list is not a final-confirm screen")
+    }
+
+    // Regression: `mo installer` confirms with "Delete N installers", not
+    // "Remove N". Matching only "Remove" meant the count never parsed and the
+    // installer flow always failed with "didn't reach its confirm screen in time".
+    func testRemovalCount_parsesInstallerDeleteWording() {
+        XCTAssertEqual(MoTUI.removalCount("➤ Delete 1 installers, 771KB  Enter confirm, ESC cancel:"), 1)
+        XCTAssertEqual(MoTUI.removalCount("➤ Delete 23 installers, 4.1GB  Enter confirm, ESC cancel:"), 23)
+        // The installer SELECTION header also contains the word "Remove" ("Select
+        // Installers to Remove …") but no count after it — must stay nil.
+        XCTAssertNil(MoTUI.removalCount("Select Installers to Remove , 1.26GB, 2 selected"))
     }
 }


### PR DESCRIPTION
Fixes the issues from QA: installer never completing, uninstall doing nothing, dead/empty trackers (disk I/O, thermal, GPU), missing battery/fans/GPU charts, network sampling too slow, purge only showing the largest finds, and settings not surviving updates.

## Installer & purge (mo selection-TUI driver)
- **Installer never reached its confirm screen.** mo's confirm now reads `Delete N installers` while `MoTUI.removalCount` only matched `Remove N`, so the count never parsed and it timed out ("didn't reach its confirm screen in time"). Purge says "Remove" — which is why it "sometimes worked." Broadened the verb match. Validated against `mo installer --dry-run`.
- **Purge "Show all".** mo caps its rendered viewport at ~50 rows but the cursor scrolls through the rest. Added a **"Show all N"** button that scroll-captures every row (`MoTUI.mergeItems` stitches overlapping frames), with a scroll-**verify** — the checked rows must match the selection *by identity* — before confirming. Validated end-to-end against `mo purge --dry-run`: captured 54/54, selected across the viewport boundary, verify confirmed exactly the picked rows, mo's confirm showed the matching count.

## Uninstall
- `mo uninstall <app>` is interactive (`Proceed? [y/N]` + an Enter-confirm); a GUI app has no TTY so it blocked until the timeout and nothing happened. Added `stdin:` to `MoleCLI.run` and feed `y` from `SoftwareView` and the MCP path.

## System trackers (Status / History)
- mo reports `disk_io=0`, `gpu usage=-1`, and `cpu/gpu temp=0` on Apple Silicon. New `LocalMetrics.swift` reads disk I/O (`IOBlockStorageDriver`) and GPU usage (`IOAccelerator` "Device Utilization %") natively via IOKit; `Sampler` patches them into the snapshot **only where mo left a hole**. Live-verified: disk I/O ~1.8 MB/s under load, GPU 28%.
- Thermal showed "No samples" — now decodes `battery_temp` (+ `fan_count`/powers) and charts the best available temp.
- Added **Fans, Battery, GPU** charts to History; **Top Processes** can rank by **CPU or RAM** (decodes `memory_bytes`/`ppid`).
- Sample fast (5s) while a live metrics pane is on screen so network spikes / disk bursts land on the chart instead of being missed at 60s.

## Settings persistence
- Flush user-facing toggles on write and on terminate so a setting changed just before an app update isn't lost in cfprefsd's write batch.

## Tests
- `xcodebuild` Debug + Release pass; **90 unit tests pass** (added `removalCount` "Delete" cases and `mergeItems` stitch/identity tests).

## Known limitations (called out, not silently shipped)
- **Fans** read as "not reported" on Apple Silicon — mo's fan detection returns 0 and a native SMC read was too hardware-risky to ship unverified. The chart works where mo reports fans.
- **Per-process network** ranking isn't offered — mo's `top_processes` only carries CPU + memory, so the toggle is CPU/RAM.
- **Settings loss couldn't be reproduced** at the API layer (values do persist; bundle id never changed). The likely real cause is the unsigned/ad-hoc build's code hash changing every release — the durable fix is Developer-ID signing + notarization (CI already supports it). The flush-hardening covers the change-then-update race regardless.