### PR TITLE
fix(analyze): actionable error for pre-1.29 mole instead of raw /dev/tty failure

### DIFF
--- a/Sources/DiskScanner.swift
+++ b/Sources/DiskScanner.swift
@@ -48,6 +48,7 @@ struct DiskScanResult {
 
 enum DiskScanError: Error, LocalizedError {
     case moNotFound
+    case moTooOld(found: String?)
     case moFailed(exitCode: Int32, stderr: String)
     case parseFailed(String)
 
@@ -55,6 +56,12 @@ enum DiskScanError: Error, LocalizedError {
         switch self {
         case .moNotFound:
             return NSLocalizedString("Mole CLI (`mo`) not found on PATH.", comment: "")
+        case .moTooOld(let found):
+            return String(format: NSLocalizedString(
+                "Disk analysis needs Mole %@ or newer (you have %@). Run `brew upgrade mole`, then try again.",
+                comment: ""),
+                MoleCLI.minimumAnalyzeJSONVersion,
+                found ?? NSLocalizedString("an unknown version", comment: ""))
         case .moFailed(let code, let stderr):
             return String(format: NSLocalizedString("mo analyze exited %d: %@", comment: ""),
                           code, String(stderr.prefix(200)))
@@ -78,12 +85,25 @@ enum DiskScanner {
         // indexing can stretch it. Beyond 5 min something's wrong.
         let result = try MoleCLI.run(args: ["analyze", "--json", path], timeout: 300)
         guard result.exitCode == 0 else {
+            if indicatesMissingJSONSupport(stderr: result.stderr) {
+                throw DiskScanError.moTooOld(found: MoleCLI.version())
+            }
             throw DiskScanError.moFailed(exitCode: result.exitCode, stderr: result.stderr)
         }
         guard let data = result.stdout.data(using: .utf8) else {
             throw DiskScanError.parseFailed("non-utf8 stdout")
         }
         return try Self.parse(data)
+    }
+
+    /// Pre-1.29 Mole doesn't know `analyze --json`: depending on vintage
+    /// it either rejects the flag (Go's "flag provided but not defined")
+    /// or ignores it and launches the TUI, which dies opening /dev/tty
+    /// under a GUI parent ("could not open a new TTY", #35). Both mean
+    /// the same thing for us: the user must upgrade mole. Pure → tested.
+    static func indicatesMissingJSONSupport(stderr: String) -> Bool {
+        stderr.contains("could not open a new TTY")
+            || stderr.contains("flag provided but not defined")
     }
 
     // MARK: - Parsing

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -638,6 +638,12 @@ struct ToolCatalog {
         // 300 s like DiskScanner — analyze on a home dir can take a while.
         let res = Self.runMo(["analyze", "--json", path], timeout: 300)
         guard res.exitCode == 0 else {
+            if DiskScanner.indicatesMissingJSONSupport(stderr: res.stderr) {
+                return Self.jsonString([
+                    "error": "installed mole is too old for `analyze --json` " +
+                             "(needs >= \(MoleCLI.minimumAnalyzeJSONVersion)); run `brew upgrade mole`",
+                    "path": path])
+            }
             return Self.jsonString(["error": "mo analyze failed",
                                     "path": path,
                                     "stderr": Self.stripANSI(res.stderr)])

--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -78,6 +78,12 @@ enum MoleCLI {
         return nil
     }
 
+    /// Oldest Mole whose `analyze` knows `--json` (added in V1.29.0,
+    /// explicitly "for non-TTY environments"). Older versions launch the
+    /// TUI instead, which opens /dev/tty and dies when the parent is a
+    /// GUI app with no controlling terminal (#35).
+    static let minimumAnalyzeJSONVersion = "1.29.0"
+
     /// Modal alert shown at launch when `mo` isn't installed. We block on
     /// it because there's nothing useful Burrow can do without Mole, and a
     /// background app silently failing is the worst possible UX for this

--- a/Tests/DiskScannerTests.swift
+++ b/Tests/DiskScannerTests.swift
@@ -1,0 +1,45 @@
+//
+//  DiskScannerTests.swift
+//  BurrowTests
+//
+//  The old-mole classifier behind #35: a pre-1.29 `mo` has no
+//  `analyze --json`, so from a GUI parent it either rejects the flag or
+//  launches its TUI and dies opening /dev/tty. Burrow must turn both
+//  stderr shapes into the actionable "upgrade mole" error instead of
+//  surfacing the raw TTY message.
+//
+
+import XCTest
+@testable import Burrow
+
+final class DiskScannerTests: XCTestCase {
+    func testClassifier_matchesDevTTYFailure() {
+        // Verbatim stderr from the #35 report.
+        let stderr = "analyzer error: could not open a new TTY: open /dev/tty: device not configured"
+        XCTAssertTrue(DiskScanner.indicatesMissingJSONSupport(stderr: stderr))
+    }
+
+    func testClassifier_matchesUnknownFlagFailure() {
+        // Go's flag package, for vintages that reject rather than ignore.
+        let stderr = "flag provided but not defined: -json\nUsage of analyze:"
+        XCTAssertTrue(DiskScanner.indicatesMissingJSONSupport(stderr: stderr))
+    }
+
+    func testClassifier_ignoresOrdinaryFailures() {
+        XCTAssertFalse(DiskScanner.indicatesMissingJSONSupport(stderr: "permission denied"))
+        XCTAssertFalse(DiskScanner.indicatesMissingJSONSupport(stderr: ""))
+    }
+
+    func testTooOldError_namesFloorAndFix() throws {
+        let msg = try XCTUnwrap(DiskScanError.moTooOld(found: "1.28.1").errorDescription)
+        XCTAssertTrue(msg.contains(MoleCLI.minimumAnalyzeJSONVersion))
+        XCTAssertTrue(msg.contains("1.28.1"))
+        XCTAssertTrue(msg.contains("brew upgrade mole"))
+    }
+
+    func testTooOldError_readableWithUnknownVersion() throws {
+        let msg = try XCTUnwrap(DiskScanError.moTooOld(found: nil).errorDescription)
+        XCTAssertTrue(msg.contains(MoleCLI.minimumAnalyzeJSONVersion))
+        XCTAssertFalse(msg.contains("%@"), "format placeholders must be resolved")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #35. The Analyze tab failed with a cryptic error when the installed `mo` predates **V1.29.0**:

```
mo analyze exited with code 1:
analyzer error: could not open a new TTY: open /dev/tty: device not configured
```

## Root cause

`mo analyze --json` (what Burrow's treemap and the MCP `burrow_analyze` tool run) was added in Mole V1.29.0, explicitly "for non-TTY environments" (tw93/Mole#533). Older moles take the TUI path instead, which opens `/dev/tty` — and a GUI-launched app has no controlling terminal, so that open fails with ENXIO ("device not configured"). It works in Terminal because the shell provides a tty, which is why the reporter couldn't reproduce it there.

Verified locally that current mole (1.42.0) runs `analyze --json` cleanly with **no** controlling terminal (spawned with `start_new_session`), so this can only fire on genuinely stale installs.

## Why not give the child a pty

Allocating a controlling terminal would let an old mole's TUI *start* — DiskScanner would then sit parsing escape codes until its 300 s timeout. The right outcome for an old mole is a fast, actionable failure, not a hang.

## Changes

- **DiskScanner**: pure classifier `indicatesMissingJSONSupport(stderr:)` matching both old-mole failure shapes (the `/dev/tty` error, and Go's "flag provided but not defined" for vintages that reject the flag), plus a new `moTooOld` error: *"Disk analysis needs Mole 1.29.0 or newer (you have X). Run `brew upgrade mole`, then try again."*
- **MCP**: `burrow_analyze` returns the same actionable message instead of raw stderr.
- **MoleCLI**: `minimumAnalyzeJSONVersion = "1.29.0"` floor constant used by both messages.
- **Tests**: new `DiskScannerTests` (5 cases, including the verbatim stderr from the report); DiskScannerTests + MoleCLITests green locally, zero build errors.

## Testing notes

The classifier and error copy are unit-tested against the exact reported stderr; the happy path is verified live against mole 1.42.0. Full end-to-end repro would need a pre-1.29 mole binary — not exercised.