### PR TITLE
fix(i18n): add missing "Endpoint" string to zh-Hant

### DIFF
--- a/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Resources/zh-Hant.lproj/Localizable.strings
@@ -351,6 +351,7 @@
 "Local HTTP query server" = "本機 HTTP 查詢伺服器";
 "Enable the Explain lens" = "啟用解讀功能";
 "Enable HTTP query server" = "啟用 HTTP 查詢伺服器";
+"Endpoint" = "端點";
 "Let agents run cleanups for real" = "允許 AI 代理真正執行清理";
 "Backend" = "後端";
 "Base URL" = "基礎 URL";


### PR DESCRIPTION
The zh-Hant localization (added in #41) is missing one key that zh-Hans has: `"Endpoint"`. Because `NSLocalizedString` falls back to the key when a translation is missing, the Endpoint label in Settings → Local HTTP query server shows in English while the rest of the page is in Traditional Chinese.

This adds the Taiwan-Mandarin equivalent:

```
"Endpoint" = "端點";
```

With this, zh-Hant covers the same 354 keys as zh-Hans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)