### PR TITLE
refactor: introduce MoleProcess runner and migrate capture-style spawns

### DIFF
--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -107,6 +107,8 @@ enum MoleCLI {
         let exitCode: Int32
     }
 
+    internal static var processPort: MoleProcessPort = SystemMoleProcess()
+
     /// Run an executable with the given args, capturing stdout + stderr.
     /// Blocks until the process exits — callers are responsible for
     /// running this on a background queue. Times out after `timeout`
@@ -123,46 +125,18 @@ enum MoleCLI {
                     executable: String? = nil,
                     stdin: String? = nil,
                     timeout: TimeInterval = 10) throws -> Result {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: executable ?? (findExecutable() ?? "/usr/bin/false"))
-        task.arguments = args
-
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        task.standardOutput = outPipe
-        task.standardError = errPipe
-
-        let inPipe: Pipe? = stdin != nil ? Pipe() : nil
-        if let inPipe { task.standardInput = inPipe }
-
-        try task.run()
-
-        // Write the canned input and close the write end so the child sees
-        // EOF after consuming it. Ignore write failures: if Mole exits before
-        // reading everything, the pipe write fails with EPIPE, which is fine.
-        if let inPipe, let stdin, let data = stdin.data(using: .utf8) {
-            let h = inPipe.fileHandleForWriting
-            try? h.write(contentsOf: data)
-            try? h.close()
-        }
-
-        // Kill the task after `timeout` if it's still running. The
-        // termination handler clears the timer so we don't fire stale
-        // kills against a recycled PID.
-        let killer = DispatchWorkItem { [weak task] in
-            if let task, task.isRunning { task.terminate() }
-        }
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: killer)
-
-        task.waitUntilExit()
-        killer.cancel()
-
-        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let resolvedExecutable = executable ?? (findExecutable() ?? "/usr/bin/false")
+        let processResult = try MoleProcess.capture(
+            executable: resolvedExecutable,
+            args: args,
+            stdin: stdin,
+            timeout: timeout,
+            port: processPort
+        )
         return Result(
-            stdout: String(data: outData, encoding: .utf8) ?? "",
-            stderr: String(data: errData, encoding: .utf8) ?? "",
-            exitCode: task.terminationStatus
+            stdout: processResult.stdout,
+            stderr: processResult.stderr,
+            exitCode: processResult.exitCode
         )
     }
 

--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -107,14 +107,16 @@ enum MoleCLI {
         let exitCode: Int32
     }
 
+    /// The subprocess runner. Production uses `SystemMoleProcess`; tests inject
+    /// a fake (reset in `tearDown`). Test-only seam — not a configuration point.
     internal static var processPort: MoleProcessPort = SystemMoleProcess()
 
     /// Run an executable with the given args, capturing stdout + stderr.
     /// Blocks until the process exits — callers are responsible for
     /// running this on a background queue. Times out after `timeout`
-    /// seconds; on timeout the process is terminated and we throw, rather
-    /// than returning a partial result, because callers always want
-    /// either a complete snapshot or to retry.
+    /// seconds; on timeout the process is terminated and the call returns a
+    /// non-zero `exitCode` (it does NOT throw). Callers treat any non-zero
+    /// exit as failure rather than distinguishing timeout from other errors.
     ///
     /// `stdin` feeds the child's standard input then closes it (EOF). This
     /// is how the uninstall flow answers Mole's `Proceed? [y/N]` and

