### PR TITLE
packaging: fix deprecated depends_on macos in cask template (#30)

### DIFF
--- a/packaging/burrow.rb
+++ b/packaging/burrow.rb
@@ -16,7 +16,7 @@ cask "burrow" do
   homepage "https://github.com/caezium/Burrow"
 
   depends_on formula: "mole"
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
 
   app "Burrow.app"
 


### PR DESCRIPTION
Resolves #30.

`brew upgrade` warns:
> Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.

Switches `depends_on macos: ">= :sonoma"` → `depends_on macos: :sonoma` (same meaning — Sonoma or later — minus the deprecation).

This updates the repo's cask **template**. The live cask in `caezium/homebrew-tap/Casks/burrow.rb` (what actually emits the warning) has been updated directly so existing users stop seeing it on the next `brew upgrade`.