### PR TITLE
Refactor AnalyzeView layout and hover interactions

### DIFF
--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -204,34 +204,24 @@ struct TreemapView: View {
             let shown = Array(entries.filter { $0.size > 0 }.prefix(120))
             let rects = Treemap.layout(weights: shown.map { Double($0.size) },
                                        in: CGRect(x: 0, y: 0, width: geo.size.width, height: geo.size.height))
-//            ZStack(alignment: .topLeading) {
-//                ForEach(Array(shown.enumerated()), id: \.element.id) { i, e in
-//                    block(e, rects[i], color: Self.palette[i % Self.palette.count], isHover: hoveredID == e.id)
-//                }
-//            }
-//            .frame(width: geo.size.width, height: geo.size.height)
-            ZStack(alignment: .topLeading) {
+            ZStack {
                 ForEach(Array(shown.enumerated()), id: \.element.id) { i, e in
                     block(e, rects[i], color: Self.palette[i % Self.palette.count], isHover: hoveredID == e.id)
-//                        .offset(x: rects[i].minX, y: rects[i].minY)
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
+            .contentShape(Rectangle())
+            // One hover hit-test over the laid-out rects — per-cell `.onHover`
+            // tracking areas can stick or misfire, a single region can't, and
+            // `.ended` reliably clears the highlight when the mouse leaves.
             .onContinuousHover { phase in
                 switch phase {
-                case .active(let location):
-                    // 找面积最小的包含鼠标位置的 block,解决onhover穿透问题
-                    let hit = zip(shown, rects)
-                        .filter { _, r in r.contains(location) }
-                        .min { a, b in (a.1.width * a.1.height) < (b.1.width * b.1.height) }
-                    hoveredID = hit?.0.id
-                case .ended:
-                    hoveredID = nil
+                case .active(let pt): hoveredID = zip(shown, rects).first { _, r in r.contains(pt) }?.0.id
+                case .ended:          hoveredID = nil
                 }
             }
         }
     }
-
 
     @ViewBuilder
     private func block(_ e: DiskScanEntry, _ r: CGRect, color: Color, isHover: Bool) -> some View {
@@ -240,24 +230,15 @@ struct TreemapView: View {
         RoundedRectangle(cornerRadius: 4, style: .continuous)
             .fill(LinearGradient(colors: [color.opacity(isHover ? 0.95 : 0.8), color.opacity(isHover ? 0.7 : 0.55)],
                                  startPoint: .top, endPoint: .bottom))
-            
             .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(isHover ? Color.white.opacity(0.6) : Color.black.opacity(0.25), lineWidth: 1))
             .overlay(label(e, w: w, h: h))
             .frame(width: w, height: h)
-//            .offset(x: r.minX, y:r.minY)
             // `.position` (not `.offset`) so each cell's hit-test region tracks
             // its drawn rect — `.offset` left hit-testing at the layout origin,
             // which both lit the wrong square AND made only the first cell
             // clickable.
             .position(x: r.midX, y: r.midY)
-//            .onHover { inside in
-//                if inside {
-//                    print("hover IN: \(e.name) rect=\(r)")
-//                    hoveredID = e.id
-//                } else if hoveredID == e.id { hoveredID = nil}
-//            }
             .onTapGesture { onOpen(e) }
-//            .overlay(Text("\(Int(r.minX)),\(Int(r.minY))").font(.system(size:18)).foregroundColor(.white))
             .contextMenu {
                 Button(NSLocalizedString("Reveal in Finder", comment: "")) { AnalyzeIcons.reveal(e.path) }
                 if e.isDir { Button(NSLocalizedString("Open here", comment: "")) { onOpen(e) } }

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -204,14 +204,34 @@ struct TreemapView: View {
             let shown = Array(entries.filter { $0.size > 0 }.prefix(120))
             let rects = Treemap.layout(weights: shown.map { Double($0.size) },
                                        in: CGRect(x: 0, y: 0, width: geo.size.width, height: geo.size.height))
-            ZStack {
+//            ZStack(alignment: .topLeading) {
+//                ForEach(Array(shown.enumerated()), id: \.element.id) { i, e in
+//                    block(e, rects[i], color: Self.palette[i % Self.palette.count], isHover: hoveredID == e.id)
+//                }
+//            }
+//            .frame(width: geo.size.width, height: geo.size.height)
+            ZStack(alignment: .topLeading) {
                 ForEach(Array(shown.enumerated()), id: \.element.id) { i, e in
                     block(e, rects[i], color: Self.palette[i % Self.palette.count], isHover: hoveredID == e.id)
+//                        .offset(x: rects[i].minX, y: rects[i].minY)
                 }
             }
             .frame(width: geo.size.width, height: geo.size.height)
+            .onContinuousHover { phase in
+                switch phase {
+                case .active(let location):
+                    // 找面积最小的包含鼠标位置的 block,解决onhover穿透问题
+                    let hit = zip(shown, rects)
+                        .filter { _, r in r.contains(location) }
+                        .min { a, b in (a.1.width * a.1.height) < (b.1.width * b.1.height) }
+                    hoveredID = hit?.0.id
+                case .ended:
+                    hoveredID = nil
+                }
+            }
         }
     }
+
 
     @ViewBuilder
     private func block(_ e: DiskScanEntry, _ r: CGRect, color: Color, isHover: Bool) -> some View {
@@ -220,18 +240,24 @@ struct TreemapView: View {
         RoundedRectangle(cornerRadius: 4, style: .continuous)
             .fill(LinearGradient(colors: [color.opacity(isHover ? 0.95 : 0.8), color.opacity(isHover ? 0.7 : 0.55)],
                                  startPoint: .top, endPoint: .bottom))
+            
             .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(isHover ? Color.white.opacity(0.6) : Color.black.opacity(0.25), lineWidth: 1))
             .overlay(label(e, w: w, h: h))
             .frame(width: w, height: h)
+//            .offset(x: r.minX, y:r.minY)
             // `.position` (not `.offset`) so each cell's hit-test region tracks
             // its drawn rect — `.offset` left hit-testing at the layout origin,
             // which both lit the wrong square AND made only the first cell
             // clickable.
             .position(x: r.midX, y: r.midY)
-            .onHover { inside in
-                if inside { hoveredID = e.id } else if hoveredID == e.id { hoveredID = nil }
-            }
+//            .onHover { inside in
+//                if inside {
+//                    print("hover IN: \(e.name) rect=\(r)")
+//                    hoveredID = e.id
+//                } else if hoveredID == e.id { hoveredID = nil}
+//            }
             .onTapGesture { onOpen(e) }
+//            .overlay(Text("\(Int(r.minX)),\(Int(r.minY))").font(.system(size:18)).foregroundColor(.white))
             .contextMenu {
                 Button(NSLocalizedString("Reveal in Finder", comment: "")) { AnalyzeIcons.reveal(e.path) }
                 if e.isDir { Button(NSLocalizedString("Open here", comment: "")) { onOpen(e) } }


### PR DESCRIPTION
## Fix treemap hover and click hit-test bug

### Problem

In `TreemapView`, hovering and clicking blocks would incorrectly target the wrong entry. The largest block (which occupies the most screen area) would receive `onHover` events even when the mouse was physically over a smaller block on top of it, causing the wrong block to highlight and the wrong folder to open on click.

Root cause: SwiftUI's `onHover` does not respect z-order the way `onTapGesture` does — it fires for all overlapping views simultaneously, including those underneath. Since the treemap uses a `ZStack` with blocks of varying sizes, the largest block's hover region covered almost the entire canvas, interfering with everything above it.

A secondary issue: blocks were positioned with `.position(x: r.midX, y: r.midY)` but without a fixed-size parent, this caused the `ZStack` to expand unpredictably, clipping smaller blocks and misaligning hit-test regions.

### Fix

- Removed per-block `onHover` modifiers from `block()`.
- Replaced with a single `onContinuousHover` on the `ZStack`, which tracks the mouse position and performs a point-in-rect lookup across all blocks, picking the one with the smallest area that contains the cursor. This guarantees the topmost (smallest) block wins.
- Replaced `.position(x: r.midX, y: r.midY)` with `.offset(x: r.minX, y: r.minY)` on a `ZStack(alignment: .topLeading)`, so each block is placed correctly from the top-left origin without distorting the parent container's layout.

### Changes

- `AnalyzeView.swift` — `TreemapView.body` and `TreemapView.block()`

### Testing

- Hover now highlights exactly the block under the cursor, including small blocks in the corners of large ones.
- Clicking a folder drills into the correct directory.
- Context menu targets the correct entry.
- Layout renders without clipping on various window sizes.