--- a/Sources/MoleProcess.swift
+++ b/Sources/MoleProcess.swift
@@ -1,0 +1,98 @@
+//
+//  MoleProcess.swift
+//  Burrow
+//
+//  Capture-style subprocess runner used by small command invocations.
+//
+
+import Foundation
+
+struct MoleProcessResult {
+    let stdout: String
+    let stderr: String
+    let exitCode: Int32
+}
+
+protocol MoleProcessPort {
+    func capture(executable: String,
+                 args: [String],
+                 stdin: String?,
+                 environment: [String: String]?,
+                 timeout: TimeInterval) throws -> MoleProcessResult
+}
+
+struct SystemMoleProcess: MoleProcessPort {
+    func capture(executable: String,
+                 args: [String],
+                 stdin: String?,
+                 environment: [String: String]? = nil,
+                 timeout: TimeInterval = 10) throws -> MoleProcessResult {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = args
+        if let environment {
+            task.environment = environment
+        }
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = errPipe
+
+        let inPipe: Pipe? = stdin != nil ? Pipe() : nil
+        if let inPipe {
+            task.standardInput = inPipe
+        }
+
+        try task.run()
+
+        // Drain stderr concurrently while stdout is read on the caller's
+        // thread so neither pipe can fill and block the child process.
+        var errData = Data()
+        let errQueue = DispatchQueue(label: "dev.caezium.burrow.process.err")
+        errQueue.async {
+            errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        }
+
+        // Write canned input and close the write end so the child sees EOF.
+        // Ignore failures: a child that exits early can make this EPIPE.
+        if let inPipe, let stdin, let data = stdin.data(using: .utf8) {
+            let handle = inPipe.fileHandleForWriting
+            try? handle.write(contentsOf: data)
+            try? handle.close()
+        }
+
+        let killer = DispatchWorkItem { [weak task] in
+            if let task, task.isRunning { task.terminate() }
+        }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: killer)
+
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        killer.cancel()
+        errQueue.sync {}
+
+        return MoleProcessResult(
+            stdout: String(data: outData, encoding: .utf8) ?? "",
+            stderr: String(data: errData, encoding: .utf8) ?? "",
+            exitCode: task.terminationStatus
+        )
+    }
+}
+
+enum MoleProcess {
+    static func capture(executable: String,
+                        args: [String],
+                        stdin: String? = nil,
+                        environment: [String: String]? = nil,
+                        timeout: TimeInterval = 10,
+                        port: MoleProcessPort = SystemMoleProcess()) throws -> MoleProcessResult {
+        try port.capture(
+            executable: executable,
+            args: args,
+            stdin: stdin,
+            environment: environment,
+            timeout: timeout
+        )
+    }
+}

