### PR TITLE
ci: SHA-pin GitHub Actions at Node 24 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Pinned to a commit SHA, not a floating tag (supply-chain hygiene;
       # comment keeps the version legible).
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Select newest Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)" && xcodebuild -version

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,10 +29,13 @@ jobs:
       # Actions pinned to commit SHAs (not floating tags): a moved tag would
       # otherwise run unreviewed third-party code in a job that holds
       # pages:write + id-token:write. Trailing comment keeps the version legible.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs
+          # v4+ stopped uploading dotfiles by default; keep shipping
+          # docs/.nojekyll so the artifact matches what v3 uploaded.
+          include-hidden-files: true
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       # Pinned to a commit SHA, not a floating tag: this job holds
       # contents:write, the signing cert, and TAP_PAT, so a moved tag must
       # not be able to run new code here. Comment keeps the version legible.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Use the newest Xcode on the runner so xcodebuild can read the project
       # format xcodegen emits (Homebrew's xcodegen targets the latest Xcode).


### PR DESCRIPTION
## Summary
GitHub force-switches actions to Node.js 24 on **2026-06-16** and removes Node 20 from runners on 2026-09-16. All three workflows pinned actions at Node 20-era releases (the source of the CI warning annotations). This bumps every pin to the latest stable release, keeping the SHA-pin + version-comment convention:

| Action | Was | Now |
|---|---|---|
| actions/checkout (ci, release, deploy-pages) | `34e1148` v4 | `df4cb1c` v6.0.3 (node24) |
| actions/configure-pages | `983d773` v5 | `45bfe01` v6.0.0 (node24) |
| actions/upload-pages-artifact | `56afc60` v3 | `fc324d3` v5.0.0 (composite) |
| actions/deploy-pages | `d6db901` v4 | `cd2ce8f` v5.0.0 (node24) |

Each SHA was resolved from the official release tag via `gh api repos/<action>/git/ref/tags/<tag>` (annotated tags dereferenced to commits) and each `action.yml` verified to declare `using: node24`.

## One deliberate non-pin change
`upload-pages-artifact` **v4.0.0 stopped uploading dotfiles by default**, and the Pages artifact is built from `docs/`, which contains `docs/.nojekyll`. Added `include-hidden-files: true` so the deployed artifact stays byte-identical to what v3 ships today.

## Compatibility notes
- checkout v5+ needs runner ≥2.327.1 — GitHub-hosted runners always satisfy this.
- checkout v6 stores persisted credentials in a separate file; no workflow here relies on persisted credentials (release.yml uses `GITHUB_TOKEN`/`TAP_PAT` explicitly).
- configure-pages v6 + upload-pages-artifact v5 + deploy-pages v5 is the current matched set from GitHub's starter workflow.
- actionlint: clean apart from two pre-existing shellcheck notes in release.yml's scripts (unrelated).

## Verification
- This PR's own CI run exercises **checkout v6.0.3** end-to-end (ci.yml checks out + builds + tests).
- `deploy-pages.yml` triggers on changes to itself, so merging runs a real Pages deploy with the new pins — glance at the Actions tab after merging.
- `release.yml` is exercised at the next version tag.