### PR TITLE
fix(packaging): cask should allow macOS 14 and newer

### DIFF
--- a/packaging/burrow.rb
+++ b/packaging/burrow.rb
@@ -16,7 +16,7 @@ cask "burrow" do
   homepage "https://github.com/caezium/Burrow"
 
   depends_on formula: "mole"
-  depends_on macos: :sonoma
+  depends_on macos: ">= :sonoma"
 
   app "Burrow.app"
 

--- a/packaging/burrow.rb
+++ b/packaging/burrow.rb
@@ -16,7 +16,16 @@ cask "burrow" do
   homepage "https://github.com/caezium/Burrow"
 
   depends_on formula: "mole"
-  depends_on macos: ">= :sonoma"
+  # Homebrew 5.1.11 (May 2026) changed `depends_on macos: :sonoma` from
+  # "exactly Sonoma" to "Sonoma or newer" and deprecated the `">= :sonoma"`
+  # string form (a hard error under HOMEBREW_DEVELOPER). Branch so both old
+  # and new Homebrew get "macOS 14 or newer" with no warning.
+  # TODO: drop the legacy branch once pre-5.1.11 Homebrew is rare (~2027).
+  if Version.new(HOMEBREW_VERSION.split("-").first) >= Version.new("5.1.11")
+    depends_on macos: :sonoma
+  else
+    depends_on macos: ">= :sonoma"
+  end
 
   app "Burrow.app"
 


### PR DESCRIPTION
## Summary
Fixes #47 — `brew install --cask caezium/tap/burrow` failed on Sequoia/Tahoe with *"This software does not run on macOS versions other than Sonoma"*, contradicting the documented macOS 14+ requirement (deployment target is 14.0 in `project.yml`).

## Root cause
The reporter is on pre-5.1.11 Homebrew, where `depends_on macos: :sonoma` means **exactly Sonoma**. Homebrew 5.1.11 (May 2026, [Homebrew/brew@0e87cc8941](https://github.com/Homebrew/brew/commit/0e87cc8941)) flipped the bare-symbol form to mean **minimum version** and deprecated the `">= :sonoma"` string form — which now prints a "report this issue to the tap" warning for everyone and is a **hard load error** under `HOMEBREW_DEVELOPER`. So neither form alone serves both Homebrew eras.

## Fix
Version-gate the requirement in the cask:
```ruby
if Version.new(HOMEBREW_VERSION.split("-").first) >= Version.new("5.1.11")
  depends_on macos: :sonoma          # blessed form, means >= Sonoma
else
  depends_on macos: ">= :sonoma"     # correct + warning-free on old Homebrew
end
```
Drop the legacy branch once pre-5.1.11 Homebrew is rare (~2027).

## Already live in the tap
The same shim is applied to **both** casks in caezium/homebrew-tap (burrow [8c2a87a](https://github.com/caezium/homebrew-tap/commit/8c2a87a54d78b7ed7920dccae814f895155e13ba), wisp [09576f4](https://github.com/caezium/homebrew-tap/commit/09576f4847663a8403797b8d01889ba56768a797) — wisp had the deprecated string form), so installs are already unblocked; this PR keeps the template in sync. The release workflow only seds `version`/`sha256` into the tap cask, so the shim survives releases.

## Verification (on macOS 26 Tahoe, Homebrew 5.1.15)
- `brew readall caezium/tap` — clean, no deprecation warnings for either cask
- `brew ruby`: requirement evaluates as `comparator=">=" version=14 satisfied=true`
- `ruby -c` passes on all three edited files