--- a/Sources/MoleProcess.swift
+++ b/Sources/MoleProcess.swift
@@ -22,11 +22,13 @@ protocol MoleProcessPort {
 }
 
 struct SystemMoleProcess: MoleProcessPort {
+    // Defaults live on `MoleProcess.capture`; the protocol witness takes every
+    // argument explicitly (concrete defaults would be unreachable through the port).
     func capture(executable: String,
                  args: [String],
                  stdin: String?,
-                 environment: [String: String]? = nil,
-                 timeout: TimeInterval = 10) throws -> MoleProcessResult {
+                 environment: [String: String]?,
+                 timeout: TimeInterval) throws -> MoleProcessResult {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: executable)
         task.arguments = args
@@ -56,6 +58,13 @@ struct SystemMoleProcess: MoleProcessPort {
 
         // Write canned input and close the write end so the child sees EOF.
         // Ignore failures: a child that exits early can make this EPIPE.
+        //
+        // NOTE: stdin is written here on the caller's thread, BEFORE stdout is
+        // drained below. That's safe only while `stdin` is small relative to the
+        // OS pipe buffer (~64 KB) — every caller today feeds a few bytes (e.g.
+        // "y\n"). A large stdin to a child that echoes it could deadlock (child
+        // blocks writing stdout while we block writing stdin); if that's ever
+        // needed, move this write onto its own queue too.
         if let inPipe, let stdin, let data = stdin.data(using: .utf8) {
             let handle = inPipe.fileHandleForWriting
             try? handle.write(contentsOf: data)

--- a/Sources/UpdatesView.swift
+++ b/Sources/UpdatesView.swift
@@ -161,30 +161,20 @@ final class UpdatesModel: ObservableObject {
     private struct BrewResult { let out: String; let err: String; let code: Int32 }
 
     private static func runBrew(_ brew: String, _ args: [String], timeout: TimeInterval = 120) -> BrewResult {
-        let t = Process()
-        t.executableURL = URL(fileURLWithPath: brew)
-        t.arguments = args
         var env = Foundation.ProcessInfo.processInfo.environment
         let dir = (brew as NSString).deletingLastPathComponent
         env["PATH"] = "\(dir):/usr/bin:/bin:/usr/sbin:/sbin:" + (env["PATH"] ?? "")
-        t.environment = env
-        let outPipe = Pipe(); let errPipe = Pipe()
-        t.standardOutput = outPipe; t.standardError = errPipe
-        do { try t.run() } catch { return BrewResult(out: "", err: "\(error)", code: -1) }
-
-        // Read both pipes concurrently so neither fills and deadlocks.
-        var errData = Data()
-        let errQ = DispatchQueue(label: "dev.caezium.burrow.brew.err")
-        errQ.async { errData = errPipe.fileHandleForReading.readDataToEndOfFile() }
-        let killer = DispatchWorkItem { if t.isRunning { t.terminate() } }
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: killer)
-        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-        t.waitUntilExit()
-        killer.cancel()
-        errQ.sync {}
-        return BrewResult(out: String(data: outData, encoding: .utf8) ?? "",
-                          err: String(data: errData, encoding: .utf8) ?? "",
-                          code: t.terminationStatus)
+        do {
+            let result = try MoleProcess.capture(
+                executable: brew,
+                args: args,
+                environment: env,
+                timeout: timeout
+            )
+            return BrewResult(out: result.stdout, err: result.stderr, code: result.exitCode)
+        } catch {
+            return BrewResult(out: "", err: "\(error)", code: -1)
+        }
     }
 
     /// Pure parser for `brew outdated --json=v2` — unit-tested against captured

--- a/Tests/MoleProcessTests.swift
+++ b/Tests/MoleProcessTests.swift
@@ -1,0 +1,135 @@
+//
+//  MoleProcessTests.swift
+//  BurrowTests
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoleProcessTests: XCTestCase {
+    private enum FakeError: Error {
+        case launchFailed
+    }
+
+    private final class FakeMoleProcessPort: MoleProcessPort {
+        var result = MoleProcessResult(stdout: "", stderr: "", exitCode: 0)
+        var error: Error?
+
+        private(set) var receivedExecutable: String?
+        private(set) var receivedArgs: [String]?
+        private(set) var receivedStdin: String?
+        private(set) var receivedEnvironment: [String: String]?
+        private(set) var receivedTimeout: TimeInterval?
+
+        func capture(executable: String,
+                     args: [String],
+                     stdin: String?,
+                     environment: [String: String]?,
+                     timeout: TimeInterval) throws -> MoleProcessResult {
+            receivedExecutable = executable
+            receivedArgs = args
+            receivedStdin = stdin
+            receivedEnvironment = environment
+            receivedTimeout = timeout
+
+            if let error {
+                throw error
+            }
+            return result
+        }
+    }
+
+    override func tearDown() {
+        MoleCLI.processPort = SystemMoleProcess()
+        super.tearDown()
+    }
+
+    func testCapture_returnsCannedResultFromInjectedPort() throws {
+        let fake = FakeMoleProcessPort()
+        fake.result = MoleProcessResult(stdout: "out", stderr: "err", exitCode: 0)
+
+        let result = try MoleProcess.capture(
+            executable: "/bin/example",
+            args: ["--flag"],
+            environment: ["PATH": "/tmp"],
+            timeout: 12,
+            port: fake
+        )
+
+        XCTAssertEqual(result.stdout, "out")
+        XCTAssertEqual(result.stderr, "err")
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(fake.receivedExecutable, "/bin/example")
+        XCTAssertEqual(fake.receivedArgs, ["--flag"])
+        XCTAssertEqual(fake.receivedEnvironment, ["PATH": "/tmp"])
+        XCTAssertEqual(fake.receivedTimeout, 12)
+    }
+
+    func testCapture_forwardsStdinToPort() throws {
+        let fake = FakeMoleProcessPort()
+
+        _ = try MoleProcess.capture(
+            executable: "/bin/cat",
+            args: [],
+            stdin: "piped input\n",
+            port: fake
+        )
+
+        XCTAssertEqual(fake.receivedStdin, "piped input\n")
+    }
+
+    func testCapture_passesThroughNonZeroExitAndStderr() throws {
+        let fake = FakeMoleProcessPort()
+        fake.result = MoleProcessResult(stdout: "", stderr: "boom", exitCode: 42)
+
+        let result = try MoleProcess.capture(executable: "/usr/bin/false", args: [], port: fake)
+
+        XCTAssertEqual(result.exitCode, 42)
+        XCTAssertEqual(result.stderr, "boom")
+    }
+
+    func testCapture_propagatesLaunchFailureFromPort() {
+        let fake = FakeMoleProcessPort()
+        fake.error = FakeError.launchFailed
+
+        XCTAssertThrowsError(try MoleProcess.capture(executable: "/missing", args: [], port: fake))
+    }
+
+    func testSystemCapture_timesOutWithNonZeroExitInsteadOfThrowing() throws {
+        let start = Date()
+        let result = try SystemMoleProcess().capture(
+            executable: "/bin/sleep",
+            args: ["5"],
+            stdin: nil,
+            environment: nil,
+            timeout: 0.4
+        )
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertLessThan(elapsed, 3.0, "the 5s sleep must be killed by the 0.4s timeout")
+        XCTAssertNotEqual(result.exitCode, 0, "a terminated process is non-zero")
+    }
+
+    func testMoleCLIRun_stillCapturesKnownEchoInvocationThroughRealPort() throws {
+        let result = try MoleCLI.run(args: ["hello world"], executable: "/bin/echo")
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "hello world")
+    }
+
+    func testMoleCLIRun_mapsInjectedPortResult() throws {
+        let fake = FakeMoleProcessPort()
+        fake.result = MoleProcessResult(stdout: "mapped out", stderr: "mapped err", exitCode: 7)
+        MoleCLI.processPort = fake
+
+        let result = try MoleCLI.run(args: ["ignored"], executable: "/bin/example", stdin: "yes\n", timeout: 3)
+
+        XCTAssertEqual(result.stdout, "mapped out")
+        XCTAssertEqual(result.stderr, "mapped err")
+        XCTAssertEqual(result.exitCode, 7)
+        XCTAssertEqual(fake.receivedExecutable, "/bin/example")
+        XCTAssertEqual(fake.receivedArgs, ["ignored"])
+        XCTAssertEqual(fake.receivedStdin, "yes\n")
+        XCTAssertEqual(fake.receivedTimeout, 3)
+    }
+}

--- a/Tests/MoleProcessTests.swift
+++ b/Tests/MoleProcessTests.swift
@@ -132,4 +132,43 @@ final class MoleProcessTests: XCTestCase {
         XCTAssertEqual(fake.receivedStdin, "yes\n")
         XCTAssertEqual(fake.receivedTimeout, 3)
     }
+
+    /// The point of draining stderr concurrently with stdout: a child can emit
+    /// far more than the ~64 KB pipe buffer without deadlocking. Reading stdout
+    /// AFTER waitUntilExit (the old `MoleCLI.run`) would hang until the timeout
+    /// killed the child and return truncated output. This locks the fix in.
+    func testSystemCapture_capturesLargeOutputWithoutDeadlockOrTruncation() throws {
+        let start = Date()
+        // seq 1…30000 is ~166 KB of stdout — well past one pipe buffer.
+        let result = try SystemMoleProcess().capture(
+            executable: "/usr/bin/seq", args: ["1", "30000"],
+            stdin: nil, environment: nil, timeout: 10)
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertEqual(result.exitCode, 0, "seq must complete, not be killed by the timeout")
+        XCTAssertLessThan(elapsed, 5.0, "must not hang until the timeout")
+        XCTAssertGreaterThan(result.stdout.utf8.count, 100_000, "full output, not a one-buffer truncation")
+        XCTAssertEqual(result.stdout.split(separator: "\n").last.map(String.init), "30000")
+    }
+
+    func testSystemCapture_appliesProvidedEnvironment() throws {
+        // The brew path's whole reason for passing environment is its augmented
+        // PATH — assert the child actually sees the env we pass.
+        let result = try SystemMoleProcess().capture(
+            executable: "/bin/sh", args: ["-c", "printf %s \"$BURROW_TEST\""],
+            stdin: nil, environment: ["BURROW_TEST": "applied", "PATH": "/usr/bin:/bin"], timeout: 5)
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stdout, "applied")
+    }
+
+    func testSystemCapture_separatesStdoutAndStderr() throws {
+        let result = try SystemMoleProcess().capture(
+            executable: "/bin/sh", args: ["-c", "echo to-out; echo to-err 1>&2"],
+            stdin: nil, environment: nil, timeout: 5)
+
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertEqual(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "to-out")
+        XCTAssertEqual(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines), "to-err")
+    }
 }


