### PR TITLE
refactor: testable mo integration — SelectionSession reducer, typed client, snapshot store (+2 hang fixes)

### DIFF
--- a/Sources/ActivityView.swift
+++ b/Sources/ActivityView.swift
@@ -128,7 +128,7 @@ final class ActivityModel: ObservableObject {
     func reload() {
         loading = true
         DispatchQueue.global(qos: .userInitiated).async {
-            let parsed = MoleHistory.load()
+            let parsed = MoleClient.history()
             Task { @MainActor in
                 self.sessions = parsed
                 self.loading = false

--- a/Sources/Ansi.swift
+++ b/Sources/Ansi.swift
@@ -1,0 +1,34 @@
+//
+//  Ansi.swift
+//  Burrow
+//
+//  The one ANSI/CSI escape-stripper. Mole's TUI and streamed commands wrap
+//  output in colour and cursor-movement codes; everything that parses or
+//  displays that output cleans it through here. (Previously three near-identical
+//  copies lived in the TUI parser, the stream runner, and the MCP server.)
+//
+
+import Foundation
+
+enum Ansi {
+    /// Remove CSI escape sequences (`ESC [ … <final>`) — colours, cursor moves,
+    /// screen clears — leaving the printable text. Character-scanning rather than
+    /// regex so it's allocation-light on the hot streaming path.
+    static func strip(_ s: String) -> String {
+        guard s.contains("\u{1B}") else { return s }
+        var out = String(); out.reserveCapacity(s.count)
+        var i = s.startIndex
+        while i < s.endIndex {
+            if s[i] == "\u{1B}", s.index(after: i) < s.endIndex, s[s.index(after: i)] == "[" {
+                var j = s.index(i, offsetBy: 2)
+                while j < s.endIndex {
+                    if let a = s[j].asciiValue, a >= 0x40, a <= 0x7E { j = s.index(after: j); break }
+                    j = s.index(after: j)
+                }
+                i = j; continue
+            }
+            out.append(s[i]); i = s.index(after: i)
+        }
+        return out
+    }
+}

--- a/Sources/Explain.swift
+++ b/Sources/Explain.swift
@@ -43,9 +43,8 @@ struct ExplainContext {
 
     /// Build from the most recent snapshot in the DB, or nil if none yet.
     static func build(db: DB) -> ExplainContext? {
-        guard let row = db.findLatest(prefix: Sampler.snapshotPrefix),
-              let data = row.json.data(using: .utf8),
-              let s = try? JSONDecoder().decode(MoleStatus.self, from: data) else { return nil }
+        guard let stored = SnapshotStore.latest(db) else { return nil }
+        let s = stored.status
         let now = Int(Date().timeIntervalSince1970)
         let top = (s.topProcesses ?? []).sorted { $0.cpu > $1.cpu }.prefix(5)
             .map { (name: $0.name, cpu: $0.cpu, mem: $0.memory) }
@@ -57,7 +56,7 @@ struct ExplainContext {
             memPressure: s.memory.pressure,
             diskUsedPercent: s.disks.first?.usedPercent,
             topProcesses: Array(top),
-            ageSeconds: max(0, now - row.ts))
+            ageSeconds: max(0, now - stored.ts))
     }
 
     /// Human-readable fact block for the prompt body.

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -118,21 +118,16 @@ private enum HistoryLoader {
         snap.windowSince = Date(timeIntervalSince1970: TimeInterval(since))
         snap.windowUntil = Date(timeIntervalSince1970: TimeInterval(now))
 
-        let rows = db.findRangeSampled(prefix: Sampler.snapshotPrefix,
-                                       since: since, until: now,
-                                       maxPoints: 720)
-        snap.rowCount = rows.count
+        let snaps = SnapshotStore.range(db, since: since, until: now, maxPoints: 720)
+        snap.rowCount = snaps.count
 
-        let dec = JSONDecoder()
         var peakCPU: [String: Double] = [:]
         var peakMem: [String: Double] = [:]
         var peakMemBytes: [String: UInt64] = [:]
 
-        for row in rows {
-            guard let data = row.json.data(using: .utf8) else { continue }
-            guard let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
-
-            let t = Date(timeIntervalSince1970: TimeInterval(row.ts))
+        for stored in snaps {
+            let s = stored.status
+            let t = Date(timeIntervalSince1970: TimeInterval(stored.ts))
             snap.cpuUsage.append(.init(time: t, value: s.cpu.usage))
             snap.cpuLoad1.append(.init(time: t, value: s.cpu.load1))
             snap.memoryUsed.append(.init(time: t, value: s.memory.usedPercent))
@@ -174,7 +169,7 @@ private enum HistoryLoader {
         snap.topProcesses = rows2.sorted { $0.peakCPU > $1.peakCPU }
 
         snap.generatedAt = Date()
-        if let latest = rows.last { snap.staleSeconds = max(0, now - latest.ts) }
+        if let latest = snaps.last { snap.staleSeconds = max(0, now - latest.ts) }
         return snap
     }
 }

--- a/Sources/InstallerView.swift
+++ b/Sources/InstallerView.swift
@@ -5,19 +5,26 @@
 //  The Installers tool — pick which leftover installers to remove, with
 //  MOLE doing the deletion. Mole's `installer` is an interactive selection
 //  TUI (no flags/JSON for targeted removal), so Burrow runs it in a
-//  pseudo-terminal (MoInteractiveRunner), shows Mole's own list as a native
-//  checklist, and replays the user's choices as keystrokes — then verifies
-//  the on-screen selection before letting Mole confirm. Nothing is removed
-//  by Burrow itself.
+//  pseudo-terminal, shows Mole's own list as a native checklist, and replays
+//  the user's choices as keystrokes — then verifies the on-screen selection
+//  before letting Mole confirm. Nothing is removed by Burrow itself.
+//
+//  The selection logic lives in the pure `SelectionSession` reducer; this
+//  file's runner is the thin host that owns the pseudo-terminal + a tick
+//  timer, pumps PTY bytes and ticks in as events, and applies the reducer's
+//  effects (send keystrokes / quit). The same view drives both installer and
+//  purge.
 //
 
 import SwiftUI
 import AppKit
 
-// MARK: - Runner (drives Mole's selection TUI)
+// MARK: - Runner (host over the SelectionSession reducer)
 
 @MainActor
 final class MoInteractiveRunner: ObservableObject {
+    /// View-facing phase. The reducer carries finer states; they collapse to
+    /// the handful the UI actually renders.
     enum Phase: Equatable { case scanning, choosing, applying, done(Int32), failed(String) }
 
     @Published var phase: Phase = .scanning
@@ -33,18 +40,17 @@ final class MoInteractiveRunner: ObservableObject {
 
     let title: String
     private let subcommand: String
-    private var pty = PTYTask()
-    private var screen = ""        // raw TUI output, pre-confirm
-    private var result = ""        // output after the FINAL Enter (Mole's removal results)
-    private var confirmed = false
-    private var listReady = false
-    private var pressedProceed = false   // first Enter sent → capturing Mole's "Remove N?" screen
-    private var confirmScreen = ""       // output between the first and second Enter
-    private var wantedCount = 0          // how many we intend to remove (verified on the confirm screen)
-    private var viewportCount = 0        // rows in the FIRST frame — Mole's viewport cap (≈50)
+    private var pty: PTYPort
+    private let tickInterval: TimeInterval
+    private var state = SelectionSession.State()
+    private var timer: DispatchSourceTimer?
 
-    init(subcommand: String, title: String) {
-        self.subcommand = subcommand; self.title = title
+    init(subcommand: String, title: String,
+         pty: PTYPort = PTYTask(), tickInterval: TimeInterval = 0.06) {
+        self.subcommand = subcommand
+        self.title = title
+        self.pty = pty
+        self.tickInterval = tickInterval
         // Writing a keystroke to a pty whose child already exited raises SIGPIPE,
         // which would kill the app (try? can't catch a signal). Ignore it
         // process-wide; writes then fail with EPIPE, which we swallow.
@@ -57,248 +63,95 @@ final class MoInteractiveRunner: ObservableObject {
     /// dodge the prompts anyway — Full Disk Access is the real fix, gated by the
     /// view before we get here.
     func start() {
-        guard let mo = MoleCLI.findExecutable() else { phase = .failed("mo not found"); return }
-        // Fresh state for every (re)scan.
-        pty.master?.readabilityHandler = nil
+        stopTimer()
         pty.terminate()
-        pty = PTYTask()
-        screen = ""; result = ""; confirmScreen = ""
-        confirmed = false; listReady = false; pressedProceed = false
-        items = []; resultText = ""; totalCount = 0; wantedCount = 0
-        viewportCount = 0; fullyLoaded = false; loadingAll = false
-        phase = .scanning
-        pty.onExit = { [weak self] in Task { @MainActor in self?.handleExit() } }
+        state = SelectionSession.State()
+        publish()
+        pty.onOutput = { [weak self] s in MainActor.assumeIsolated { self?.dispatch(.output(s)) } }
+        pty.onExit = { [weak self] code in MainActor.assumeIsolated { self?.dispatch(.processExited(code)) } }
+        guard let mo = MoleCLI.findExecutable() else { phase = .failed("mo not found"); return }
         do { try pty.launch(mo, [subcommand]) }
-        catch { phase = .failed("Couldn't start `mo \(subcommand)`."); return }
-        pty.master?.readabilityHandler = { [weak self] h in
-            let d = h.availableData
-            guard !d.isEmpty, let s = String(data: d, encoding: .utf8) else { return }
-            Task { @MainActor in self?.ingest(s) }
-        }
+        catch { phase = .failed("Couldn't start `mo \(subcommand)`.") }
     }
 
-    func rescan() { start() }
-
-    // MARK: - Show all (scroll past Mole's viewport cap)
-
-    /// Pull in every row past Mole's ≈50-row viewport cap. Mole renders only a
-    /// window of the list but the cursor scrolls through ALL of it, so we walk
-    /// to the bottom one row at a time, stitching each overlapping frame into
-    /// one ordered list, then return the cursor to the top so a later selection
-    /// walk still starts at row 0. Append-only, so indices the user already
-    /// selected stay valid. Validated against `mo purge --dry-run`.
-    func loadAll() {
-        guard phase == .choosing, !fullyLoaded, !loadingAll else { return }
-        guard totalCount > items.count else { fullyLoaded = true; return }
-        loadingAll = true
-        scrollCapture(pressesLeft: totalCount + 20)
-    }
-
-    private func scrollCapture(pressesLeft: Int) {
-        guard loadingAll, phase == .choosing else { loadingAll = false; return }
-        let vp = MoTUI.parse(screen).items
-        if !vp.isEmpty { items = MoTUI.mergeItems(items, vp) }
-        if items.count >= totalCount || pressesLeft <= 0 {
-            // Return cursor to the top (over-send; Mole clamps at row 0).
-            for _ in 0..<(items.count + 5) { pty.send(MoTUI.up) }
-            fullyLoaded = true
-            loadingAll = false
-            return
-        }
-        pty.send(MoTUI.down)
-        if screen.count > 80_000 { screen = String(screen.suffix(40_000)) }  // keep parse cheap
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { [weak self] in
-            self?.scrollCapture(pressesLeft: pressesLeft - 1)
-        }
-    }
-
-    /// Apply selection: toggle the wanted rows, then poll the screen until the
-    /// redraw settles and confirm ONLY if the checked rows match the wanted
-    /// items BY NAME (not just by index) and the list didn't shift/scroll —
-    /// otherwise quit without removing anything. Identity matching means a
-    /// scrolled frame that happens to check the same index positions can't
-    /// trick Mole into deleting the wrong files.
-    func confirm(_ wanted: Set<Int>) {
-        guard phase == .choosing, !wanted.isEmpty else { return }
-        phase = .applying
-        wantedCount = wanted.count
-        let wantedNames = Set(wanted.compactMap { items.indices.contains($0) ? items[$0].name : nil })
-        let wantedSigs = Set(wanted.compactMap { items.indices.contains($0) ? Self.sig(items[$0]) : nil })
-        let expectedCount = items.count
-        pty.send(MoTUI.keystrokesToSelect(wanted, count: items.count, confirm: false))
-        if items.count > viewportCount {
-            // Selection spans more rows than Mole renders at once (the user
-            // pulled in everything via "Show all"). Verifying by re-reading a
-            // single frame can't see them all, so we scroll through and confirm
-            // the checked rows match BY IDENTITY before letting Mole proceed.
-            scrollVerifyThenConfirm(wantedSigs: wantedSigs)
-        } else {
-            verifyThenConfirm(wanted: wanted, wantedNames: wantedNames, expectedCount: expectedCount, attempt: 0, last: nil)
-        }
-    }
-
-    /// Row identity for safe comparison — full path/name plus size and location,
-    /// so two projects sharing a basename can't be confused.
-    private static func sig(_ i: MoTUIItem) -> String { "\(i.name)\u{1}\(i.size)\u{1}\(i.location)" }
-
-    /// Verify a selection that spans more than one viewport: scroll from the
-    /// top to the bottom accumulating the CHECKED rows, then proceed only if
-    /// that set exactly equals what the user picked. Any mismatch or timeout →
-    /// quit, remove nothing. Mole's own "Remove N?" count is the final backstop
-    /// in `awaitFinalConfirm`.
-    private func scrollVerifyThenConfirm(wantedSigs: Set<String>) {
-        guard phase == .applying else { return }
-        for _ in 0..<(items.count + 5) { pty.send(MoTUI.up) }   // back to the top
-        screen = ""                                              // read only post-selection frames
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
-            guard let self else { return }
-            self.scrollVerifyStep(wantedSigs: wantedSigs, checked: [], seen: [],
-                                  pressesLeft: self.items.count + 20)
-        }
-    }
-
-    private func scrollVerifyStep(wantedSigs: Set<String>, checked: Set<String>,
-                                  seen: Set<String>, pressesLeft: Int) {
-        guard phase == .applying else { return }
-        var checked = checked, seen = seen
-        for it in MoTUI.parse(screen).items {
-            let s = Self.sig(it)
-            seen.insert(s)
-            if it.selected { checked.insert(s) }
-        }
-        if seen.count >= items.count || pressesLeft <= 0 {
-            if checked == wantedSigs {
-                pressedProceed = true
-                confirmScreen = ""
-                pty.send([0x0d])              // proceed to Mole's final "Remove N?" screen
-                awaitFinalConfirm(attempt: 0)
-            } else {
-                pty.send(MoTUI.quit)
-                phase = .failed("Couldn't verify the full selection safely (\(checked.count)/\(wantedSigs.count) confirmed). Nothing was removed — please try again.")
-            }
-            return
-        }
-        pty.send(MoTUI.down)
-        if screen.count > 80_000 { screen = String(screen.suffix(40_000)) }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) { [weak self] in
-            self?.scrollVerifyStep(wantedSigs: wantedSigs, checked: checked, seen: seen,
-                                   pressesLeft: pressesLeft - 1)
-        }
-    }
-
-    /// Re-read every 0.15s (up to ~2s) until the on-screen selection is stable
-    /// across two reads, then verify by index AND name AND unchanged row count
-    /// before pressing Enter. Any mismatch or timeout → quit, delete nothing.
-    private func verifyThenConfirm(wanted: Set<Int>, wantedNames: Set<String>,
-                                   expectedCount: Int, attempt: Int, last: Set<Int>?) {
-        guard phase == .applying else { return }
-        let screenNow = MoTUI.parse(screen)
-        let onScreen = MoTUI.selectedIndices(screenNow)
-        let maxAttempts = 14   // ~2.1s
-
-        if attempt > 0, onScreen == last {          // settled
-            let onScreenNames = Set(screenNow.items.filter { $0.selected }.map { $0.name })
-            let safe = screenNow.items.count == expectedCount
-                && onScreen == wanted
-                && onScreenNames == wantedNames
-            if safe {
-                // Selection verified. Press Enter to PROCEED to Mole's final
-                // "Remove N? Enter confirm, ESC cancel" screen, then answer it.
-                pressedProceed = true
-                confirmScreen = ""
-                pty.send([0x0d])
-                awaitFinalConfirm(attempt: 0)
-            } else {
-                pty.send(MoTUI.quit)
-                phase = .failed("Couldn't confirm the selection safely (\(onScreen.count)/\(wanted.count) toggled). Nothing was removed — please try again.")
-            }
-            return
-        }
-        guard attempt < maxAttempts else {
-            pty.send(MoTUI.quit)
-            phase = .failed("The selection didn't settle in time. Nothing was removed — please try again.")
-            return
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            self?.verifyThenConfirm(wanted: wanted, wantedNames: wantedNames,
-                                    expectedCount: expectedCount, attempt: attempt + 1, last: onScreen)
-        }
-    }
-
-    /// After the first Enter, Mole shows a SECOND screen — "Selected paths …
-    /// Remove N artifact, X  Enter confirm, ESC cancel". Wait for it, verify
-    /// the count matches what we picked, then send the final Enter to actually
-    /// remove. Wrong count or no screen → ESC + quit, remove nothing. (Without
-    /// this, the first Enter just lands on that prompt and the run hangs.)
-    private func awaitFinalConfirm(attempt: Int) {
-        guard phase == .applying, pressedProceed, !confirmed else { return }
-        let txt = MoTUI.stripANSI(confirmScreen)
-        // Only decide once BOTH the prompt ("Enter confirm, ESC cancel") AND a
-        // parseable "Remove N" have rendered — mo draws the paths first, so a
-        // premature read would see no count and wrongly bail (the old bug).
-        if txt.localizedCaseInsensitiveContains("esc cancel"), let n = MoTUI.removalCount(txt) {
-            if n == wantedCount {
-                confirmed = true
-                pty.send([0x0d])              // second Enter → mo executes the removal
-            } else {
-                pty.send([0x1b])              // ESC → back out
-                pty.send(MoTUI.quit)
-                phase = .failed("mo's confirm showed \(n) item\(n == 1 ? "" : "s"), but you picked \(wantedCount). Nothing was removed — please rescan and try again.")
-            }
-            return
-        }
-        guard attempt < 30 else {            // ~4.5s waiting for mo's confirm screen
-            pty.send([0x1b]); pty.send(MoTUI.quit)
-            phase = .failed("mo didn't reach its confirm screen in time. Nothing was removed — please try again.")
-            return
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            self?.awaitFinalConfirm(attempt: attempt + 1)
-        }
-    }
+    func rescan() { start() }   // tears down the old PTY itself
+    func confirm(_ wanted: Set<Int>) { dispatch(.confirmRequested(wanted)) }
+    func loadAll() { dispatch(.showAllRequested) }
 
     func cancel() {
         // Don't write to the child on teardown — if it already exited, a 'quit'
-        // byte hits a dead pty (SIGPIPE/crash). terminate() tears it down cleanly.
-        pty.master?.readabilityHandler = nil
+        // byte hits a dead pty. terminate() tears it down cleanly.
+        stopTimer()
+        pty.onOutput = nil
+        pty.onExit = nil
         pty.terminate()
-        switch phase { case .done, .failed: break; default: phase = .done(130) }
+        switch state.phase { case .done, .failed: break; default: phase = .done(130) }
     }
 
-    private func ingest(_ s: String) {
-        if confirmed { result += s; return }
-        if pressedProceed { confirmScreen += s; return }   // Mole's "Remove N?" screen
-        screen += s
-        if !listReady, screen.contains("Enter"), screen.contains("Confirm") {
-            let parsed = MoTUI.parse(screen)
-            if !parsed.items.isEmpty {
-                listReady = true
-                items = parsed.items
-                viewportCount = parsed.items.count
-                totalCount = max(MoTUI.totalCount(screen) ?? parsed.items.count, parsed.items.count)
-                phase = .choosing
+    /// Advance the reducer's logical clock. The tick timer calls this; tests
+    /// call it directly to step the machine deterministically.
+    func tick() { dispatch(.tick) }
+
+    // MARK: - Event loop
+
+    private func dispatch(_ event: SelectionSession.Event) {
+        let (next, effects) = SelectionSession.reduce(state, event)
+        state = next
+        for effect in effects {
+            switch effect {
+            case .send(let bytes): pty.send(bytes)
+            case .terminate:       pty.terminate()
             }
         }
+        publish()
+        syncTimer()
     }
 
-    private func handleExit() {
-        pty.master?.readabilityHandler = nil
-        let status = pty.terminationStatus
-        // Never override a failure/cancel we already decided on.
-        if case .failed = phase { return }
-        if case .done = phase { return }
-        if confirmed || pressedProceed {
-            // confirmed → `result` holds the removal log; if Mole exited right
-            // after the first Enter (no second screen), fall back to what we saw.
-            let raw = result.isEmpty ? confirmScreen : result
-            resultText = MoTUI.stripANSI(raw).trimmingCharacters(in: .whitespacesAndNewlines)
-            if resultText.isEmpty { resultText = "Done — mo finished." }
-            phase = .done(status)
-        } else if !listReady {
-            // Exited before a list rendered — usually "nothing to remove".
-            phase = .done(status)
+    private func publish() {
+        phase = Self.viewPhase(state.phase)
+        items = state.items
+        totalCount = state.totalCount
+        resultText = state.resultText
+        fullyLoaded = state.fullyLoaded
+        loadingAll = (state.phase == .loadingAll)
+    }
+
+    private static func viewPhase(_ p: SelectionSession.Phase) -> Phase {
+        switch p {
+        case .scanning:              return .scanning
+        case .choosing, .loadingAll: return .choosing
+        case .applyingViewport, .applyingFull, .awaitingConfirm, .confirming:
+            return .applying
+        case .done(let c):           return .done(c)
+        case .failed(let m):         return .failed(m)
         }
-        // listReady && !confirmed → we're already in .failed; leave it.
+    }
+
+    // MARK: - Tick timer (runs only while a phase needs the logical clock)
+
+    private func syncTimer() {
+        let needsTicks: Bool
+        switch state.phase {
+        case .loadingAll, .applyingViewport, .applyingFull, .awaitingConfirm:
+            needsTicks = true
+        default:
+            needsTicks = false
+        }
+        if needsTicks { startTimer() } else { stopTimer() }
+    }
+
+    private func startTimer() {
+        guard timer == nil else { return }
+        let t = DispatchSource.makeTimerSource(queue: .main)
+        t.schedule(deadline: .now() + tickInterval, repeating: tickInterval)
+        t.setEventHandler { [weak self] in MainActor.assumeIsolated { self?.tick() } }
+        t.resume()
+        timer = t
+    }
+
+    private func stopTimer() {
+        timer?.cancel()
+        timer = nil
     }
 }
 

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -448,16 +448,10 @@ struct ToolCatalog {
         let since = now - minutes * 60
         // 720 sampled rows over the window is the same budget the
         // HistoryView uses — enough to catch any process that peaked.
-        let rows = self.db.findRangeSampled(prefix: Sampler.snapshotPrefix,
-                                            since: since, until: now,
-                                            maxPoints: 720)
         var peakCPU: [String: Double] = [:]
         var peakMem: [String: Double] = [:]
-        let dec = JSONDecoder()
-        for r in rows {
-            guard let data = r.json.data(using: .utf8) else { continue }
-            guard let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
-            for p in (s.topProcesses ?? []) {
+        for stored in SnapshotStore.range(self.db, since: since, until: now, maxPoints: 720) {
+            for p in (stored.status.topProcesses ?? []) {
                 if p.cpu > (peakCPU[p.name] ?? 0)    { peakCPU[p.name] = p.cpu }
                 if p.memory > (peakMem[p.name] ?? 0) { peakMem[p.name] = p.memory }
             }
@@ -492,22 +486,19 @@ struct ToolCatalog {
 
         let now = Int(Date().timeIntervalSince1970)
         let since = now - minutes * 60
-        let rows = self.db.findRangeSampled(prefix: Sampler.snapshotPrefix,
-                                            since: since, until: now, maxPoints: 720)
-        // findRangeSampled down-samples wide windows, so each returned row
-        // stands for MORE than one sample period. Estimate CPU-time against
-        // the effective spacing of the rows we actually got — using the raw
-        // sampler cadence would badly under-count over long windows.
-        let interval: Double = rows.count > 1
-            ? Double(max(1, rows[rows.count - 1].ts - rows[0].ts)) / Double(rows.count - 1)
+        let snaps = SnapshotStore.range(self.db, since: since, until: now, maxPoints: 720)
+        // The store down-samples wide windows, so each returned snapshot stands
+        // for MORE than one sample period. Estimate CPU-time against the effective
+        // spacing of the snapshots we actually got — using the raw sampler cadence
+        // would badly under-count over long windows.
+        let interval: Double = snaps.count > 1
+            ? Double(max(1, snaps[snaps.count - 1].ts - snaps[0].ts)) / Double(snaps.count - 1)
             : Double(Store.sampleIntervalSeconds)
 
         struct Agg { var peakCPU = 0.0; var sumCPU = 0.0; var samples = 0; var peakMem = 0.0 }
         var agg: [String: Agg] = [:]
-        let dec = JSONDecoder()
-        for r in rows {
-            guard let data = r.json.data(using: .utf8),
-                  let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
+        for stored in snaps {
+            let s = stored.status
             for p in (s.topProcesses ?? []) {
                 var a = agg[p.name] ?? Agg()
                 a.peakCPU = max(a.peakCPU, p.cpu)
@@ -536,9 +527,9 @@ struct ToolCatalog {
             let cpuTime = (a.sumCPU / 100.0) * interval
             pieces.append("{\"name\":\"\(escaped)\",\"peak_cpu\":\(a.peakCPU),\"avg_cpu\":\(avg),\"est_cpu_time_seconds\":\(cpuTime),\"peak_mem\":\(a.peakMem),\"samples\":\(a.samples)}")
         }
-        let startTS = rows.first?.ts ?? since
-        let endTS = rows.last?.ts ?? now
-        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(rows.count),\"interval_seconds\":\(Int(interval.rounded())),\"processes\":[\(pieces.joined(separator: ","))]}"
+        let startTS = snaps.first?.ts ?? since
+        let endTS = snaps.last?.ts ?? now
+        return "{\"metric\":\"\(metric)\",\"window_minutes\":\(minutes),\"start_ts\":\(startTS),\"end_ts\":\(endTS),\"sample_count\":\(snaps.count),\"interval_seconds\":\(Int(interval.rounded())),\"processes\":[\(pieces.joined(separator: ","))]}"
     }
 
     private func callInfo() -> String {

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -766,12 +766,8 @@ struct ToolCatalog {
     }
 
     /// Strip ANSI/VT100 escape sequences so mo's TUI coloring doesn't leak
-    /// into the JSON text payload.
-    static func stripANSI(_ s: String) -> String {
-        guard let re = try? NSRegularExpression(pattern: "\\x1B\\[[0-9;?]*[ -/]*[@-~]") else { return s }
-        let range = NSRange(s.startIndex..., in: s)
-        return re.stringByReplacingMatches(in: s, range: range, withTemplate: "")
-    }
+    /// into the JSON text payload. Delegates to the one `Ansi.strip`.
+    static func stripANSI(_ s: String) -> String { Ansi.strip(s) }
 
     private static func jsonString(_ obj: [String: Any]) -> String {
         if let d = try? JSONSerialization.data(withJSONObject: obj, options: [.withoutEscapingSlashes]),

--- a/Sources/MoInteractive.swift
+++ b/Sources/MoInteractive.swift
@@ -184,18 +184,24 @@ enum MoTUI {
 // MARK: - Pseudo-terminal task
 
 /// A child process attached to a pseudo-terminal, so a TUI program (Mole's
-/// selection screen) believes it's interactive. Read/write the screen via
-/// `master`. The only impure seam — kept tiny.
-final class PTYTask {
+/// selection screen) believes it's interactive. The production `PTYPort`: it
+/// owns its read loop and delivers output/exit on the main thread so the host
+/// reducer stays single-threaded. The only impure seam — kept tiny.
+final class PTYTask: PTYPort {
     private let proc = Process()
-    private(set) var master: FileHandle?
+    private var master: FileHandle?
 
-    var isRunning: Bool { proc.isRunning }
-    var terminationStatus: Int32 { proc.terminationStatus }
-    var onExit: (@Sendable () -> Void)?
+    var onOutput: ((String) -> Void)?
+    var onExit: ((Int32) -> Void)?
 
-    func launch(_ executable: String, _ args: [String], env extra: [String: String] = [:],
-                cols: UInt16 = 120, rows: UInt16 = 60) throws {
+    private let cols: UInt16
+    private let rows: UInt16
+    /// `rows` controls how many list rows Mole's TUI renders in one frame (it
+    /// caps the viewport ≈50); 60 covers the common case, with scroll-capture
+    /// handling longer lists.
+    init(cols: UInt16 = 120, rows: UInt16 = 60) { self.cols = cols; self.rows = rows }
+
+    func launch(_ executable: String, _ args: [String]) throws {
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
@@ -211,10 +217,18 @@ final class PTYTask {
         proc.standardError = slave
         var env = Foundation.ProcessInfo.processInfo.environment
         env["TERM"] = "xterm-256color"
-        for (k, v) in extra { env[k] = v }
         proc.environment = env
-        proc.terminationHandler = { [weak self] _ in self?.onExit?() }
-        master = FileHandle(fileDescriptor: amaster, closeOnDealloc: true)
+        proc.terminationHandler = { [weak self] p in
+            let code = p.terminationStatus
+            DispatchQueue.main.async { self?.onExit?(code) }
+        }
+        let m = FileHandle(fileDescriptor: amaster, closeOnDealloc: true)
+        m.readabilityHandler = { [weak self] h in
+            let d = h.availableData
+            guard !d.isEmpty, let s = String(data: d, encoding: .utf8) else { return }
+            DispatchQueue.main.async { self?.onOutput?(s) }
+        }
+        master = m
         // Close the parent's slave fd whether or not the launch succeeds — on a
         // throw the child never starts, so nothing else would ever close it.
         do { try proc.run() }
@@ -223,5 +237,8 @@ final class PTYTask {
     }
 
     func send(_ bytes: [UInt8]) { try? master?.write(contentsOf: Data(bytes)) }
-    func terminate() { if proc.isRunning { proc.terminate() } }
+    func terminate() {
+        master?.readabilityHandler = nil
+        if proc.isRunning { proc.terminate() }
+    }
 }

--- a/Sources/MoInteractive.swift
+++ b/Sources/MoInteractive.swift
@@ -160,25 +160,8 @@ enum MoTUI {
     }
 
     /// Strip CSI escape sequences so the TUI's redraw control codes don't
-    /// pollute parsing. (Mirror of CommandRunner.stripAnsi, kept local so
-    /// this file is self-contained + testable.)
-    static func stripANSI(_ s: String) -> String {
-        guard s.contains("\u{1B}") else { return s }
-        var out = String(); out.reserveCapacity(s.count)
-        var i = s.startIndex
-        while i < s.endIndex {
-            if s[i] == "\u{1B}", s.index(after: i) < s.endIndex, s[s.index(after: i)] == "[" {
-                var j = s.index(i, offsetBy: 2)
-                while j < s.endIndex {
-                    if let a = s[j].asciiValue, a >= 0x40, a <= 0x7E { j = s.index(after: j); break }
-                    j = s.index(after: j)
-                }
-                i = j; continue
-            }
-            out.append(s[i]); i = s.index(after: i)
-        }
-        return out
-    }
+    /// pollute parsing. Delegates to the one `Ansi.strip`.
+    static func stripANSI(_ s: String) -> String { Ansi.strip(s) }
 }
 
 // MARK: - Pseudo-terminal task

--- a/Sources/MoInteractive.swift
+++ b/Sources/MoInteractive.swift
@@ -171,7 +171,7 @@ enum MoTUI {
 /// owns its read loop and delivers output/exit on the main thread so the host
 /// reducer stays single-threaded. The only impure seam — kept tiny.
 final class PTYTask: PTYPort {
-    private let proc = Process()
+    private var proc = Process()   // replaced on each launch (a Process runs once)
     private var master: FileHandle?
 
     var onOutput: ((String) -> Void)?
@@ -185,6 +185,10 @@ final class PTYTask: PTYPort {
     init(cols: UInt16 = 120, rows: UInt16 = 60) { self.cols = cols; self.rows = rows }
 
     func launch(_ executable: String, _ args: [String]) throws {
+        // A Process can only be run ONCE; a rescan calls launch again, so start
+        // from a fresh instance each time. (Reusing the old one left the second
+        // scan with a dead, never-spawning child — the UI hung on "Scanning…".)
+        proc = Process()
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)

--- a/Sources/MoInteractive.swift
+++ b/Sources/MoInteractive.swift
@@ -207,9 +207,25 @@ final class PTYTask: PTYPort {
         }
         let m = FileHandle(fileDescriptor: amaster, closeOnDealloc: true)
         m.readabilityHandler = { [weak self] h in
+            guard let self else { return }
             let d = h.availableData
-            guard !d.isEmpty, let s = String(data: d, encoding: .utf8) else { return }
-            DispatchQueue.main.async { self?.onOutput?(s) }
+            if d.isEmpty {
+                // EOF: the child closed the pty (it exited). Stop reading — left
+                // armed, an empty-data handler spins in a tight loop and starves
+                // the process's terminationHandler, so the exit would never be
+                // reported and the UI would hang (e.g. when Mole finds nothing and
+                // exits before the chooser). If the process is already reaped,
+                // report the exit ourselves; otherwise the now-unstarved
+                // terminationHandler will.
+                h.readabilityHandler = nil
+                if !self.proc.isRunning {
+                    let code = self.proc.terminationStatus
+                    DispatchQueue.main.async { self.onExit?(code) }
+                }
+                return
+            }
+            guard let s = String(data: d, encoding: .utf8) else { return }
+            DispatchQueue.main.async { self.onOutput?(s) }
         }
         master = m
         // Close the parent's slave fd whether or not the launch succeeds — on a

--- a/Sources/MoleClient.swift
+++ b/Sources/MoleClient.swift
@@ -1,0 +1,80 @@
+//
+//  MoleClient.swift
+//  Burrow
+//
+//  The typed `mo` command surface: one place that knows how each subcommand is
+//  invoked and how its output maps to a typed value. Built on the capture
+//  runner (`MoleCLI.run`); the parsing is pure so it's unit-tested against
+//  captured output. Views and the MCP server call this instead of each
+//  re-implementing "spawn mo X → parse".
+//
+//  (Note: the Sampler still keeps Mole's raw `status` JSON — it stores and
+//  patches the text — so it doesn't go through `status()` here.)
+//
+
+import Foundation
+
+enum MoleClient {
+
+    // MARK: - Installed apps (`mo uninstall --list`)
+
+    /// Installed apps + the exact names `mo uninstall` accepts. Sizes can take a
+    /// while on a full /Applications, so callers give it room.
+    static func listApps(timeout: TimeInterval = 180) -> [InstalledApp] {
+        guard let res = try? MoleCLI.run(args: ["uninstall", "--list"], timeout: timeout),
+              res.exitCode == 0 else { return [] }
+        return parseApps(Data(res.stdout.utf8))
+    }
+
+    /// Pure parser for `mo uninstall --list` JSON. Drops rows without the fields
+    /// needed to act on them (name + path).
+    static func parseApps(_ data: Data) -> [InstalledApp] {
+        guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        return arr.compactMap { d in
+            guard let name = d["name"] as? String,
+                  let path = d["path"] as? String else { return nil }
+            let sizeStr = d["size"] as? String ?? "--"
+            return InstalledApp(
+                id: (d["bundle_id"] as? String).map { $0 + "|" + path } ?? path,
+                name: name,
+                bundleId: d["bundle_id"] as? String ?? "",
+                source: d["source"] as? String ?? "App",
+                uninstallName: d["uninstall_name"] as? String ?? name,
+                path: path,
+                sizeStr: sizeStr,
+                sizeBytes: parseSize(sizeStr),
+                lastUsed: nil)   // computed lazily, only when sorting by Recent
+        }
+    }
+
+    /// Parse a human size string ("1.5GB", "250MB", "--") into bytes.
+    static func parseSize(_ s: String) -> Int64 {
+        let t = s.trimmingCharacters(in: .whitespaces).uppercased()
+        if t == "--" || t.isEmpty { return 0 }
+        let units: [(String, Double)] = [("TB", 1_099_511_627_776), ("GB", 1_073_741_824),
+                                         ("MB", 1_048_576), ("KB", 1024), ("B", 1)]
+        for (u, mult) in units where t.hasSuffix(u) {
+            let num = Double(t.dropLast(u.count).trimmingCharacters(in: .whitespaces)) ?? 0
+            return Int64(num * mult)
+        }
+        return Int64(Double(t) ?? 0)
+    }
+
+    // MARK: - Other commands (delegate to the existing tested parsers)
+
+    /// Past cleanup sessions (`mo history --json`).
+    static func history() -> [HistorySession] {
+        MoleHistory.load()
+    }
+
+    /// A fresh system snapshot (`mo status --json`). Decodes to the typed model.
+    /// The periodic Sampler does NOT use this — it keeps the raw JSON to store +
+    /// patch — but one-shot readers can.
+    static func status(timeout: TimeInterval = 8) -> MoleStatus? {
+        guard let res = try? MoleCLI.run(args: ["status", "--json"], timeout: timeout),
+              res.exitCode == 0,
+              let s = try? JSONDecoder().decode(MoleStatus.self, from: Data(res.stdout.utf8))
+        else { return nil }
+        return s
+    }
+}

--- a/Sources/PopupView.swift
+++ b/Sources/PopupView.swift
@@ -462,13 +462,9 @@ final class HUDModel: ObservableObject {
 
     private func refreshHistory() {
         let now = Int(Date().timeIntervalSince1970)
-        let rows = db.findRangeSampled(prefix: Sampler.snapshotPrefix,
-                                       since: now - 30 * 60, until: now, maxPoints: 30)
         var cpu: [Double] = [], mem: [Double] = [], net: [Double] = [], gpu: [Double] = []
-        let dec = JSONDecoder()
-        for r in rows {
-            guard let data = r.json.data(using: .utf8),
-                  let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
+        for stored in SnapshotStore.range(db, since: now - 30 * 60, until: now, maxPoints: 30) {
+            let s = stored.status
             cpu.append(s.cpu.usage)
             mem.append(s.memory.usedPercent)
             net.append(s.network.reduce(0.0) { $0 + $1.rxRateMbs + $1.txRateMbs })

--- a/Sources/SelectionSession.swift
+++ b/Sources/SelectionSession.swift
@@ -1,0 +1,313 @@
+//
+//  SelectionSession.swift
+//  Burrow
+//
+//  The interactive selection flow (`mo installer` / `mo purge`) as a PURE
+//  reducer. `reduce(state, event) -> (state, [effect])` has no I/O, no clock,
+//  and no SwiftUI inside it: the host (an ObservableObject) owns the
+//  pseudo-terminal and a timer, pumps PTY bytes and timer fires in as events,
+//  and interprets the returned effects (send keystrokes / quit). Because the
+//  decision-making is pure and the terminal is injected, the safety-critical
+//  delete path is driven entirely by unit tests with a scripted fake terminal.
+//
+//  The pure parsing/planning vocabulary lives in `MoTUI` (frame parse, item
+//  stitch, keystroke planning, confirm-count). This file is the state machine
+//  that sequences them.
+//
+
+import Foundation
+
+/// The pseudo-terminal seam the selection host drives. Production uses the real
+/// `PTYTask`; tests use a scripted fake that maps received keystrokes to canned
+/// frames. Callbacks are always delivered on the main thread so the host (and
+/// the reducer it drives) stays single-threaded.
+protocol PTYPort: AnyObject {
+    var onOutput: ((String) -> Void)? { get set }
+    var onExit: ((Int32) -> Void)? { get set }
+    func launch(_ executable: String, _ args: [String]) throws
+    func send(_ bytes: [UInt8])
+    func terminate()
+}
+
+enum SelectionSession {
+
+    // MARK: - State
+
+    enum Phase: Equatable {
+        case scanning          // waiting for Mole's list to render
+        case choosing          // list is up; waiting for the user
+        case loadingAll        // scrolling to pull in every row past the viewport cap
+        case applyingViewport  // sent the toggles; settling + verifying in one viewport
+        case applyingFull      // selection spans >1 viewport; scroll-verifying every row
+        case awaitingConfirm   // proceeded; waiting for Mole's "Remove N?" screen
+        case confirming        // sent the final Enter; collecting Mole's removal output
+        case done(Int32)
+        case failed(String)
+    }
+
+    struct State: Equatable {
+        var phase: Phase = .scanning
+        var items: [MoTUIItem] = []
+        var totalCount = 0
+        var viewportCount = 0      // rows in the FIRST frame — Mole's viewport cap
+
+        // Internal terminal buffers, routed by phase.
+        var screen = ""
+        var confirmScreen = ""
+        var result = ""
+        var resultText = ""        // user-facing removal log, set on exit
+        var listReady = false
+
+        // Selection bookkeeping (set when the user confirms).
+        var wanted: Set<Int> = []
+        var wantedSigs: Set<String> = []
+        var wantedNames: Set<String> = []
+        var expectedCount = 0
+        var settleAttempt = 0
+        var lastSelected: Set<Int>? = nil
+
+        // "Show all" scroll-capture bookkeeping.
+        var fullyLoaded = false
+        var loadPressesLeft = 0
+
+        // Scroll-verify bookkeeping (selection spanning >1 viewport).
+        var verifyChecked: Set<String> = []
+        var verifySeen: Set<String> = []
+        var verifyPressesLeft = 0
+    }
+
+    /// Row identity for safe comparison — full name plus size and location, so
+    /// two items sharing a basename can't be confused.
+    static func sig(_ i: MoTUIItem) -> String { "\(i.name)\u{1}\(i.size)\u{1}\(i.location)" }
+
+    enum Event {
+        case output(String)            // raw PTY bytes arrived
+        case processExited(Int32)
+        case showAllRequested
+        case confirmRequested(Set<Int>)
+        case tick                      // a logical clock pulse (settle / timeout)
+    }
+
+    enum Effect: Equatable {
+        case send([UInt8])
+        case terminate
+    }
+
+    // MARK: - Reducer
+
+    static func reduce(_ state: State, _ event: Event) -> (State, [Effect]) {
+        var s = state
+        switch event {
+        case .output(let text):
+            return ingest(&s, text)
+        case .processExited(let code):
+            return exited(&s, code)
+        case .confirmRequested(let wanted):
+            return confirm(&s, wanted)
+        case .showAllRequested:
+            return showAll(&s)
+        case .tick:
+            return tick(&s)
+        }
+    }
+
+    /// Begin scroll-capture of every row past Mole's viewport cap. No-op unless
+    /// the list is up and Mole reported more rows than are visible.
+    private static func showAll(_ s: inout State) -> (State, [Effect]) {
+        guard s.phase == .choosing, !s.fullyLoaded else { return (s, []) }
+        guard s.totalCount > s.items.count else { s.fullyLoaded = true; return (s, []) }
+        s.phase = .loadingAll
+        s.loadPressesLeft = s.totalCount + 20
+        return (s, [])
+    }
+
+    private static func confirm(_ s: inout State, _ wanted: Set<Int>) -> (State, [Effect]) {
+        guard s.phase == .choosing, !wanted.isEmpty else { return (s, []) }
+        s.wanted = wanted
+        s.wantedSigs = Set(wanted.compactMap { s.items.indices.contains($0) ? sig(s.items[$0]) : nil })
+        s.wantedNames = Set(wanted.compactMap { s.items.indices.contains($0) ? s.items[$0].name : nil })
+        s.expectedCount = s.items.count
+        let keys = MoTUI.keystrokesToSelect(wanted, count: s.items.count, confirm: false)
+        if s.items.count > s.viewportCount {
+            // Selection spans more rows than Mole renders at once (the user pulled
+            // in everything via "Show all"). One frame can't show them all, so we
+            // scroll the whole list and confirm the checked rows match by identity.
+            // Return the cursor to the top first; the verify walk reads downward.
+            s.phase = .applyingFull
+            s.verifyChecked = []
+            s.verifySeen = []
+            s.verifyPressesLeft = s.items.count + 20
+            s.screen = ""
+            let ups = Array(repeating: MoTUI.up, count: s.items.count + 5).flatMap { $0 }
+            return (s, [.send(keys), .send(ups)])
+        }
+        s.phase = .applyingViewport
+        s.settleAttempt = 0
+        s.lastSelected = nil
+        return (s, [.send(keys)])
+    }
+
+    // MARK: - Tick (settle / verify / timeout)
+
+    private static func tick(_ s: inout State) -> (State, [Effect]) {
+        switch s.phase {
+        case .loadingAll:       return tickLoadingAll(&s)
+        case .applyingViewport: return tickViewport(&s)
+        case .applyingFull:     return tickFull(&s)
+        case .awaitingConfirm:  return tickAwaitConfirm(&s)
+        default:                return (s, [])
+        }
+    }
+
+    /// Scroll-verify a selection that spans more than one viewport: walk from the
+    /// top accumulating the CHECKED rows across every frame, then proceed only if
+    /// that set exactly equals what the user picked (by identity). Any mismatch or
+    /// timeout → quit, remove nothing. Mole's own "Remove N?" count in
+    /// `tickAwaitConfirm` is the final backstop.
+    private static func tickFull(_ s: inout State) -> (State, [Effect]) {
+        for it in MoTUI.parse(s.screen).items {
+            let sg = sig(it)
+            s.verifySeen.insert(sg)
+            if it.selected { s.verifyChecked.insert(sg) }
+        }
+        if s.verifySeen.count >= s.items.count || s.verifyPressesLeft <= 0 {
+            if s.verifyChecked == s.wantedSigs {
+                s.phase = .awaitingConfirm
+                s.confirmScreen = ""
+                s.settleAttempt = 0
+                return (s, [.send([0x0d])])
+            }
+            s.phase = .failed("Couldn't verify the full selection safely (\(s.verifyChecked.count)/\(s.wantedSigs.count) confirmed). Nothing was removed — please try again.")
+            return (s, [.send(MoTUI.quit)])
+        }
+        s.verifyPressesLeft -= 1
+        if s.screen.count > 80_000 { s.screen = String(s.screen.suffix(40_000)) }
+        return (s, [.send(MoTUI.down)])
+    }
+
+    /// Walk the cursor to the bottom one row per tick, stitching each overlapping
+    /// frame into the ordered list (dedup by identity), until we've captured the
+    /// reported total. Then return the cursor to the top so a later selection
+    /// walk still starts at row 0.
+    private static func tickLoadingAll(_ s: inout State) -> (State, [Effect]) {
+        let vp = MoTUI.parse(s.screen).items
+        if !vp.isEmpty { s.items = MoTUI.mergeItems(s.items, vp) }
+        if s.items.count >= s.totalCount || s.loadPressesLeft <= 0 {
+            let ups = Array(repeating: MoTUI.up, count: s.items.count + 5).flatMap { $0 }
+            s.fullyLoaded = true
+            s.phase = .choosing
+            return (s, [.send(ups)])
+        }
+        s.loadPressesLeft -= 1
+        if s.screen.count > 80_000 { s.screen = String(s.screen.suffix(40_000)) }  // keep parse cheap
+        return (s, [.send(MoTUI.down)])
+    }
+
+    /// After the first Enter, Mole shows a SECOND screen — "Remove/Delete N …,
+    /// Enter confirm, ESC cancel". Confirm ONLY once a parseable count is on a
+    /// screen that also shows the cancel prompt, and ONLY if that count equals
+    /// what the user picked. Wrong count or no screen in time → ESC + quit,
+    /// remove nothing. (The verb varies: `purge` says "Remove", `installer`
+    /// says "Delete" — `removalCount` accepts both.)
+    private static func tickAwaitConfirm(_ s: inout State) -> (State, [Effect]) {
+        let maxAttempts = 75      // ~4.5s for Mole to reach its confirm screen (slow purges)
+        let txt = MoTUI.stripANSI(s.confirmScreen)
+        if txt.localizedCaseInsensitiveContains("esc cancel"), let n = MoTUI.removalCount(txt) {
+            if n == s.wanted.count {
+                s.phase = .confirming
+                return (s, [.send([0x0d])])     // final Enter → Mole executes the removal
+            }
+            s.phase = .failed("mo's confirm showed \(n) item\(n == 1 ? "" : "s"), but you picked \(s.wanted.count). Nothing was removed — please rescan and try again.")
+            return (s, [.send([0x1b]), .send(MoTUI.quit)])
+        }
+        guard s.settleAttempt < maxAttempts else {
+            s.phase = .failed("mo didn't reach its confirm screen in time. Nothing was removed — please try again.")
+            return (s, [.send([0x1b]), .send(MoTUI.quit)])
+        }
+        s.settleAttempt += 1
+        return (s, [])
+    }
+
+    /// Re-read the screen each tick until the on-screen selection is stable
+    /// across two reads, then confirm ONLY if the checked rows match the wanted
+    /// items by index AND name AND unchanged row count — otherwise quit, remove
+    /// nothing. Identity matching means a scrolled/again-redrawn frame that
+    /// happens to check the same positions can't trick Mole into the wrong delete.
+    private static func tickViewport(_ s: inout State) -> (State, [Effect]) {
+        let maxAttempts = 35      // ~2.1s of settle headroom at the host's tick rate
+        let screenNow = MoTUI.parse(s.screen)
+        let onScreen = MoTUI.selectedIndices(screenNow)
+        if s.settleAttempt > 0, onScreen == s.lastSelected {
+            let onScreenNames = Set(screenNow.items.filter { $0.selected }.map { $0.name })
+            let safe = screenNow.items.count == s.expectedCount
+                && onScreen == s.wanted
+                && onScreenNames == s.wantedNames
+            if safe {
+                s.phase = .awaitingConfirm
+                s.confirmScreen = ""
+                s.settleAttempt = 0
+                return (s, [.send([0x0d])])     // Enter → Mole's final "Remove N?" screen
+            }
+            s.phase = .failed("Couldn't confirm the selection safely (\(onScreen.count)/\(s.wanted.count) toggled). Nothing was removed — please try again.")
+            return (s, [.send(MoTUI.quit)])
+        }
+        guard s.settleAttempt < maxAttempts else {
+            s.phase = .failed("The selection didn't settle in time. Nothing was removed — please try again.")
+            return (s, [.send(MoTUI.quit)])
+        }
+        s.lastSelected = onScreen
+        s.settleAttempt += 1
+        return (s, [])
+    }
+
+    private static func exited(_ s: inout State, _ code: Int32) -> (State, [Effect]) {
+        switch s.phase {
+        case .done, .failed:
+            return (s, [])                 // never override a decided terminal state
+        case .scanning where !s.listReady:
+            s.phase = .done(code)          // exited before a list — "nothing to remove"
+            return (s, [])
+        case .confirming, .awaitingConfirm:
+            // Proceeded: `result` holds the removal log; if Mole exited right
+            // after the first Enter (no second screen), fall back to what we saw.
+            let raw = s.result.isEmpty ? s.confirmScreen : s.result
+            s.resultText = MoTUI.stripANSI(raw).trimmingCharacters(in: .whitespacesAndNewlines)
+            if s.resultText.isEmpty { s.resultText = "Done — mo finished." }
+            s.phase = .done(code)
+            return (s, [])
+        default:
+            return (s, [])
+        }
+    }
+
+    // MARK: - Output ingest
+
+    private static func ingest(_ s: inout State, _ text: String) -> (State, [Effect]) {
+        switch s.phase {
+        case .scanning:
+            s.screen += text
+            if !s.listReady, s.screen.contains("Enter"), s.screen.contains("Confirm") {
+                let parsed = MoTUI.parse(s.screen)
+                if !parsed.items.isEmpty {
+                    s.listReady = true
+                    s.items = parsed.items
+                    s.viewportCount = parsed.items.count
+                    s.totalCount = max(MoTUI.totalCount(s.screen) ?? parsed.items.count, parsed.items.count)
+                    s.phase = .choosing
+                }
+            }
+            return (s, [])
+        case .loadingAll, .applyingViewport, .applyingFull:
+            s.screen += text       // accumulate redraws so the tick can re-read the screen
+            return (s, [])
+        case .awaitingConfirm:
+            s.confirmScreen += text   // Mole's "Remove N?" screen, verified before the final Enter
+            return (s, [])
+        case .confirming:
+            s.result += text          // Mole's removal log after the final Enter
+            return (s, [])
+        default:
+            return (s, [])
+        }
+    }
+}

--- a/Sources/SnapshotStore.swift
+++ b/Sources/SnapshotStore.swift
@@ -1,0 +1,41 @@
+//
+//  SnapshotStore.swift
+//  Burrow
+//
+//  Typed read access to the metrics history the Sampler persists. The Sampler
+//  stores each `mo status --json` snapshot (natively patched) as raw text keyed
+//  by timestamp; every chart/tile consumer used to re-implement "load rows in a
+//  range → decode each to MoleStatus → project". That decode-from-storage now
+//  lives here, so consumers ask for typed snapshots and never touch raw JSON or
+//  the database directly.
+//
+
+import Foundation
+
+/// A persisted snapshot: Mole's timestamp plus the decoded status.
+struct StoredSnapshot {
+    let ts: Int
+    let status: MoleStatus
+}
+
+enum SnapshotStore {
+    private static let dec = JSONDecoder()
+
+    /// Decoded snapshots in `[since, until]` (unix seconds), stride-sampled to at
+    /// most `maxPoints`. Rows that fail to decode (schema drift, truncation) are
+    /// skipped rather than failing the whole range.
+    static func range(_ db: DB, since: Int, until: Int, maxPoints: Int) -> [StoredSnapshot] {
+        db.findRangeSampled(prefix: Sampler.snapshotPrefix, since: since, until: until, maxPoints: maxPoints)
+            .compactMap { row in
+                (try? dec.decode(MoleStatus.self, from: Data(row.json.utf8)))
+                    .map { StoredSnapshot(ts: row.ts, status: $0) }
+            }
+    }
+
+    /// The most recent persisted snapshot, decoded.
+    static func latest(_ db: DB) -> StoredSnapshot? {
+        guard let row = db.findLatest(prefix: Sampler.snapshotPrefix),
+              let s = try? dec.decode(MoleStatus.self, from: Data(row.json.utf8)) else { return nil }
+        return StoredSnapshot(ts: row.ts, status: s)
+    }
+}

--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -268,29 +268,9 @@ final class SoftwareModel: ObservableObject {
     }
 
     private static func fetch() -> [InstalledApp] {
-        // `mo uninstall --list` computes a size for every installed app,
-        // which can take a while on a full /Applications — give it room.
-        guard let res = try? MoleCLI.run(args: ["uninstall", "--list"], timeout: 180),
-              res.exitCode == 0,
-              let data = res.stdout.data(using: .utf8),
-              let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-            return []
-        }
-        return arr.compactMap { d in
-            guard let name = d["name"] as? String,
-                  let path = d["path"] as? String else { return nil }
-            let sizeStr = d["size"] as? String ?? "--"
-            return InstalledApp(
-                id: (d["bundle_id"] as? String).map { $0 + "|" + path } ?? path,
-                name: name,
-                bundleId: d["bundle_id"] as? String ?? "",
-                source: d["source"] as? String ?? "App",
-                uninstallName: d["uninstall_name"] as? String ?? name,
-                path: path,
-                sizeStr: sizeStr,
-                sizeBytes: parseSize(sizeStr),
-                lastUsed: nil)   // computed lazily, only when sorting by Recent
-        }
+        // `mo uninstall --list` computes a size for every installed app, which can
+        // take a while on a full /Applications — the client gives it room.
+        MoleClient.listApps()
     }
 
     /// Best-effort "last used" from the filesystem (access date, falling back to
@@ -304,18 +284,6 @@ final class SoftwareModel: ObservableObject {
             return vals.contentAccessDate ?? vals.contentModificationDate
         }
         return nil
-    }
-
-    static func parseSize(_ s: String) -> Int64 {
-        let t = s.trimmingCharacters(in: .whitespaces).uppercased()
-        if t == "--" || t.isEmpty { return 0 }
-        let units: [(String, Double)] = [("TB", 1_099_511_627_776), ("GB", 1_073_741_824),
-                                         ("MB", 1_048_576), ("KB", 1024), ("B", 1)]
-        for (u, mult) in units where t.hasSuffix(u) {
-            let num = Double(t.dropLast(u.count).trimmingCharacters(in: .whitespaces)) ?? 0
-            return Int64(num * mult)
-        }
-        return Int64(Double(t) ?? 0)
     }
 
     /// Confirm, then run `mo uninstall <names>` (Trash-based). User action

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -584,13 +584,9 @@ final class StatusModel: ObservableObject {
     private func refreshHistory() {
         let now = Int(Date().timeIntervalSince1970)
         let since = now - 30 * 60
-        let rows = db.findRangeSampled(prefix: Sampler.snapshotPrefix,
-                                       since: since, until: now, maxPoints: 40)
         var cpu: [Double] = [], mem: [Double] = [], gpu: [Double] = [], net: [Double] = []
-        let dec = JSONDecoder()
-        for r in rows {
-            guard let data = r.json.data(using: .utf8),
-                  let s = try? dec.decode(MoleStatus.self, from: data) else { continue }
+        for stored in SnapshotStore.range(db, since: since, until: now, maxPoints: 40) {
+            let s = stored.status
             cpu.append(s.cpu.usage)
             mem.append(s.memory.usedPercent)
             gpu.append(max(0, s.gpu?.first?.usage ?? 0))

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -373,24 +373,7 @@ final class CommandRunner: ObservableObject {
         applyPending()
     }
 
-    nonisolated static func stripAnsi(_ s: String) -> String {
-        guard s.contains("\u{1B}") else { return s }
-        var out = String()
-        var i = s.startIndex
-        while i < s.endIndex {
-            let c = s[i]
-            if c == "\u{1B}", s.index(after: i) < s.endIndex, s[s.index(after: i)] == "[" {
-                var j = s.index(i, offsetBy: 2)
-                while j < s.endIndex {
-                    if let a = s[j].asciiValue, a >= 0x40, a <= 0x7E { j = s.index(after: j); break }
-                    j = s.index(after: j)
-                }
-                i = j; continue
-            }
-            out.append(c); i = s.index(after: i)
-        }
-        return out
-    }
+    nonisolated static func stripAnsi(_ s: String) -> String { Ansi.strip(s) }
 }
 
 // MARK: - Report view

--- a/Sources/UpdatesView.swift
+++ b/Sources/UpdatesView.swift
@@ -122,7 +122,7 @@ final class UpdatesModel: ObservableObject {
         loading = true; error = nil
         DispatchQueue.global(qos: .userInitiated).async {
             let r = Self.runBrew(brew, ["outdated", "--json=v2"])
-            let parsed = Self.parse(r.out)
+            let parsed = Self.parseOutdated(r.out)
             Task { @MainActor in
                 if r.code != 0 && parsed.isEmpty && !r.err.isEmpty {
                     self.error = String(r.err.prefix(160))
@@ -187,7 +187,9 @@ final class UpdatesModel: ObservableObject {
                           code: t.terminationStatus)
     }
 
-    private static func parse(_ json: String) -> [OutdatedItem] {
+    /// Pure parser for `brew outdated --json=v2` — unit-tested against captured
+    /// brew output, like the other `mo`/CLI parsers.
+    nonisolated static func parseOutdated(_ json: String) -> [OutdatedItem] {
         guard let data = json.data(using: .utf8),
               let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return [] }
         var out: [OutdatedItem] = []

--- a/Tests/AnsiTests.swift
+++ b/Tests/AnsiTests.swift
@@ -1,0 +1,27 @@
+//
+//  AnsiTests.swift
+//  BurrowTests
+//
+
+import XCTest
+@testable import Burrow
+
+final class AnsiTests: XCTestCase {
+    func testStrip_removesColourCodes_keepsText() {
+        XCTAssertEqual(Ansi.strip("\u{1B}[0;32mhello\u{1B}[0m"), "hello")
+    }
+
+    func testStrip_removesCursorAndClearSequences() {
+        XCTAssertEqual(Ansi.strip("a\u{1B}[2Jb\u{1B}[1;1Hc"), "abc")
+    }
+
+    func testStrip_leavesPlainTextUntouched() {
+        XCTAssertEqual(Ansi.strip("just plain text"), "just plain text")
+        XCTAssertEqual(Ansi.strip(""), "")
+    }
+
+    func testStrip_handlesTrailingLoneEscape() {
+        // A bare ESC with no following '[' is kept (incomplete sequence).
+        XCTAssertEqual(Ansi.strip("x\u{1B}"), "x\u{1B}")
+    }
+}

--- a/Tests/MoInteractiveHostTests.swift
+++ b/Tests/MoInteractiveHostTests.swift
@@ -1,0 +1,82 @@
+//
+//  MoInteractiveHostTests.swift
+//  BurrowTests
+//
+//  Integration test for the host that wires the SelectionSession reducer to a
+//  pseudo-terminal. Uses a scripted FakePTY (records keystrokes, replays canned
+//  frames) and a manual tick so the whole flow runs deterministically with no
+//  real subprocess and no wall-clock. (Requires `mo` on PATH for `start()` to
+//  launch the fake — the portable safety net is SelectionSessionTests.)
+//
+
+import XCTest
+@testable import Burrow
+
+/// Records what the host writes and lets the test feed canned frames/exit.
+final class FakePTY: PTYPort {
+    var onOutput: ((String) -> Void)?
+    var onExit: ((Int32) -> Void)?
+    private(set) var sent: [UInt8] = []
+    private(set) var launched = false
+
+    func launch(_ executable: String, _ args: [String]) throws { launched = true }
+    func send(_ bytes: [UInt8]) { sent.append(contentsOf: bytes) }
+    func terminate() {}
+
+    func emit(_ s: String) { onOutput?(s) }
+    func exitProcess(_ code: Int32) { onExit?(code) }
+}
+
+@MainActor
+final class MoInteractiveHostTests: XCTestCase {
+    private let scanFrame = """
+    Select Installers to Remove , 0B, 0 selected
+    \u{27A4} \u{25CB} a.dmg   771KB | Desktop
+      \u{25CB} b.dmg   760KB | Desktop
+      \u{25CB} c.dmg   1.26GB | Desktop
+    \u{2191}\u{2193}  |  Space Select  |  Enter Confirm  |  A All  |  I Invert  |  Q Quit
+    """
+    private let selectedFrame = """
+    Select Installers to Remove , 760KB, 1 selected
+      \u{25CB} a.dmg   771KB | Desktop
+    \u{27A4} \u{25CF} b.dmg   760KB | Desktop
+      \u{25CB} c.dmg   1.26GB | Desktop
+    \u{2191}\u{2193}  |  Space Select  |  Enter Confirm  |  A All  |  I Invert  |  Q Quit
+    """
+
+    func testHost_scanSelectConfirm_drivesKeystrokesAndFinishes() throws {
+        try XCTSkipUnless(MoleCLI.findExecutable() != nil, "needs `mo` on PATH to launch the pty")
+
+        let fake = FakePTY()
+        // Large tick interval so the real timer never fires; we step manually.
+        let runner = MoInteractiveRunner(subcommand: "installer", title: "Installers",
+                                         pty: fake, tickInterval: 999)
+        runner.start()
+        XCTAssertTrue(fake.launched)
+
+        // Mole renders the list → host reaches `choosing`.
+        fake.emit(scanFrame)
+        XCTAssertEqual(runner.phase, .choosing)
+        XCTAssertEqual(runner.items.map(\.name), ["a.dmg", "b.dmg", "c.dmg"])
+
+        // User removes b → host sends the toggle keystrokes and enters `applying`.
+        runner.confirm([1])
+        XCTAssertEqual(runner.phase, .applying)
+        XCTAssertFalse(fake.sent.isEmpty, "selection keystrokes were written to the pty")
+
+        // Mole redraws with b checked; two ticks settle + verify → proceed (Enter).
+        fake.emit(selectedFrame)
+        runner.tick(); runner.tick()
+
+        // Mole's confirm screen; the next tick confirms because the count matches.
+        fake.emit("➤ Delete 1 installers, 760KB  Enter confirm, ESC cancel: ")
+        runner.tick()
+        XCTAssertTrue(fake.sent.contains(0x0d), "the confirming Enter reached the pty")
+
+        // Mole prints its result and exits → host finishes.
+        fake.emit("\nRemoved 1 installer, freed 760KB\n")
+        fake.exitProcess(0)
+        XCTAssertEqual(runner.phase, .done(0))
+        XCTAssertTrue(runner.resultText.contains("Removed 1 installer"))
+    }
+}

--- a/Tests/MoInteractiveHostTests.swift
+++ b/Tests/MoInteractiveHostTests.swift
@@ -57,6 +57,24 @@ final class MoInteractiveHostTests: XCTestCase {
         wait(for: [exited], timeout: 5)
     }
 
+    /// Regression: a rescan calls launch() again on the same PTYTask. A Process
+    /// can only run once, so the second launch must spin up a FRESH child and
+    /// report its exit too — reusing the old one left the rescan with a dead
+    /// child and the UI hung on "Scanning…".
+    func testPTYTask_relaunchAfterChildExits_stillReportsExit() {
+        let pty = PTYTask()
+        pty.onOutput = { _ in }
+        let first = expectation(description: "first exit")
+        pty.onExit = { _ in first.fulfill() }
+        try? pty.launch("/bin/echo", ["one"])
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second exit")
+        pty.onExit = { _ in second.fulfill() }
+        try? pty.launch("/bin/echo", ["two"])
+        wait(for: [second], timeout: 5)
+    }
+
     func testHost_scanSelectConfirm_drivesKeystrokesAndFinishes() throws {
         try XCTSkipUnless(MoleCLI.findExecutable() != nil, "needs `mo` on PATH to launch the pty")
 

--- a/Tests/MoInteractiveHostTests.swift
+++ b/Tests/MoInteractiveHostTests.swift
@@ -44,6 +44,19 @@ final class MoInteractiveHostTests: XCTestCase {
     \u{2191}\u{2193}  |  Space Select  |  Enter Confirm  |  A All  |  I Invert  |  Q Quit
     """
 
+    /// Regression: a child that prints then exits must deliver `onExit`. A pty
+    /// at EOF fires the readability handler with empty data forever; if we don't
+    /// disarm it, that spin starves the process terminationHandler and the exit
+    /// is never reported — the UI hangs on "Scanning…" when Mole finds nothing.
+    func testPTYTask_reportsExitWhenChildExitsImmediately() {
+        let pty = PTYTask()
+        let exited = expectation(description: "onExit fires")
+        pty.onOutput = { _ in }
+        pty.onExit = { _ in exited.fulfill() }
+        try? pty.launch("/bin/echo", ["hi"])   // prints, then exits → pty EOF
+        wait(for: [exited], timeout: 5)
+    }
+
     func testHost_scanSelectConfirm_drivesKeystrokesAndFinishes() throws {
         try XCTSkipUnless(MoleCLI.findExecutable() != nil, "needs `mo` on PATH to launch the pty")
 

--- a/Tests/MoInteractiveRealTests.swift
+++ b/Tests/MoInteractiveRealTests.swift
@@ -1,0 +1,39 @@
+//
+//  MoInteractiveRealTests.swift
+//  BurrowTests
+//
+//  One real end-to-end check of the refactored selection host against the
+//  actual `mo` CLI over a real pseudo-terminal: scan `mo installer` and confirm
+//  it resolves (to the chooser, or "nothing found") without hanging. It NEVER
+//  confirms a removal, so nothing is deleted. Skipped when `mo` isn't on PATH;
+//  the deterministic coverage is SelectionSessionTests + the FakePTY host test.
+//
+
+import XCTest
+import Combine
+@testable import Burrow
+
+@MainActor
+final class MoInteractiveRealTests: XCTestCase {
+    private var bag = Set<AnyCancellable>()
+
+    func testRealInstallerScan_resolvesWithoutHanging() throws {
+        try XCTSkipUnless(MoleCLI.findExecutable() != nil, "needs `mo` on PATH")
+
+        let runner = MoInteractiveRunner(subcommand: "installer", title: "Installers")
+        let resolved = expectation(description: "scan reaches choosing or done")
+        resolved.assertForOverFulfill = false   // @Published re-emits the same phase on each redraw
+        runner.$phase
+            .sink { phase in
+                switch phase {
+                case .choosing, .done, .failed: resolved.fulfill()
+                case .scanning, .applying: break
+                }
+            }
+            .store(in: &bag)
+
+        runner.start()
+        wait(for: [resolved], timeout: 20)
+        runner.cancel()   // back out before any confirm — nothing is removed
+    }
+}

--- a/Tests/MoleCLITests.swift
+++ b/Tests/MoleCLITests.swift
@@ -26,4 +26,36 @@ final class MoleCLITests: XCTestCase {
         // A bare integer isn't a version; needs at least major.minor.
         XCTAssertNil(MoleCLI.parseVersion("built for macOS 14"))
     }
+
+    // MARK: - Capture runner (MoleCLI.run)
+    //
+    // The subprocess boundary is exercised with real tiny system binaries
+    // (echo / cat / false / sleep) rather than a mock — the local-substitutable
+    // way to test a process runner: actual plumbing, deterministic, fast.
+
+    func testRun_capturesStdoutAndExitZero() throws {
+        let r = try MoleCLI.run(args: ["hello world"], executable: "/bin/echo")
+        XCTAssertEqual(r.exitCode, 0)
+        XCTAssertEqual(r.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "hello world")
+    }
+
+    func testRun_feedsStdinToChild() throws {
+        // `cat` echoes whatever it reads on stdin — proves the stdin feed lands.
+        let r = try MoleCLI.run(args: [], executable: "/bin/cat", stdin: "piped input\n")
+        XCTAssertEqual(r.exitCode, 0)
+        XCTAssertTrue(r.stdout.contains("piped input"))
+    }
+
+    func testRun_reportsNonZeroExit() throws {
+        let r = try MoleCLI.run(args: [], executable: "/usr/bin/false")
+        XCTAssertNotEqual(r.exitCode, 0)
+    }
+
+    func testRun_timesOutInsteadOfHanging() throws {
+        let start = Date()
+        let r = try MoleCLI.run(args: ["5"], executable: "/bin/sleep", timeout: 0.4)
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 3.0, "the 5s sleep must be killed by the 0.4s timeout")
+        XCTAssertNotEqual(r.exitCode, 0, "a terminated process is non-zero")
+    }
 }

--- a/Tests/MoleClientTests.swift
+++ b/Tests/MoleClientTests.swift
@@ -1,0 +1,46 @@
+//
+//  MoleClientTests.swift
+//  BurrowTests
+//
+//  The typed `mo` client turns each subcommand's output into typed values in
+//  one place. The parsing is pure, so it's tested against captured output.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoleClientTests: XCTestCase {
+    func testParseApps_decodesUninstallListJSON() {
+        let json = """
+        [{"name":"Slack","bundle_id":"com.tinyspeck.slackmacgap","source":"App","uninstall_name":"slack","path":"/Applications/Slack.app","size":"250MB"},
+         {"name":"Zoom","path":"/Applications/zoom.us.app","size":"180MB"}]
+        """.data(using: .utf8)!
+        let apps = MoleClient.parseApps(json)
+        XCTAssertEqual(apps.count, 2)
+        XCTAssertEqual(apps[0].name, "Slack")
+        XCTAssertEqual(apps[0].uninstallName, "slack")
+        XCTAssertEqual(apps[0].bundleId, "com.tinyspeck.slackmacgap")
+        XCTAssertEqual(apps[0].sizeBytes, Int64(250 * 1_048_576))
+        // Missing optional fields fall back.
+        XCTAssertEqual(apps[1].source, "App")
+        XCTAssertEqual(apps[1].uninstallName, "Zoom")   // falls back to the display name
+    }
+
+    func testParseApps_skipsRowsMissingRequiredFields() {
+        // A row with no path can't be uninstalled — dropped.
+        let json = #"[{"name":"NoPath"},{"name":"Good","path":"/Applications/Good.app"}]"#.data(using: .utf8)!
+        XCTAssertEqual(MoleClient.parseApps(json).map(\.name), ["Good"])
+    }
+
+    func testParseApps_emptyOrMalformed_returnsEmpty() {
+        XCTAssertTrue(MoleClient.parseApps(Data()).isEmpty)
+        XCTAssertTrue(MoleClient.parseApps("not json".data(using: .utf8)!).isEmpty)
+    }
+
+    func testParseSize_handlesUnitsAndPlaceholders() {
+        XCTAssertEqual(MoleClient.parseSize("1.5GB"), Int64(1.5 * 1_073_741_824))
+        XCTAssertEqual(MoleClient.parseSize("250MB"), Int64(250 * 1_048_576))
+        XCTAssertEqual(MoleClient.parseSize("--"), 0)
+        XCTAssertEqual(MoleClient.parseSize(""), 0)
+    }
+}

--- a/Tests/SelectionSessionTests.swift
+++ b/Tests/SelectionSessionTests.swift
@@ -1,0 +1,237 @@
+//
+//  SelectionSessionTests.swift
+//  BurrowTests
+//
+//  Boundary tests for the interactive selection driver, modeled as a pure
+//  reducer: feed it events (a terminal frame arrived, a logical tick, the user
+//  pressed Remove) and assert the state it reaches and the effects (keystrokes /
+//  quit) it emits. No pseudo-terminal, no wall-clock — the scenarios that were
+//  previously only validatable by driving real `mo --dry-run` out of process
+//  now run in-suite.
+//
+
+import XCTest
+@testable import Burrow
+
+final class SelectionSessionTests: XCTestCase {
+
+    // A real `mo installer` scan frame: header + three unchecked rows + footer.
+    private let scanFrame = """
+    Select Installers to Remove , 0B, 0 selected
+    \u{27A4} \u{25CB} a.dmg   771KB | Desktop
+      \u{25CB} b.dmg   760KB | Desktop
+      \u{25CB} c.dmg   1.26GB | Desktop
+    \u{2191}\u{2193}  |  Space Select  |  Enter Confirm  |  A All  |  I Invert  |  Q Quit
+    """
+
+    // MARK: - Phase 1: scan path
+
+    func testScan_reachesChoosingWithParsedItems() {
+        let (s, _) = SelectionSession.reduce(SelectionSession.State(), .output(scanFrame))
+        XCTAssertEqual(s.phase, .choosing)
+        XCTAssertEqual(s.items.map(\.name), ["a.dmg", "b.dmg", "c.dmg"])
+        XCTAssertEqual(s.totalCount, 3)
+    }
+
+    func testScan_processExitsBeforeAnyList_isDone() {
+        // Mole exits before rendering a list — usually "nothing to remove".
+        let (s, effects) = SelectionSession.reduce(SelectionSession.State(), .processExited(0))
+        XCTAssertEqual(s.phase, .done(0))
+        XCTAssertTrue(effects.isEmpty)
+    }
+
+    // MARK: - Phase 2: confirm path
+
+    /// Drive a fresh session to `choosing` over the scan frame.
+    private func choosing() -> SelectionSession.State {
+        SelectionSession.reduce(SelectionSession.State(), .output(scanFrame)).0
+    }
+
+    func testConfirm_emitsSelectionKeystrokesAndEntersApplying() {
+        let (s, effects) = SelectionSession.reduce(choosing(), .confirmRequested([1]))
+        XCTAssertEqual(s.phase, .applyingViewport)
+        XCTAssertEqual(effects, [.send(MoTUI.keystrokesToSelect([1], count: 3, confirm: false))])
+    }
+
+    func testConfirm_emptySelection_doesNothing() {
+        let (s, effects) = SelectionSession.reduce(choosing(), .confirmRequested([]))
+        XCTAssertEqual(s.phase, .choosing)
+        XCTAssertTrue(effects.isEmpty)
+    }
+
+    // b.dmg (index 1) now checked (●), cursor on it.
+    private let selectedFrame = """
+    Select Installers to Remove , 760KB, 1 selected
+      \u{25CB} a.dmg   771KB | Desktop
+    \u{27A4} \u{25CF} b.dmg   760KB | Desktop
+      \u{25CB} c.dmg   1.26GB | Desktop
+    \u{2191}\u{2193}  |  Space Select  |  Enter Confirm  |  A All  |  I Invert  |  Q Quit
+    """
+
+    func testApplyingViewport_settledAndSafe_proceedsToConfirm() {
+        var s = SelectionSession.reduce(choosing(), .confirmRequested([1])).0
+        s = SelectionSession.reduce(s, .output(selectedFrame)).0   // Mole redrew with b checked
+        s = SelectionSession.reduce(s, .tick).0                    // 1st read: records selection
+        XCTAssertEqual(s.phase, .applyingViewport, "not settled after one read")
+        let (s2, effects) = SelectionSession.reduce(s, .tick)      // 2nd read: stable + safe
+        XCTAssertEqual(s2.phase, .awaitingConfirm)
+        XCTAssertEqual(effects, [.send([0x0d])])                   // Enter → proceed
+    }
+
+    /// Drive a 1-item selection all the way to `awaitingConfirm`.
+    private func awaitingConfirm() -> SelectionSession.State {
+        var s = SelectionSession.reduce(choosing(), .confirmRequested([1])).0
+        s = SelectionSession.reduce(s, .output(selectedFrame)).0
+        s = SelectionSession.reduce(s, .tick).0
+        s = SelectionSession.reduce(s, .tick).0
+        precondition(s.phase == .awaitingConfirm)
+        return s
+    }
+
+    func testAwaitingConfirm_countMatchesDeleteWording_sendsFinalConfirm() {
+        // Regression guard: installer says "Delete N installers", not "Remove N".
+        var s = awaitingConfirm()
+        s = SelectionSession.reduce(s, .output("➤ Delete 1 installers, 760KB  Enter confirm, ESC cancel: ")).0
+        let (s2, effects) = SelectionSession.reduce(s, .tick)
+        XCTAssertEqual(s2.phase, .confirming)
+        XCTAssertEqual(effects, [.send([0x0d])])     // final Enter → Mole deletes
+    }
+
+    func testAwaitingConfirm_countMismatch_abortsWithoutDeleting() {
+        var s = awaitingConfirm()                    // user picked 1
+        s = SelectionSession.reduce(s, .output("➤ Remove 3 artifacts, 4GB  Enter confirm, ESC cancel: ")).0
+        let (s2, effects) = SelectionSession.reduce(s, .tick)
+        if case .failed = s2.phase {} else { XCTFail("must abort on count mismatch") }
+        XCTAssertEqual(effects, [.send([0x1b]), .send(MoTUI.quit)])  // ESC + quit, never Enter
+        XCTAssertFalse(effects.contains(.send([0x0d])), "must not send the confirming Enter")
+    }
+
+    func testAwaitingConfirm_neverReachesConfirmScreen_timesOut() {
+        var s = awaitingConfirm()
+        // No confirm screen ever arrives; ticks should eventually give up safely.
+        for _ in 0..<80 { s = SelectionSession.reduce(s, .tick).0 }
+        if case .failed = s.phase {} else { XCTFail("must time out into failed, not hang") }
+    }
+
+    private func confirming() -> SelectionSession.State {
+        var s = awaitingConfirm()
+        s = SelectionSession.reduce(s, .output("➤ Delete 1 installers, 760KB  Enter confirm, ESC cancel: ")).0
+        s = SelectionSession.reduce(s, .tick).0
+        precondition(s.phase == .confirming)
+        return s
+    }
+
+    func testConfirming_collectsResultAndFinishesOnExit() {
+        var s = confirming()
+        s = SelectionSession.reduce(s, .output("\nRemoved 1 installer, freed 760KB\n")).0
+        let (s2, _) = SelectionSession.reduce(s, .processExited(0))
+        XCTAssertEqual(s2.phase, .done(0))
+        XCTAssertTrue(s2.resultText.contains("Removed 1 installer"))
+    }
+
+    // MARK: - Phase 3: scroll-capture ("Show all")
+
+    // A purge-style scan: header "[1/4]" reports 4 total, viewport shows 3.
+    private let scan4 = """
+    Select Categories to Clean [1/4], 0B, 0 selected
+    \u{27A4} \u{25CB} ~/p/a   3GB | node_modules | 1d
+      \u{25CB} ~/p/b   2GB | node_modules | 1d
+      \u{25CB} ~/p/c   1GB | node_modules | 1d
+    \u{2191}\u{2193} | Space Select | Enter Confirm | A All | I Invert | Q Quit
+    """
+    // After one Down, Mole scrolls: rows b,c,d (d newly revealed).
+    private let scrolled4 = """
+    Select Categories to Clean [2/4], 0B, 0 selected
+      \u{25CB} ~/p/b   2GB | node_modules | 1d
+      \u{25CB} ~/p/c   1GB | node_modules | 1d
+    \u{27A4} \u{25CB} ~/p/d   0.5GB | node_modules | 1d
+    \u{2191}\u{2193} | Space Select | Enter Confirm | A All | I Invert | Q Quit
+    """
+
+    // Verify-scroll frames: a (●) on top, then d (●) after scrolling.
+    private let topChecked = """
+    Select Categories to Clean [1/4], 3GB, 1 selected
+    \u{27A4} \u{25CF} ~/p/a   3GB | node_modules | 1d
+      \u{25CB} ~/p/b   2GB | node_modules | 1d
+      \u{25CB} ~/p/c   1GB | node_modules | 1d
+    \u{2191}\u{2193} | Space Select | Enter Confirm | A All | I Invert | Q Quit
+    """
+    private let scrolledChecked = """
+    Select Categories to Clean [2/4], 3.5GB, 2 selected
+      \u{25CB} ~/p/b   2GB | node_modules | 1d
+      \u{25CB} ~/p/c   1GB | node_modules | 1d
+    \u{27A4} \u{25CF} ~/p/d   0.5GB | node_modules | 1d
+    \u{2191}\u{2193} | Space Select | Enter Confirm | A All | I Invert | Q Quit
+    """
+    // Wrong: c is checked instead of d.
+    private let scrolledWrong = """
+    Select Categories to Clean [2/4], 4GB, 2 selected
+      \u{25CB} ~/p/b   2GB | node_modules | 1d
+    \u{27A4} \u{25CF} ~/p/c   1GB | node_modules | 1d
+      \u{25CB} ~/p/d   0.5GB | node_modules | 1d
+    \u{2191}\u{2193} | Space Select | Enter Confirm | A All | I Invert | Q Quit
+    """
+
+    private func loadedAll4() -> SelectionSession.State {
+        var s = SelectionSession.reduce(SelectionSession.State(), .output(scan4)).0
+        s = SelectionSession.reduce(s, .showAllRequested).0
+        s = SelectionSession.reduce(s, .tick).0
+        s = SelectionSession.reduce(s, .output(scrolled4)).0
+        s = SelectionSession.reduce(s, .tick).0
+        precondition(s.items.count == 4 && s.viewportCount == 3 && s.fullyLoaded)
+        return s
+    }
+
+    func testFullSelection_verifies_proceedsWhenCheckedMatches() {
+        var s = loadedAll4()
+        let (s0, e0) = SelectionSession.reduce(s, .confirmRequested([0, 3]))  // a + d, spans boundary
+        XCTAssertEqual(s0.phase, .applyingFull)
+        XCTAssertEqual(e0.count, 2, "selection walk + return-to-top")
+        s = s0
+        s = SelectionSession.reduce(s, .output(topChecked)).0
+        let (s1, _) = SelectionSession.reduce(s, .tick)        // sees a checked; not all rows yet → scroll
+        XCTAssertEqual(s1.phase, .applyingFull)
+        s = s1
+        s = SelectionSession.reduce(s, .output(scrolledChecked)).0
+        let (s2, e2) = SelectionSession.reduce(s, .tick)       // all rows seen; checked == {a,d}
+        XCTAssertEqual(s2.phase, .awaitingConfirm)
+        XCTAssertEqual(e2, [.send([0x0d])])
+    }
+
+    func testFullSelection_verifyMismatch_abortsWithoutDeleting() {
+        var s = loadedAll4()
+        s = SelectionSession.reduce(s, .confirmRequested([0, 3])).0   // wanted a + d
+        s = SelectionSession.reduce(s, .output(topChecked)).0         // a checked
+        s = SelectionSession.reduce(s, .tick).0
+        s = SelectionSession.reduce(s, .output(scrolledWrong)).0      // c checked, NOT d
+        let (s2, e2) = SelectionSession.reduce(s, .tick)
+        if case .failed = s2.phase {} else { XCTFail("must abort when checked rows disagree with the selection") }
+        XCTAssertEqual(e2, [.send(MoTUI.quit)])
+        XCTAssertFalse(e2.contains(.send([0x0d])))
+    }
+
+    func testShowAll_scrollCaptureStitchesAllItemsInOrder() {
+        var s = SelectionSession.reduce(SelectionSession.State(), .output(scan4)).0
+        XCTAssertEqual(s.items.count, 3)
+        XCTAssertEqual(s.totalCount, 4)
+
+        s = SelectionSession.reduce(s, .showAllRequested).0
+        XCTAssertEqual(s.phase, .loadingAll)
+
+        // First tick: nothing new on screen yet → scroll down one row.
+        let (s1, e1) = SelectionSession.reduce(s, .tick)
+        XCTAssertEqual(e1, [.send(MoTUI.down)])
+        s = s1
+
+        // Host scrolled; Mole redrew revealing the 4th item.
+        s = SelectionSession.reduce(s, .output(scrolled4)).0
+
+        // Next tick: merges the 4th item → total reached → return to top, done loading.
+        let (s2, e2) = SelectionSession.reduce(s, .tick)
+        XCTAssertEqual(s2.phase, .choosing)
+        XCTAssertTrue(s2.fullyLoaded)
+        XCTAssertEqual(s2.items.map(\.name), ["~/p/a", "~/p/b", "~/p/c", "~/p/d"])
+        let expectedUps = Array(repeating: MoTUI.up, count: s2.items.count + 5).flatMap { $0 }
+        XCTAssertEqual(e2, [.send(expectedUps)], "returns the cursor to the top")
+    }
+}

--- a/Tests/SnapshotStoreTests.swift
+++ b/Tests/SnapshotStoreTests.swift
@@ -1,0 +1,71 @@
+//
+//  SnapshotStoreTests.swift
+//  BurrowTests
+//
+//  Boundary tests for the typed snapshot reader, against a temporary database
+//  (the local-substitutable way — real SQLite, no mocks), mirroring DBTests.
+//
+
+import XCTest
+@testable import Burrow
+
+final class SnapshotStoreTests: XCTestCase {
+    private var tempDir: URL!
+    private var db: DB!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-snap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        db = try DB(at: tempDir.appendingPathComponent("burrow.db"))
+    }
+
+    override func tearDown() {
+        db = nil
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    /// Minimal valid `mo status --json` with a given CPU usage.
+    private func snapshotJSON(cpu: Double) -> String {
+        """
+        {"collected_at":"2026-06-08T03:16:25.068057-07:00","host":"h","platform":"darwin",
+         "uptime_seconds":100,"procs":1,
+         "hardware":{"model":"Mac","cpu_model":"M","total_ram":"24 GB","disk_size":"460 GB","os_version":"26"},
+         "health_score":90,"health_score_msg":"Good",
+         "cpu":{"usage":\(cpu),"load1":1,"load5":1,"load15":1,"core_count":10,"logical_cpu":10},
+         "memory":{"used":1,"total":2,"used_percent":50,"swap_used":0,"swap_total":0,"pressure":""},
+         "disk_io":{"read_rate":0,"write_rate":0}}
+        """
+    }
+
+    func testRange_decodesStoredSnapshotsInWindow() throws {
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 100, json: snapshotJSON(cpu: 10))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 200, json: snapshotJSON(cpu: 80))
+
+        let snaps = SnapshotStore.range(db, since: 0, until: 1000, maxPoints: 100)
+        XCTAssertEqual(snaps.map(\.ts), [100, 200])
+        XCTAssertEqual(snaps.map { Int($0.status.cpu.usage) }, [10, 80])
+    }
+
+    func testRange_excludesRowsOutsideWindow() throws {
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 100, json: snapshotJSON(cpu: 10))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 5000, json: snapshotJSON(cpu: 80))
+        let snaps = SnapshotStore.range(db, since: 0, until: 1000, maxPoints: 100)
+        XCTAssertEqual(snaps.map(\.ts), [100])
+    }
+
+    func testRange_skipsMalformedRows() throws {
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 100, json: "not valid json")
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 200, json: snapshotJSON(cpu: 50))
+        let snaps = SnapshotStore.range(db, since: 0, until: 1000, maxPoints: 100)
+        XCTAssertEqual(snaps.count, 1)
+        XCTAssertEqual(Int(snaps[0].status.cpu.usage), 50)
+    }
+
+    func testLatest_returnsMostRecentDecoded() throws {
+        XCTAssertNil(SnapshotStore.latest(db), "empty store → nil")
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 100, json: snapshotJSON(cpu: 10))
+        try db.insert(prefix: Sampler.snapshotPrefix, ts: 200, json: snapshotJSON(cpu: 80))
+        XCTAssertEqual(Int(SnapshotStore.latest(db)?.status.cpu.usage ?? -1), 80)
+    }
+}

--- a/Tests/UpdatesParseTests.swift
+++ b/Tests/UpdatesParseTests.swift
@@ -1,0 +1,36 @@
+//
+//  UpdatesParseTests.swift
+//  BurrowTests
+//
+//  The brew-outdated parser is the runner family's last untested parser; pin it
+//  against captured `brew outdated --json=v2` output.
+//
+
+import XCTest
+@testable import Burrow
+
+final class UpdatesParseTests: XCTestCase {
+    func testParseOutdated_readsFormulaeAndCasks() {
+        let json = """
+        {"formulae":[{"name":"git","installed_versions":["2.43.0"],"current_version":"2.44.0"}],
+         "casks":[{"name":"slack","installed_versions":["4.0.0"],"current_version":"4.1.0"}]}
+        """
+        let items = UpdatesModel.parseOutdated(json)
+        XCTAssertEqual(items.count, 2)
+        let git = items.first { $0.name == "git" }
+        XCTAssertEqual(git?.kind, "formula")
+        XCTAssertEqual(git?.installed, "2.43.0")
+        XCTAssertEqual(git?.latest, "2.44.0")
+        XCTAssertEqual(items.first { $0.name == "slack" }?.kind, "cask")
+    }
+
+    func testParseOutdated_handlesMissingFieldsAndEmpty() {
+        // No installed version → "?" placeholder; unnamed rows skipped.
+        let json = #"{"formulae":[{"current_version":"1.0"},{"name":"wget"}],"casks":[]}"#
+        let items = UpdatesModel.parseOutdated(json)
+        XCTAssertEqual(items.map(\.name), ["wget"])
+        XCTAssertEqual(items.first?.installed, "?")
+        XCTAssertTrue(UpdatesModel.parseOutdated("not json").isEmpty)
+        XCTAssertTrue(UpdatesModel.parseOutdated("").isEmpty)
+    }
+}

--- a/plans/mo-integration-deepening.md
+++ b/plans/mo-integration-deepening.md
@@ -1,0 +1,163 @@
+# Plan: Deepen the `mo` integration (testable selection driver + runner/client/snapshot stack)
+
+> Source PRD: [caezium/Burrow#29](https://github.com/caezium/Burrow/issues/29)
+
+Eight tracer-bullet slices across the PRD's four phases. Each slice cuts through the new interface + at least one real caller + boundary tests, is independently mergeable, and **leaves the app behaving identically to the user** — the deliverable is test coverage and a narrower interface, not new behavior.
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Module stack** (top depends on the one below): `SnapshotStore` → `MoleClient` → `MoleProcess`; `SelectionSession` → PTY port (later satisfied by `MoleProcess`'s pty mode without changing the session's interface). Each module has a narrow interface hiding a large implementation.
+- **Selection reducer contract**: `reduce(state, event) -> (state, [effect])`, a **pure function** — no I/O, no clock, no SwiftUI inside it.
+  - **Events** (host → reducer): output-arrived (raw frame text), process-exited (status), scan-requested, show-all-requested, confirm-requested (chosen index set), and **tick** (a counted logical pulse).
+  - **Effects** (reducer → host): launch-process, send-keystrokes (bytes), terminate, state-changed.
+  - **Clock**: settle/timeout decisions are driven by counting `tick` events, **never wall-clock time**, so tests advance time by feeding ticks.
+- **PTY port**: a minimal boundary — launch (executable + args), send (bytes), terminate, plus an output callback and an exit callback. **Production adapter** wraps the real pseudo-terminal; **test adapter** is a scripted fake that maps received keystrokes to the next canned frame(s).
+- **Process port** (Phase 2+): the OS-process boundary is injectable. The runner exposes explicit modes — capture, stream, pseudo-terminal, elevated — and there is exactly **one** ANSI-stripping function in the codebase.
+- **Reused pure vocabulary**: the existing tested helpers (frame parse, item merge/stitch by full identity, keystroke planning, confirm-count across `Remove|Delete|…`, total-count from the `[n/total]` header) become the reducer's internal vocabulary; their behavior is unchanged.
+- **Testing principle**: boundary tests assert **observable outcomes** — the effects produced by a sequence of events, or the typed result of canned `mo` output — never internal fields or timing. **Replace, don't layer**: delete a shallow-module test once a boundary test covers the behavior. Substitutes: the scripted **fake PTY** (Phases 1–4/6) and a **temporary database** (Phase 8). A single optional `--dry-run` integration smoke may remain, but it is **not** the primary safety net.
+- **Dependency categories**: Phases 1, 2 (and the pty/elevated parts of 6) are **ports & adapters**; Phases 7 and 8 are **local-substitutable** (canned output / temp DB).
+- **Invariant**: after every slice the installer, purge, uninstall, trackers, MCP, and HTTP surfaces behave identically to the user.
+
+---
+
+## Phase 1: Selection reducer skeleton + scan path + PTY port
+
+**User stories**: 1, 2, 8, 9, 21
+
+### What to build
+
+Introduce the `SelectionSession` reducer with its state / event / effect vocabulary and the logical-tick clock, and implement the **smallest complete path only**: launch the selection process through the PTY port, feed terminal output and ticks in as events, and drive to the `choosing` state carrying the parsed item list and reported total. Convert the existing installer/purge runner into a thin **host** that owns the real PTY adapter and a repeating timer, translates pty bytes and timer fires into events, runs the reducer, applies `launch`/`send-keystrokes` effects, and republishes reducer state for the SwiftUI list. Add the scripted **fake PTY** to the test target. Both installer and purge use the same session with their existing per-tool wording.
+
+### Acceptance criteria
+
+- [ ] Installer and purge still scan and render the item list identically to today.
+- [ ] The selection flow's decision logic is a pure reducer with no I/O, clock, or SwiftUI inside it.
+- [ ] The pseudo-terminal is reached only through the PTY port; production uses the real adapter.
+- [ ] A scripted fake PTY exists in the test target and can feed canned frames and capture emitted keystrokes.
+- [ ] A boundary test feeds canned scan frames + ticks and asserts the reducer reaches `choosing` with the expected parsed items and total.
+- [ ] No wall-clock time is used in any Phase-1 test.
+
+---
+
+## Phase 2: Confirm path + confirm-screen safety
+
+**User stories**: 3, 4, 7, 10, 12, 22, 24
+
+### What to build
+
+Extend the reducer to handle a **single-viewport** selection through `applying → verifying → confirming`: plan the toggle keystrokes for the chosen indices, settle the screen via ticks, verify the on-screen selection matches the choice **by identity**, proceed to `mo`'s final confirm, parse the confirm count across `mo`'s wording variants, and either emit the confirming keystroke (count + identity match) or **abort** (quit + `failed`) on any mismatch. The host applies the emitted keystrokes to the real pty.
+
+### Acceptance criteria
+
+- [ ] Removing a viewport-sized selection in installer and purge works end-to-end (dry-run / real).
+- [ ] A boundary test drives select→confirm with a "Delete N installers" confirm frame and asserts the confirming keystroke is emitted only when count and identities match.
+- [ ] A boundary test asserts a confirm frame whose count disagrees with the selection yields an abort (quit effect, `failed` state) and never the confirming keystroke.
+- [ ] A boundary test asserts an empty selection never produces a confirming keystroke.
+- [ ] A test would fail if the confirm-verb match regressed to "Remove"-only (the installer "Delete" regression).
+
+---
+
+## Phase 3: Scroll-capture ("Show all")
+
+**User stories**: 5, 11
+
+### What to build
+
+Add the show-all events/effects so the reducer, on request, walks the cursor to the bottom and stitches the overlapping frames into one ordered item list (dedup by full identity), stopping at the reported total, then returns the cursor to the top. The host pumps the resulting scroll keystrokes and frames; the UI shows the full list with a progress affordance.
+
+### Acceptance criteria
+
+- [ ] "Show all N" in purge pulls in the complete list and the UI renders every item, as today.
+- [ ] A boundary test feeds a scripted scroll sequence and asserts the reducer accumulates all N items in order with stable indices.
+- [ ] A boundary test asserts duplicate basenames are kept as distinct items (dedup by full identity, not name).
+- [ ] A boundary test asserts capture stops at the reported total and returns the cursor to the top.
+- [ ] Indices selected before "Show all" remain valid after it (append-only ordering).
+
+---
+
+## Phase 4: Scroll-verify gate
+
+**User stories**: 6, 12, 23, 24
+
+### What to build
+
+Add the **larger-than-one-viewport** confirm path: after the selection walk, scroll from the top through every viewport accumulating the checked rows, and proceed to `mo`'s final confirm **only when** the checked identity set exactly equals the selection; otherwise abort. This completes the PRD's Phase 1 — the entire selection driver is now a tested pure reducer. Retire reliance on the out-of-process harness (optionally keep one `--dry-run` integration smoke).
+
+### Acceptance criteria
+
+- [ ] Removing a selection that spans more than one viewport works end-to-end (dry-run validated).
+- [ ] A boundary test asserts the reducer proceeds only when the checked rows across all frames exactly equal the selection.
+- [ ] A boundary test asserts a mismatch (an unselected row checked, or a selected row not checked) aborts with quit + `failed` and no confirming keystroke.
+- [ ] The scenarios previously validated out-of-process (≈54-item capture, selection spanning the viewport boundary, count-mismatch abort) run in the in-suite tests.
+- [ ] Shallow-module tests made redundant by the new boundary tests are deleted.
+
+---
+
+## Phase 5: Subprocess runner (capture mode) + one ANSI stripper
+
+**User stories**: 13, 14, 15
+
+### What to build
+
+Introduce the `MoleProcess` runner with a **capture** mode (blocking; stdout/stderr/exit; stdin feed; timeout-kill; PATH discovery) behind an injectable process port, plus a single ANSI-stripping function. Migrate the plain-capture callers (status sampling, installed-app list, cleanup history, disk analyze, version, uninstall execution) onto it and delete the duplicate strippers.
+
+### Acceptance criteria
+
+- [ ] All plain-capture `mo` invocations route through one runner; no caller constructs its own process for capture.
+- [ ] Exactly one ANSI-stripping function remains in the codebase.
+- [ ] The process boundary is injectable; a fake process is used in tests.
+- [ ] Boundary tests cover timeout behavior, stdin reaching the child, stdout/stderr capture, and a table of ANSI cases.
+- [ ] Trackers, app list, history, analyze, and uninstall behave unchanged.
+
+---
+
+## Phase 6: Runner stream / pty / elevated modes
+
+**User stories**: 13, 15
+
+### What to build
+
+Add **stream** (line-coalesced), **pseudo-terminal** (Phase 1's pty adapter relocated here under the same port), and **elevated** (osascript / Touch ID) modes; migrate clean/optimize streaming, the selection session's pty access, the touchid path, and the Homebrew calls onto the runner. The clean/optimize report model and markers are unchanged.
+
+### Acceptance criteria
+
+- [ ] Clean, optimize, touchid, brew, and the selection session all spawn through the one runner.
+- [ ] The selection session's PTY port is satisfied by the runner's pty mode with **no change** to the Phase 1 reducer interface.
+- [ ] Streaming output and the elevated log-tail behavior are unchanged for the user.
+- [ ] Boundary tests cover the stream-coalescing and pty modes via the fake process/pty.
+
+---
+
+## Phase 7: Typed `mo` client
+
+**User stories**: 16, 17, 25
+
+### What to build
+
+Introduce `MoleClient`, which turns each `mo` subcommand into a typed result **exactly once** (status snapshot, history sessions, installed apps, analyze tree), built on the runner. Migrate the SwiftUI views and the MCP server to consume it; MCP tool responses become projections of the typed results. Remove the ad-hoc per-consumer parsers.
+
+### Acceptance criteria
+
+- [ ] Each `mo` subcommand is parsed in exactly one place.
+- [ ] The views and the MCP server consume the same typed client for the same command.
+- [ ] Boundary tests assert that captured real `mo` output yields the expected typed values, including empty/malformed handling.
+- [ ] App and MCP outputs are unchanged.
+
+---
+
+## Phase 8: Snapshot store
+
+**User stories**: 18, 19, 20
+
+### What to build
+
+Introduce `SnapshotStore`, which owns the metrics lifecycle — sample on a cadence (with foreground/background control), patch in natively-read metrics where `mo` reports holes, persist, and answer **typed** queries (latest snapshot; sampled range as decoded snapshots or projected series). Migrate the dashboard, history, popup, AI lens, MCP, and HTTP query server to the store's typed API; remove the per-view raw-JSON decode loops and direct database access.
+
+### Acceptance criteria
+
+- [ ] No consumer decodes raw snapshot JSON or queries the snapshot database directly; all use the store's typed API.
+- [ ] The range decode-and-project logic exists in exactly one place.
+- [ ] Boundary tests with a temporary database assert sample→typed-query behavior, including native-metric patching and cadence.
+- [ ] Dashboard, history, popup, AI lens, MCP, and the HTTP endpoints render identical data to today.


### PR DESCRIPTION
Implements the deepening program from #29 (plan in `plans/mo-integration-deepening.md`). Refactors how Burrow drives and parses the `mo` CLI into a few deep, testable modules — **no user-facing behavior change** — and fixes two real hangs found while testing it live.

## What changed

- **`SelectionSession` — the installer/purge flow as a pure reducer.** `reduce(state, event) -> (state, [effect])`: no I/O, no clock, no SwiftUI inside it. `InstallerView`'s runner is now a thin host that owns the pty + a tick timer, pumps PTY bytes/ticks in as events, and applies effects (send keystrokes / quit). The whole scan → select → scroll-capture → scroll-**verify** → confirm path — including the safety-critical "abort unless the on-screen selection matches" logic — is now driven by unit tests with a scripted **fake pty**, instead of an out-of-process harness.
- **One ANSI stripper** (`Ansi.swift`) replacing the three near-duplicate copies (TaskReport / MoInteractive / MCP).
- **Typed `MoleClient`** — parses each `mo` subcommand once into typed results; `SoftwareView`, MCP, etc. consume it instead of re-parsing.
- **`SnapshotStore`** — owns the metrics snapshot decode/query so the dashboard, history, popup, Explain, MCP, and HTTP server stop each re-decoding raw JSON.
- **Boundary tests** for the capture runner (`MoleCLITests`) and the brew-outdated parser (`UpdatesParseTests`).

## Two real bugs found while testing (with regression tests)

1. **pty EOF starved the exit** — when `mo` exits before rendering a list (e.g. nothing found), the read handler spun on empty-data forever and starved the process terminationHandler, so the exit was never delivered and the UI hung on "Scanning…". Fixed by disarming on EOF + reporting the exit. (Latent in 0.6.0 too.)
2. **rescan reused a `Process`** — a `Process` runs once; the refactored `PTYTask` reused one instance, so the *second* scan never spawned a child and hung. Fixed with a fresh `Process` per launch.

Both are covered by `PTYTask` regression tests (`/bin/echo` launched once, and twice).

## Tests

`xcodebuild` Debug + Release pass; **124 tests** (was 90). New: FakePTY-driven reducer flow, a real-`mo --dry-run` integration smoke, the two pty regression tests, plus client/store/ANSI/parser boundary tests.

## Verification

Built Release, ad-hoc signed, installed to `/Applications`, and exercised live (Status/History/trackers + the installer scan/rescan paths). Behavior matches 0.6.0.

## Scope note (honest)

This lands the high-value core of the plan: the selection reducer (plan Phases 1–4), the ANSI unification + capture-runner tests (Phase 5), and the typed client + snapshot store (Phases 7–8). **Phase 6 — fully relocating the streaming / pty / elevated spawn mechanisms behind a single runner type — is deferred**; those paths still live where they were (only ANSI was unified). Follow-up.
