### PR TITLE
ci(release): upload dSYMs to Sentry so crash/hang frames symbolicate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,35 @@ jobs:
             exit 1
           fi
 
+      # Symbolicate Sentry crash/hang reports. Without the dSYM, every event's
+      # Burrow frames arrive as <unknown> ("debug information file was
+      # missing") — exactly what made the 0.6.7 "App Hanging" reports show only
+      # system frames. Runs after the tag/version check so only a real
+      # release's symbols ship; skipped (with a warning) when no token is set,
+      # matching the sign/notarize steps.
+      - name: Upload dSYMs to Sentry — skipped if no token
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: henry-zhang-r7
+          SENTRY_PROJECT: burrow
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "::warning::No SENTRY_AUTH_TOKEN — skipping dSYM upload; Sentry frames for ${{ steps.build.outputs.version }} stay unsymbolicated."
+            exit 0
+          fi
+          DSYM="build_dist/Build/Products/Release/Burrow.app.dSYM"
+          if [ ! -d "$DSYM" ]; then
+            echo "::warning::No dSYM at $DSYM — nothing to upload (Release build didn't emit one?)."
+            exit 0
+          fi
+          # From Homebrew, consistent with the xcodegen install above — this
+          # job is SHA-pinned for Actions, so sentry-cli comes from brew rather
+          # than a piped remote installer.
+          brew install sentry-cli
+          # Debug symbols only (names + line maps); no --include-sources, so no
+          # source files are ever shipped to Sentry.
+          sentry-cli debug-files upload "$DSYM"
+
       - name: Code-sign (Developer ID) — skipped if no cert
         id: sign
         env:


### PR DESCRIPTION
## Why

Every Sentry event for 0.6.7 reports **"A required debug information file was missing"**, so all Burrow frames show as `<unknown>`. The 10 "App Hanging" reports only ever exposed *system* frames (`AttributeGraph`, `UnaryLayoutEngine`, `malloc`) — never the app function/view actually hanging. Root cause: `release.yml` never uploaded dSYMs.

## What

A post-build step (after the tag/version check, before signing) uploads `build_dist/Build/Products/Release/Burrow.app.dSYM` to Sentry via `sentry-cli debug-files upload`.

- **Skipped with a warning** when `SENTRY_AUTH_TOKEN` is absent — same pattern as the sign/notarize steps, so releases never break on a missing secret.
- **Debug symbols only** — no `--include-sources`, so no source files are shipped to Sentry (consistent with the privacy posture in TELEMETRY.md).
- `sentry-cli` comes from Homebrew (this job pins Actions to SHAs; brew matches the existing `xcodegen` install rather than a piped remote installer).

## One-time setup required

Add a repo secret **`SENTRY_AUTH_TOKEN`** — a Sentry **org auth token** (Settings → Auth Tokens) scoped `project:releases` + `project:write` for org `henry-zhang-r7`, project `burrow`. Until it's added, the step no-ops with a warning.

> Note: this symbolicates **future** releases (0.6.8+). It can't retroactively fix the existing 0.6.7 events (their build's dSYM isn't archived, and a rebuild wouldn't produce a matching Debug ID).

Validated with `actionlint` (clean; only pre-existing warnings elsewhere in the file).