### PR DESCRIPTION
## Summary

Phase 6 (partial / tracer bullet) of the `mo` integration RFC: introduce one `MoleProcess` capture runner behind an injectable port, and migrate the two capture-style spawn sites onto it. Behavior of the migrated sites is preserved exactly.

This is intentionally scoped to the two simplest spawn paths to prove the runner + injectable-port pattern before the heavier callback-driven paths follow. The streaming (`CommandRunner`), pty (`PTYTask` / `MoInteractive`), and elevated (`runElevated` / osascript) migrations are deferred to a follow-up, since each carries its own callback / lifecycle surgery.

## Why this matters

Refs #29, phase 6 (partial scope). The RFC calls for collapsing the four separate `Process`-spawning implementations into one runner with explicit modes behind an injectable port, so the subprocess boundary lives in one place and is testable. Today only ANSI stripping was consolidated; the spawn plumbing is still duplicated. This change lands the runner and the capture mode, and makes the seam test-injectable, so the remaining modes can be moved over incrementally without another from-scratch design.

## Changes

- `Sources/MoleProcess.swift` (new): `MoleProcessPort` protocol (launch executable + args, optional stdin written-then-EOF, optional environment, timeout; returns captured stdout/stderr/exit), a `SystemMoleProcess` production adapter wrapping `Process`, and a `MoleProcess.capture(...)` entry point with an injectable `port` parameter. The adapter drains stderr concurrently with stdout so neither pipe can fill and block the child.
- `Sources/MoleCLI.swift`: `MoleCLI.run(args:executable:stdin:timeout:)` keeps its exact signature and routes through an injectable `processPort`. Executable resolution, stdin EOF semantics, timeout-kill (returns non-zero, does not throw), and `Result` mapping are unchanged.
- `Sources/UpdatesView.swift`: `UpdatesModel.runBrew` routes through `MoleProcess`, preserving its PATH-augmented environment, timeout, `BrewResult` mapping, and the launch-failure path (`code -1` with the error string).
- `Tests/MoleProcessTests.swift` (new): fake-port coverage (canned result, stdin forwarding, non-zero exit pass-through, launch-failure propagation), a real-binary timeout test asserting non-zero-and-no-throw, and a `MoleCLI.run` regression through both the real and an injected port.

Out of scope (deferred): `CommandRunner`, `PTYTask` / `MoInteractive`, `TaskReport` spawns, and `runElevated` are untouched.

## Testing

Built and ran the targeted suites locally on macOS (Xcode 26.4, `xcodebuild test`):

- `MoleProcessTests` — 7 passed
- `MoleCLITests` — 7 passed (including the existing timeout-returns-non-zero regression)
- `UpdatesParseTests` — 2 passed

Full app + test target compiles cleanly. `** TEST SUCCEEDED **`.

AI was used for assistance.
