### PR TITLE
release: 0.7.0 — redesign polish, history/GPU fixes, notifications, FDA relaunch

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.7</string>
+	<string>0.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSDesktopFolderUsageDescription</key>

--- a/Sources/AnalyzeView.swift
+++ b/Sources/AnalyzeView.swift
@@ -2,11 +2,11 @@
 //  AnalyzeView.swift
 //  Burrow
 //
-//  The Analyze tab — Burrow's take on mole.fit's "Jupiter" disk map.
-//  A squarified treemap of a directory (via `mo analyze --json`, the
-//  existing DiskScanner + Treemap engine), a left rail of the biggest
-//  children, a breadcrumb, and drill-in by click. Reveal / Trash live
-//  in each block's context menu.
+//  The Analyze tab — an interactive disk-usage map. A squarified
+//  treemap of a directory (via `mo analyze --json`, the existing
+//  DiskScanner + Treemap engine), a left rail of the biggest children,
+//  a breadcrumb, and drill-in by click. Reveal / Trash live in each
+//  block's context menu.
 //
 
 import SwiftUI

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -21,6 +21,7 @@
 
 import Cocoa
 import SwiftUI
+import UserNotifications
 
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// Singleton handle so SwiftUI views can reach the live
@@ -125,6 +126,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let maintenance = Maintenance(db: db)
         self.maintenance = maintenance
         maintenance.start()
+
+        // Completion notices + opt-in smart reminders. The delegate must
+        // be set before any notification is delivered or clicked;
+        // authorization is requested lazily by the first actual post
+        // (BurrowNotifier), never here at launch. (Main-actor hop: the
+        // notifier is @MainActor, this delegate callback isn't.)
+        Task { @MainActor in
+            UNUserNotificationCenter.current().delegate = BurrowNotifier.shared
+            BurrowNotifier.shared.startReminders()
+        }
 
         if Store.showMenuBarIcon {
             self.statusBar = StatusBarController(db: db, producer: producer, delegate: self)
@@ -302,6 +313,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         self.installMainContent(into: window, initial: initial)
         wc.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    /// Bring Burrow forward without forcing a pane switch — notification
+    /// clicks land here so a completion notice doesn't navigate away from
+    /// the finished run's receipt. Reopens the main window only when
+    /// nothing is visible.
+    @available(macOS 14.0, *)
+    func bringForward() {
+        if mainWC?.window?.isVisible == true {
+            NSApp.setActivationPolicy(.regular)
+            mainWC?.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        } else {
+            openMainWindow(initial: .home)
+        }
     }
 
     @available(macOS 14.0, *)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -183,6 +183,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
+    /// Settings ▸ General ▸ "Replay onboarding": clear the seen flag and
+    /// present the slides again right away — the same window path as first
+    /// run, so finishing them re-sets the flag and lands on Home.
+    @available(macOS 14, *)
+    func replayOnboarding() {
+        Store.onboardingCompleted = false
+        if let wc = onboardingWC {
+            wc.showWindow(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        showOnboardingWindow()
+    }
+
     /// First-run onboarding window: plain chrome, traffic lights only.
     /// Finishing marks onboarding complete and opens the main window.
     @available(macOS 14, *)

--- a/Sources/Brand.swift
+++ b/Sources/Brand.swift
@@ -2,10 +2,10 @@
 //  Brand.swift
 //  Burrow
 //
-//  Burrow's own visual language — built to match mole.fit's *experience*
+//  Burrow's own visual language — a polished native experience
 //  (translucent window, glass cards, monospaced numerics, per-tool
-//  colour) while staying our own brand: our palette, our marks, our
-//  copy. This is deliberately separate from the legacy `Theme` enum so
+//  colour) with our own palette, our marks, our copy. This is
+//  deliberately separate from the legacy `Theme` enum so
 //  the redesign can land without disturbing the older views that still
 //  reference `Theme.*`.
 //

--- a/Sources/CleanView.swift
+++ b/Sources/CleanView.swift
@@ -258,7 +258,8 @@ struct CleanView: View {
         }
         screen = .hero
         realFlow.start(.moleStream(["clean"], elevated: true,
-                                   label: NSLocalizedString("Cleaning caches", comment: "")))
+                                   label: NSLocalizedString("Cleaning caches", comment: ""),
+                                   notifyOnEnd: true))
         // Restore is owned by the RUN, not the view: this watcher ends the
         // fenced session however the flow finishes, even if the user
         // navigates away mid-clean (a view-attached onChange would never
@@ -289,7 +290,8 @@ struct CleanView: View {
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         screen = .hero
         realFlow.start(.moleStream(["clean"], elevated: true,
-                                   label: NSLocalizedString("Cleaning caches", comment: "")))
+                                   label: NSLocalizedString("Cleaning caches", comment: ""),
+                                   notifyOnEnd: true))
     }
 
     // MARK: - Trash mode
@@ -314,7 +316,8 @@ struct CleanView: View {
 
         screen = .hero
         let opID = UUID()
-        OperationCenter.shared.begin(opID, label: NSLocalizedString("Moving caches to Trash", comment: ""))
+        OperationCenter.shared.begin(opID, label: NSLocalizedString("Moving caches to Trash", comment: ""),
+                                     notifiesOnEnd: true)
         DispatchQueue.global(qos: .userInitiated).async {
             var moved = 0, failed = 0
             for path in paths {
@@ -359,7 +362,7 @@ struct CleanView: View {
             Rectangle().fill(Brand.hairline).frame(height: 1)
             if case .finished(.done) = realFlow.state {
                 DoneBanner(accent: Tool.clean.accent, title: "Cleaned",
-                           detail: realFlow.report?.summary.map(cleanedDetail))
+                           detail: realFlow.report?.summary.map(\.completionLine))
             }
             TaskReportView(groups: realFlow.report?.groups ?? [], accent: Tool.clean.accent)
         }
@@ -378,17 +381,8 @@ struct CleanView: View {
         }
     }
 
-    /// Post-run detail line. Prefers the real freed-space numbers Mole
-    /// prints after a live clean ("Free space change / now"), falling
-    /// back to the tracked-cleanup size when those aren't present.
-    private func cleanedDetail(_ s: TaskSummary) -> String {
-        var parts: [String] = []
-        if !s.freeChange.isEmpty { parts.append(String(format: NSLocalizedString("Freed %@", comment: ""), s.freeChange)) }
-        else if !s.space.isEmpty { parts.append(String(format: NSLocalizedString("Cleaned %@", comment: ""), s.space)) }
-        if !s.freeNow.isEmpty { parts.append(String(format: NSLocalizedString("%@ free now", comment: ""), s.freeNow)) }
-        if !s.items.isEmpty { parts.append(String(format: NSLocalizedString("%@ items", comment: ""), s.items)) }
-        return parts.isEmpty ? NSLocalizedString("Done", comment: "") : parts.joined(separator: " · ")
-    }
+    // (The post-run detail line lives on TaskSummary.completionLine —
+    // shared with the completion notification.)
 
     // MARK: - Dry-run plumbing
 

--- a/Sources/Components/MiniChart.swift
+++ b/Sources/Components/MiniChart.swift
@@ -3,7 +3,7 @@
 //  Burrow / Components
 //
 //  Inline sparkline with two looks: `.area` (filled gradient under a
-//  line — memory, network, gpu) and `.bars` (discrete columns — CPU).
+//  line — memory, network, fan) and `.bars` (discrete columns — CPU, GPU).
 //  No axes, no labels: just the recent shape of a number. Pure `Path`
 //  rendering so it stays crisp at ~30 px tall where SwiftUI Charts'
 //  margins would eat everything.

--- a/Sources/Components/PermissionRow.swift
+++ b/Sources/Components/PermissionRow.swift
@@ -17,6 +17,11 @@ struct PermissionRow: View {
     let granted: Bool
     var onOpenSettings: () -> Void
     var onCheck: () -> Void
+    /// When non-nil, the permission was granted *after* this process
+    /// started, so the running app can't use it until relaunch (macOS
+    /// prompts the same way). Surfaces a "Relaunch" button beside the
+    /// granted chip.
+    var onRelaunch: (() -> Void)? = nil
 
     var body: some View {
         HStack(spacing: 12) {
@@ -27,12 +32,17 @@ struct PermissionRow: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(title)
                     .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
-                Text(benefit)
-                    .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                Text(onRelaunch != nil
+                     ? NSLocalizedString("Granted — relaunch Burrow to start using it.", comment: "")
+                     : benefit)
+                    .font(Brand.sans(11))
+                    .foregroundStyle(onRelaunch != nil ? Brand.amber : Brand.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer(minLength: 12)
-            if granted {
+            if let onRelaunch {
+                secondaryButton(NSLocalizedString("Relaunch", comment: ""), action: onRelaunch)
+            } else if granted {
                 Chip(text: NSLocalizedString("Granted", comment: ""), color: Brand.green)
             } else {
                 HStack(spacing: 8) {

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -322,7 +322,11 @@ struct HistoryView: View {
                                 // point, hence no bar — never a fill drawn
                                 // across a hole in the data.
                                 ForEach(s.points) { p in
-                                    BarMark(x: .value("Time", p.time), y: .value("Value", p.value))
+                                    // .ratio keeps a clear gap between bars at
+                                    // any range/point-count, so a wide history
+                                    // card reads as bars, not a filled block.
+                                    BarMark(x: .value("Time", p.time), y: .value("Value", p.value),
+                                            width: .ratio(0.6))
                                         .foregroundStyle(s.color.opacity(0.85))
                                 }
                             } else {

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -2,9 +2,9 @@
 //  HistoryView.swift
 //  Burrow
 //
-//  History window (Burrow's own value-add over mole.fit): long-range
-//  charts over the SQLite history, plus a peak-per-process table. Opened
-//  from the HUD's clock button.
+//  History window (Burrow's own long-range value-add): charts over the
+//  SQLite history, plus a peak-per-process table. Opened from the HUD's
+//  clock button.
 //
 //  Data path is unchanged from the original: range chip → DB.findRange
 //  Sampled (stride-sampled, ≤720 rows) → decode each row to MoleStatus →
@@ -225,11 +225,11 @@ struct HistoryView: View {
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 ScrollView {
                     LazyVGrid(columns: [GridItem(.flexible(), spacing: 13), GridItem(.flexible(), spacing: 13)], spacing: 13) {
-                        chartCard("CPU usage", "%", [("usage", snapshot.cpuUsage, Brand.green)])
+                        chartCard("CPU usage", "%", [("usage", snapshot.cpuUsage, Brand.green)], marks: .bars)
                         chartCard("CPU load", "1m avg", [("load1", snapshot.cpuLoad1, Brand.orange)])
                         chartCard("Memory", snapshot.memoryPressure.isEmpty ? "% used" : snapshot.memoryPressure,
                                   [("used", snapshot.memoryUsed, Brand.amber)])
-                        chartCard("GPU usage", "%", [("gpu", snapshot.gpuUsage, Brand.orange)])
+                        chartCard("GPU usage", "%", [("gpu", snapshot.gpuUsage, Brand.orange)], marks: .bars)
                         chartCard("Disk I/O", "MB/s", [("read", snapshot.diskRead, Brand.blue),
                                                        ("write", snapshot.diskWrite, Color(hex: 0x6E8BEA))])
                         chartCard("Network", "MB/s", [("rx", snapshot.netRx, Brand.green),
@@ -240,7 +240,7 @@ struct HistoryView: View {
                         chartCard("Fans", snapshot.fanCount > 0 ? "RPM" : "not reported",
                                   [("fan", snapshot.fanSpeed, Color(hex: 0x6EC1E4))])
                         chartCard("Battery", "%", [("charge", snapshot.batteryPercent, Brand.green)])
-                        chartCard("Health score", "0–100", [("health", snapshot.healthScore, Brand.gold)])
+                        chartCard("Health score", "0–100", [("health", snapshot.healthScore, Brand.gold)], marks: .bars)
                         topProcessesCard
                     }
                     .padding(16)
@@ -291,8 +291,13 @@ struct HistoryView: View {
         .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
+    /// How a chart card draws its series: continuous metrics stay lines,
+    /// discrete usage-style metrics (CPU / GPU / health) read as bars.
+    private enum ChartMarks { case line, bars }
+
     private func chartCard(_ title: String, _ subtitle: String,
-                           _ series: [(name: String, points: [ChartPoint], color: Color)]) -> some View {
+                           _ series: [(name: String, points: [ChartPoint], color: Color)],
+                           marks: ChartMarks = .line) -> some View {
         let allEmpty = series.allSatisfy { $0.points.isEmpty }
         let style = AxisStyle.forRangeMinutes(range.minutes)
         let window = Double(range.minutes * 60)
@@ -311,11 +316,22 @@ struct HistoryView: View {
                 } else {
                     Chart {
                         ForEach(series, id: \.name) { s in
-                            ForEach(HistorySegment.split(s.points, name: s.name, gap: gapThreshold)) { p in
-                                LineMark(x: .value("Time", p.time), y: .value("Value", p.value),
-                                         series: .value("Series", p.key))
-                                    .foregroundStyle(s.color)
-                                    .interpolationMethod(.monotone)
+                            if marks == .bars {
+                                // Bars keep the gap behaviour for free:
+                                // where Burrow wasn't sampling there is no
+                                // point, hence no bar — never a fill drawn
+                                // across a hole in the data.
+                                ForEach(s.points) { p in
+                                    BarMark(x: .value("Time", p.time), y: .value("Value", p.value))
+                                        .foregroundStyle(s.color.opacity(0.85))
+                                }
+                            } else {
+                                ForEach(HistorySegment.split(s.points, name: s.name, gap: gapThreshold)) { p in
+                                    LineMark(x: .value("Time", p.time), y: .value("Value", p.value),
+                                             series: .value("Series", p.key))
+                                        .foregroundStyle(s.color)
+                                        .interpolationMethod(.monotone)
+                                }
                             }
                         }
                     }

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -333,32 +333,39 @@ struct HistoryView: View {
                     // as a clean fraction of that slot. Axis labels map a few
                     // indices back to their real timestamps.
                     let pts = series.first?.points ?? []
-                    Chart {
-                        ForEach(series, id: \.name) { s in
-                            ForEach(Array(s.points.enumerated()), id: \.offset) { idx, p in
-                                BarMark(x: .value("Sample", Double(idx)), y: .value("Value", p.value),
-                                        width: .ratio(0.7))
-                                    .foregroundStyle(s.color.opacity(0.85))
-                            }
-                        }
-                    }
-                    .chartXScale(domain: -0.5 ... (Double(max(pts.count, 1)) - 0.5))
-                    .chartXAxis {
-                        AxisMarks(values: barAxisTicks(pts.count, desired: style.desiredCount)) { v in
-                            AxisGridLine().foregroundStyle(Brand.hairline)
-                            if let d = v.as(Double.self) {
-                                let i = Int(d.rounded())
-                                if i >= 0, i < pts.count {
-                                    AxisValueLabel { Text(pts[i].time, format: style.format) }
-                                        .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                    // Width is a real pixel value from the plot geometry —
+                    // .ratio never establishes a unit on this scale (the bars
+                    // vanished), and a fixed point width renders reliably and
+                    // scales with the sample count so it never overlaps.
+                    GeometryReader { geo in
+                        let barW = max(1.0, geo.size.width / CGFloat(max(pts.count, 1)) * 0.6)
+                        Chart {
+                            ForEach(series, id: \.name) { s in
+                                ForEach(Array(s.points.enumerated()), id: \.offset) { idx, p in
+                                    BarMark(x: .value("Sample", Double(idx)), y: .value("Value", p.value),
+                                            width: .fixed(barW))
+                                        .foregroundStyle(s.color.opacity(0.85))
                                 }
                             }
                         }
-                    }
-                    .chartYAxis {
-                        AxisMarks { _ in
-                            AxisGridLine().foregroundStyle(Brand.hairline)
-                            AxisValueLabel().foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                        .chartXScale(domain: -0.5 ... (Double(max(pts.count, 1)) - 0.5))
+                        .chartXAxis {
+                            AxisMarks(values: barAxisTicks(pts.count, desired: style.desiredCount)) { v in
+                                AxisGridLine().foregroundStyle(Brand.hairline)
+                                if let d = v.as(Double.self) {
+                                    let i = Int(d.rounded())
+                                    if i >= 0, i < pts.count {
+                                        AxisValueLabel { Text(pts[i].time, format: style.format) }
+                                            .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                                    }
+                                }
+                            }
+                        }
+                        .chartYAxis {
+                            AxisMarks { _ in
+                                AxisGridLine().foregroundStyle(Brand.hairline)
+                                AxisValueLabel().foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                            }
                         }
                     }
                     .frame(height: 170)

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -295,6 +295,16 @@ struct HistoryView: View {
     /// discrete usage-style metrics (CPU / GPU / health) read as bars.
     private enum ChartMarks { case line, bars }
 
+    /// Fixed bar width for a bars card, scaled to the point count: fat when
+    /// a short range holds a handful of samples, thin when a long range
+    /// packs hundreds. (Computed against the card's typical plot width;
+    /// the clamp keeps it sane if the real width differs.)
+    private func barWidth(for count: Int) -> CGFloat {
+        let typicalPlotWidth = 360.0
+        let slot = typicalPlotWidth / Double(max(count, 1))
+        return CGFloat(max(2.0, min(14.0, slot * 0.66)))
+    }
+
     private func chartCard(_ title: String, _ subtitle: String,
                            _ series: [(name: String, points: [ChartPoint], color: Color)],
                            marks: ChartMarks = .line) -> some View {
@@ -322,11 +332,15 @@ struct HistoryView: View {
                                 // point, hence no bar — never a fill drawn
                                 // across a hole in the data.
                                 ForEach(s.points) { p in
-                                    // .ratio keeps a clear gap between bars at
-                                    // any range/point-count, so a wide history
-                                    // card reads as bars, not a filled block.
+                                    // BarMark sits on a CONTINUOUS time axis
+                                    // (chartXScale domain) with no implicit
+                                    // category step, so .ratio collapses to
+                                    // nothing and the default fills the gap to
+                                    // the next bar ("too wide"). A fixed width
+                                    // scaled to the point count stays bar-shaped
+                                    // and thin across every range.
                                     BarMark(x: .value("Time", p.time), y: .value("Value", p.value),
-                                            width: .ratio(0.6))
+                                            width: .fixed(barWidth(for: s.points.count)))
                                         .foregroundStyle(s.color.opacity(0.85))
                                 }
                             } else {

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -295,14 +295,12 @@ struct HistoryView: View {
     /// discrete usage-style metrics (CPU / GPU / health) read as bars.
     private enum ChartMarks { case line, bars }
 
-    /// Fixed bar width for a bars card, scaled to the point count: fat when
-    /// a short range holds a handful of samples, thin when a long range
-    /// packs hundreds. (Computed against the card's typical plot width;
-    /// the clamp keeps it sane if the real width differs.)
-    private func barWidth(for count: Int) -> CGFloat {
-        let typicalPlotWidth = 360.0
-        let slot = typicalPlotWidth / Double(max(count, 1))
-        return CGFloat(max(2.0, min(14.0, slot * 0.66)))
+    /// Evenly spaced sample indices to label on a by-index bar axis — maps
+    /// back to real timestamps for the labels without distorting the bars.
+    private func barAxisTicks(_ count: Int, desired: Int) -> [Int] {
+        guard count > 1 else { return count == 1 ? [0] : [] }
+        let n = max(2, min(desired, count))
+        return (0..<n).map { Int((Double($0) * Double(count - 1) / Double(n - 1)).rounded()) }
     }
 
     private func chartCard(_ title: String, _ subtitle: String,
@@ -323,33 +321,50 @@ struct HistoryView: View {
                     Text("No samples in this window")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
                         .frame(maxWidth: .infinity, minHeight: 170)
+                } else if marks == .bars {
+                    // Bars are plotted BY INDEX (like the Status sparklines):
+                    // each sample gets an equal slot, so width and gaps are
+                    // uniform at every range. On a continuous time axis the
+                    // bars bunched up where samples clustered and stretched
+                    // where they were sparse — index spacing fixes both. An
+                    // integer x has a unit step of 1, so .ratio sizes the bar
+                    // as a clean fraction of that slot. Axis labels map a few
+                    // indices back to their real timestamps.
+                    let pts = series.first?.points ?? []
+                    Chart {
+                        ForEach(series, id: \.name) { s in
+                            ForEach(Array(s.points.enumerated()), id: \.offset) { idx, p in
+                                BarMark(x: .value("Sample", idx), y: .value("Value", p.value),
+                                        width: .ratio(0.7))
+                                    .foregroundStyle(s.color.opacity(0.85))
+                            }
+                        }
+                    }
+                    .chartXScale(domain: -0.5 ... (Double(max(pts.count, 1)) - 0.5))
+                    .chartXAxis {
+                        AxisMarks(values: barAxisTicks(pts.count, desired: style.desiredCount)) { v in
+                            AxisGridLine().foregroundStyle(Brand.hairline)
+                            if let i = v.as(Int.self), i >= 0, i < pts.count {
+                                AxisValueLabel { Text(pts[i].time, format: style.format) }
+                                    .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                            }
+                        }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Brand.hairline)
+                            AxisValueLabel().foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                        }
+                    }
+                    .frame(height: 170)
                 } else {
                     Chart {
                         ForEach(series, id: \.name) { s in
-                            if marks == .bars {
-                                // Bars keep the gap behaviour for free:
-                                // where Burrow wasn't sampling there is no
-                                // point, hence no bar — never a fill drawn
-                                // across a hole in the data.
-                                ForEach(s.points) { p in
-                                    // BarMark sits on a CONTINUOUS time axis
-                                    // (chartXScale domain) with no implicit
-                                    // category step, so .ratio collapses to
-                                    // nothing and the default fills the gap to
-                                    // the next bar ("too wide"). A fixed width
-                                    // scaled to the point count stays bar-shaped
-                                    // and thin across every range.
-                                    BarMark(x: .value("Time", p.time), y: .value("Value", p.value),
-                                            width: .fixed(barWidth(for: s.points.count)))
-                                        .foregroundStyle(s.color.opacity(0.85))
-                                }
-                            } else {
-                                ForEach(HistorySegment.split(s.points, name: s.name, gap: gapThreshold)) { p in
-                                    LineMark(x: .value("Time", p.time), y: .value("Value", p.value),
-                                             series: .value("Series", p.key))
-                                        .foregroundStyle(s.color)
-                                        .interpolationMethod(.monotone)
-                                }
+                            ForEach(HistorySegment.split(s.points, name: s.name, gap: gapThreshold)) { p in
+                                LineMark(x: .value("Time", p.time), y: .value("Value", p.value),
+                                         series: .value("Series", p.key))
+                                    .foregroundStyle(s.color)
+                                    .interpolationMethod(.monotone)
                             }
                         }
                     }

--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -297,10 +297,12 @@ struct HistoryView: View {
 
     /// Evenly spaced sample indices to label on a by-index bar axis — maps
     /// back to real timestamps for the labels without distorting the bars.
-    private func barAxisTicks(_ count: Int, desired: Int) -> [Int] {
+    /// Doubles so they match the bars' Double x-scale (an Int x on a Double
+    /// domain renders nothing).
+    private func barAxisTicks(_ count: Int, desired: Int) -> [Double] {
         guard count > 1 else { return count == 1 ? [0] : [] }
         let n = max(2, min(desired, count))
-        return (0..<n).map { Int((Double($0) * Double(count - 1) / Double(n - 1)).rounded()) }
+        return (0..<n).map { (Double($0) * Double(count - 1) / Double(n - 1)).rounded() }
     }
 
     private func chartCard(_ title: String, _ subtitle: String,
@@ -334,7 +336,7 @@ struct HistoryView: View {
                     Chart {
                         ForEach(series, id: \.name) { s in
                             ForEach(Array(s.points.enumerated()), id: \.offset) { idx, p in
-                                BarMark(x: .value("Sample", idx), y: .value("Value", p.value),
+                                BarMark(x: .value("Sample", Double(idx)), y: .value("Value", p.value),
                                         width: .ratio(0.7))
                                     .foregroundStyle(s.color.opacity(0.85))
                             }
@@ -344,9 +346,12 @@ struct HistoryView: View {
                     .chartXAxis {
                         AxisMarks(values: barAxisTicks(pts.count, desired: style.desiredCount)) { v in
                             AxisGridLine().foregroundStyle(Brand.hairline)
-                            if let i = v.as(Int.self), i >= 0, i < pts.count {
-                                AxisValueLabel { Text(pts[i].time, format: style.format) }
-                                    .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                            if let d = v.as(Double.self) {
+                                let i = Int(d.rounded())
+                                if i >= 0, i < pts.count {
+                                    AxisValueLabel { Text(pts[i].time, format: style.format) }
+                                        .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
+                                }
                             }
                         }
                     }

--- a/Sources/MetricsCore.swift
+++ b/Sources/MetricsCore.swift
@@ -60,10 +60,15 @@ enum SnapshotPatcher {
             changed = true
         }
 
-        // GPU usage — only when Mole reports it as unavailable (-1).
+        // GPU usage — fill from the native reading whenever Mole has no
+        // positive value. On Apple Silicon Mole can't read GPU% and reports
+        // 0 (not just -1), so a strict `< 0` test left every stored sample at
+        // 0 while the live tile showed the real figure. `<= 0` covers both;
+        // where Mole reports a real value (Intel) it's kept, and where the
+        // native reading is unavailable (`fill.gpu == nil`) nothing changes.
         if var gpus = root["gpu"] as? [[String: Any]], !gpus.isEmpty {
             let moUsage = (gpus[0]["usage"] as? NSNumber)?.doubleValue ?? -1
-            if moUsage < 0, let util = fill.gpu {
+            if moUsage <= 0, let util = fill.gpu {
                 gpus[0]["usage"] = util
                 root["gpu"] = gpus
                 changed = true

--- a/Sources/Notifications.swift
+++ b/Sources/Notifications.swift
@@ -121,11 +121,14 @@ final class BurrowNotifier: NSObject {
 
     // MARK: Completion notices
 
-    /// Called by OperationCenter.end for ops that opted in. Quiet when
-    /// the app is frontmost (the user is watching the run) or the
-    /// Settings toggle is off.
+    /// Called by OperationCenter.end for ops that opted in. Posts whenever
+    /// the Settings toggle is on — including while Burrow is frontmost: a
+    /// real clean can take minutes, the user often tabs away, and the
+    /// `willPresent` handler below lets the banner show even in-app. (The
+    /// background reminders still stay silent while active — those are
+    /// nudges, not results.)
     func operationCompleted(label: String, success: Bool, detail: String) {
-        guard !inert, Store.notifyOnCompletion, NSApp?.isActive != true else { return }
+        guard !inert, Store.notifyOnCompletion else { return }
         let content = UNMutableNotificationContent()
         content.title = String(format: success ? NSLocalizedString("%@ — done", comment: "notification title")
                                                : NSLocalizedString("%@ — failed", comment: "notification title"),
@@ -275,6 +278,15 @@ final class BurrowNotifier: NSObject {
 // MARK: - Click routing
 
 extension BurrowNotifier: UNUserNotificationCenterDelegate {
+    /// Show the banner even when Burrow is frontmost. Without this, macOS
+    /// silently drops foreground notifications — which is why completion
+    /// notices never appeared while the window was open.
+    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                            willPresent notification: UNNotification,
+                                            withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .list, .sound])
+    }
+
     /// A click brings Burrow forward; reminders that name a tool land on
     /// it (the clean nudges open Clean). Completions don't force a pane —
     /// the finished run's receipt is already on whichever tab ran it.

--- a/Sources/Notifications.swift
+++ b/Sources/Notifications.swift
@@ -255,21 +255,48 @@ final class BurrowNotifier: NSObject {
         post(content, id: id)
     }
 
-    /// Deliver, requesting authorization lazily on the very first post.
-    /// Denied = stay silent forever; the OS owns that choice.
+    /// Ask for notification permission up front — called when a notifying
+    /// operation STARTS, so the grant is settled before the run finishes
+    /// (requesting only at completion races a closed window). Logged so a
+    /// denial, or an unsigned-build registration failure, is visible in
+    /// Console (`log stream --predicate 'eventMessage CONTAINS "Burrow.notify"'`).
+    func prepareAuthorization() {
+        guard !inert else { return }
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+                    if let error {
+                        NSLog("Burrow.notify: authorization request failed: \(error.localizedDescription)")
+                    } else {
+                        NSLog("Burrow.notify: notification permission \(granted ? "granted" : "declined")")
+                    }
+                }
+            case .denied:
+                NSLog("Burrow.notify: notifications are OFF in System Settings ▸ Notifications ▸ Burrow")
+            default:
+                break
+            }
+        }
+    }
+
+    /// Deliver. Authorization is normally already settled by
+    /// `prepareAuthorization()`; this still requests lazily as a fallback.
     private nonisolated func post(_ content: UNMutableNotificationContent, id: String) {
         let center = UNUserNotificationCenter.current()
         center.getNotificationSettings { settings in
             let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
             switch settings.authorizationStatus {
             case .notDetermined:
-                center.requestAuthorization(options: [.alert]) { granted, _ in
+                center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+                    if let error { NSLog("Burrow.notify: auth failed: \(error.localizedDescription)") }
                     if granted { center.add(request) }
                 }
             case .denied:
-                break
+                NSLog("Burrow.notify: suppressed — notifications denied for Burrow")
             default:
-                center.add(request)
+                center.add(request) { if let e = $0 { NSLog("Burrow.notify: add failed: \(e.localizedDescription)") } }
             }
         }
     }

--- a/Sources/Notifications.swift
+++ b/Sources/Notifications.swift
@@ -1,0 +1,296 @@
+//
+//  Notifications.swift
+//  Burrow
+//
+//  User notifications, two kinds:
+//
+//    * Completion notices — a long operation (real clean, optimize,
+//      uninstall) finished while Burrow wasn't frontmost. Posted by
+//      OperationCenter.end for ops that opted in, carrying the parsed
+//      result (freed bytes etc.) as the body. ON by default; Settings ▸
+//      General ▸ Notifications turns them off.
+//
+//    * Smart reminders — opt-in, throttled nudges modeled on the canon
+//      polished cleaner apps ship (a "Trash exceeds N GB" notice, a
+//      low-disk-space alert, periodic cleanup reminders): your last
+//      clean was weeks ago, free space crossed under 10%, the Trash is
+//      holding gigabytes. OFF by default, at most one notice per rule
+//      per week (reviewers pan chatty cleaners — throttling is the
+//      feature), and never while the app is frontmost.
+//
+//  UNUserNotificationCenter authorization is requested lazily by the
+//  first actual post — launching Burrow never prompts. The whole class
+//  is inert under XCTest (TEST_HOST shell).
+//
+
+import AppKit
+import UserNotifications
+
+// MARK: - Pure reminder rules (unit-tested)
+
+enum ReminderRules {
+    /// Free-space fraction that trips the low-disk notice…
+    static let diskLowFraction = 0.10
+    /// …and the higher fraction that re-arms it (hysteresis: a disk
+    /// hovering at the threshold must not flap).
+    static let diskRecoverFraction = 0.12
+    /// Trash size that trips the full-Trash notice.
+    static let trashThresholdBytes: Int64 = 5 << 30   // 5 GiB
+    /// Days without a completed clean before the cadence nudge speaks.
+    static let cleanLapseDays = 14
+    /// Hard per-rule cooldown: nothing repeats more than weekly.
+    static let repeatCooldownDays = 7
+
+    struct Decision: Equatable {
+        let notify: Bool
+        /// Persisted back as the rule's hysteresis flag.
+        let nowActive: Bool
+    }
+
+    /// Low disk: one notice when free space crosses under the line,
+    /// re-armed only after it recovers past `diskRecoverFraction`.
+    static func diskLow(freeFraction: Double, active: Bool) -> Decision {
+        if freeFraction < diskLowFraction {
+            return Decision(notify: !active, nowActive: true)
+        }
+        if freeFraction >= diskRecoverFraction {
+            return Decision(notify: false, nowActive: false)
+        }
+        return Decision(notify: false, nowActive: active)   // hysteresis band
+    }
+
+    /// Full Trash: one notice when the size crosses the threshold,
+    /// re-armed once it shrinks below half (i.e. was emptied), with the
+    /// weekly cooldown on top.
+    static func trashFull(bytes: Int64, active: Bool, lastNotice: Date?, now: Date = Date()) -> Decision {
+        if bytes >= trashThresholdBytes {
+            guard !active else { return Decision(notify: false, nowActive: true) }
+            let cooled = lastNotice.map { now.timeIntervalSince($0) >= Double(repeatCooldownDays) * 86_400 } ?? true
+            return Decision(notify: cooled, nowActive: cooled)
+        }
+        if bytes < trashThresholdBytes / 2 {
+            return Decision(notify: false, nowActive: false)
+        }
+        return Decision(notify: false, nowActive: active)
+    }
+
+    /// Days since the last completed clean when a cadence reminder is
+    /// due, nil otherwise. Only speaks when a previous clean EXISTS —
+    /// "you haven't cleaned in N weeks" must never be invented for a
+    /// Mac that simply never cleaned.
+    static func cleanLapsedDays(lastClean: Date?, lastNotice: Date?, now: Date = Date()) -> Int? {
+        guard let lastClean else { return nil }
+        let days = Int(now.timeIntervalSince(lastClean) / 86_400)
+        guard days >= cleanLapseDays else { return nil }
+        if let lastNotice, now.timeIntervalSince(lastNotice) < Double(repeatCooldownDays) * 86_400 {
+            return nil
+        }
+        return days
+    }
+
+    /// Most recent completed `clean` session from `mo history`.
+    /// `started_at` is "yyyy-MM-dd HH:mm:ss" in local time; rows that
+    /// don't parse contribute nothing (we never guess).
+    static func lastCompletedClean(_ sessions: [HistorySession]) -> Date? {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return sessions
+            .filter { $0.command == "clean" && $0.isComplete }
+            .compactMap { fmt.date(from: $0.startedAt) }
+            .max()
+    }
+}
+
+// MARK: - The notifier
+
+@MainActor
+final class BurrowNotifier: NSObject {
+    static let shared = BurrowNotifier()
+
+    /// Inert under XCTest: the TEST_HOST shell must never prompt for
+    /// notification permission or litter Notification Center.
+    private let inert = Foundation.ProcessInfo.processInfo
+        .environment["XCTestConfigurationFilePath"] != nil
+
+    private var reminderTimer: Timer?
+    /// `mo history` is spawned at most daily for the cadence rule.
+    private var lastHistoryProbeAt: Date?
+
+    private override init() { super.init() }
+
+    // MARK: Completion notices
+
+    /// Called by OperationCenter.end for ops that opted in. Quiet when
+    /// the app is frontmost (the user is watching the run) or the
+    /// Settings toggle is off.
+    func operationCompleted(label: String, success: Bool, detail: String) {
+        guard !inert, Store.notifyOnCompletion, NSApp?.isActive != true else { return }
+        let content = UNMutableNotificationContent()
+        content.title = String(format: success ? NSLocalizedString("%@ — done", comment: "notification title")
+                                               : NSLocalizedString("%@ — failed", comment: "notification title"),
+                               label)
+        content.body = detail.isEmpty
+            ? (success ? NSLocalizedString("Finished.", comment: "")
+                       : NSLocalizedString("Open Burrow for details.", comment: ""))
+            : detail
+        post(content, id: "burrow-op-\(UUID().uuidString)")
+    }
+
+    // MARK: Smart reminders
+
+    /// Started once from AppDelegate.startServices. Hourly sweep — each
+    /// rule throttles itself — plus a first pass a couple of minutes
+    /// after launch so a Mac that's already low on disk hears about it
+    /// today, not in an hour.
+    func startReminders() {
+        guard !inert, reminderTimer == nil else { return }
+        let timer = Timer(timeInterval: 3_600, repeats: true) { _ in
+            Task { @MainActor in BurrowNotifier.shared.checkReminders() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        reminderTimer = timer
+        DispatchQueue.main.asyncAfter(deadline: .now() + 120) { [weak self] in
+            self?.checkReminders()
+        }
+    }
+
+    func checkReminders() {
+        guard !inert, Store.smartRemindersEnabled else { return }
+        // Reminders are background nudges by definition — while the user
+        // is in the app the UI already says all of this.
+        guard NSApp?.isActive != true else { return }
+        let probeHistory = lastHistoryProbeAt.map { Date().timeIntervalSince($0) > 86_400 } ?? true
+        if probeHistory { lastHistoryProbeAt = Date() }
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let free = Self.freeDiskSpace()
+            let trashBytes = Self.trashSizeBytes()
+            let lastClean = probeHistory ? ReminderRules.lastCompletedClean(MoleHistory.load()) : nil
+            Task { @MainActor in
+                self?.evaluateReminders(free: free, trashBytes: trashBytes, lastClean: lastClean)
+            }
+        }
+    }
+
+    private func evaluateReminders(free: (fraction: Double, freeBytes: Int64)?,
+                                   trashBytes: Int64, lastClean: Date?) {
+        guard Store.smartRemindersEnabled else { return }
+
+        if let free {
+            let d = ReminderRules.diskLow(freeFraction: free.fraction, active: Store.diskLowNoticeActive)
+            Store.diskLowNoticeActive = d.nowActive
+            if d.notify {
+                postReminder(
+                    title: NSLocalizedString("Disk space is running low", comment: ""),
+                    body: String(format: NSLocalizedString("Only %@ free (%.0f%%). A clean can usually win some of it back.", comment: ""),
+                                 Fmt.bytes(free.freeBytes), free.fraction * 100),
+                    pane: "clean", id: "burrow-reminder-disk")
+            }
+        }
+
+        let t = ReminderRules.trashFull(bytes: trashBytes, active: Store.trashNoticeActive,
+                                        lastNotice: Store.lastTrashReminderAt)
+        Store.trashNoticeActive = t.nowActive
+        if t.notify {
+            Store.lastTrashReminderAt = Date()
+            postReminder(
+                title: String(format: NSLocalizedString("Your Trash is holding %@", comment: ""), Fmt.bytes(trashBytes)),
+                body: NSLocalizedString("Deleted files still take up disk space until the Trash is emptied.", comment: ""),
+                pane: nil, id: "burrow-reminder-trash")
+        }
+
+        if let days = ReminderRules.cleanLapsedDays(lastClean: lastClean,
+                                                    lastNotice: Store.lastCleanReminderAt) {
+            Store.lastCleanReminderAt = Date()
+            postReminder(
+                title: String(format: NSLocalizedString("It's been %d days since your last clean", comment: ""), days),
+                body: NSLocalizedString("Caches grow back on their own — a quick scan shows what's reclaimable.", comment: ""),
+                pane: "clean", id: "burrow-reminder-clean")
+        }
+    }
+
+    // MARK: Probes (off-main, best-effort)
+
+    /// Free fraction + bytes for the volume holding the user's home.
+    private nonisolated static func freeDiskSpace() -> (fraction: Double, freeBytes: Int64)? {
+        let home = URL(fileURLWithPath: NSHomeDirectory())
+        guard let vals = try? home.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey,
+                                                            .volumeTotalCapacityKey]),
+              let avail = vals.volumeAvailableCapacityForImportantUsage,
+              let total = vals.volumeTotalCapacity, total > 0 else { return nil }
+        return (Double(avail) / Double(total), avail)
+    }
+
+    /// Allocated size of the user's Trash. Without Full Disk Access
+    /// macOS hides ~/.Trash → enumeration yields nothing → 0 → no
+    /// reminder. We measure or stay silent; never guess.
+    private nonisolated static func trashSizeBytes() -> Int64 {
+        let fm = FileManager.default
+        let trash = (try? fm.url(for: .trashDirectory, in: .userDomainMask,
+                                 appropriateFor: nil, create: false))
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".Trash")
+        guard let enumerator = fm.enumerator(at: trash,
+                                             includingPropertiesForKeys: [.totalFileAllocatedSizeKey,
+                                                                          .fileAllocatedSizeKey],
+                                             options: [], errorHandler: { _, _ in true }) else { return 0 }
+        var total: Int64 = 0
+        for case let url as URL in enumerator {
+            guard let vals = try? url.resourceValues(forKeys: [.totalFileAllocatedSizeKey,
+                                                               .fileAllocatedSizeKey]) else { continue }
+            total += Int64(vals.totalFileAllocatedSize ?? vals.fileAllocatedSize ?? 0)
+        }
+        return total
+    }
+
+    // MARK: Delivery
+
+    private func postReminder(title: String, body: String, pane: String?, id: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        if let pane { content.userInfo = ["pane": pane] }
+        post(content, id: id)
+    }
+
+    /// Deliver, requesting authorization lazily on the very first post.
+    /// Denied = stay silent forever; the OS owns that choice.
+    private nonisolated func post(_ content: UNMutableNotificationContent, id: String) {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationSettings { settings in
+            let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
+            switch settings.authorizationStatus {
+            case .notDetermined:
+                center.requestAuthorization(options: [.alert]) { granted, _ in
+                    if granted { center.add(request) }
+                }
+            case .denied:
+                break
+            default:
+                center.add(request)
+            }
+        }
+    }
+}
+
+// MARK: - Click routing
+
+extension BurrowNotifier: UNUserNotificationCenterDelegate {
+    /// A click brings Burrow forward; reminders that name a tool land on
+    /// it (the clean nudges open Clean). Completions don't force a pane —
+    /// the finished run's receipt is already on whichever tab ran it.
+    nonisolated func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                            didReceive response: UNNotificationResponse,
+                                            withCompletionHandler completionHandler: @escaping () -> Void) {
+        let pane = response.notification.request.content.userInfo["pane"] as? String
+        Task { @MainActor in
+            if #available(macOS 14, *) {
+                if pane == "clean" {
+                    AppDelegate.shared?.openMainWindow(initial: .tool(.clean))
+                } else {
+                    AppDelegate.shared?.bringForward()
+                }
+            }
+            completionHandler()
+        }
+    }
+}

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -24,7 +24,11 @@ struct OnboardingView: View {
     @State private var page = 0
     @State private var fdaGranted = Privacy.hasFullDiskAccess()
     @State private var showRelaunchHint = false
+    /// Cleaning-engine status, probed off-main (nil = still checking).
+    @State private var engine: EngineStatus?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private struct EngineStatus { let installed: Bool; let version: String? }
 
     var body: some View {
         ZStack {
@@ -71,6 +75,7 @@ struct OnboardingView: View {
                 .padding(.top, 6)
 
             VStack(spacing: 10) {
+                engineRow
                 PermissionRow(
                     title: NSLocalizedString("Full Disk Access", comment: ""),
                     benefit: NSLocalizedString("Unlocks the caches and leftovers Burrow needs to reach.", comment: ""),
@@ -102,6 +107,59 @@ struct OnboardingView: View {
             }
             .padding(24)
         }
+        .task { await probeEngine() }
+    }
+
+    /// Engine status: confirms `mo` is installed and shows its version, so
+    /// the user can see the one dependency Burrow drives is in place. (A
+    /// truly missing engine is gated before onboarding by MoleInstallView;
+    /// this row is the reassuring confirmation, with an install link as a
+    /// belt-and-braces fallback.)
+    private var engineRow: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill((engine?.installed ?? false) ? Brand.green
+                      : (engine == nil ? Color.white.opacity(0.22) : Brand.amber))
+                .frame(width: 9, height: 9)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(NSLocalizedString("Cleaning engine", comment: ""))
+                    .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                Text(engineSubtitle)
+                    .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+            }
+            Spacer(minLength: 12)
+            if let engine, engine.installed {
+                Chip(text: engine.version.map { "v\($0)" } ?? NSLocalizedString("Installed", comment: ""),
+                     color: Brand.green)
+            } else if engine != nil {
+                Button(NSLocalizedString("Install", comment: "")) {
+                    NSWorkspace.shared.open(MoleCLI.repoURL)
+                }
+                .buttonStyle(.plain)
+                .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.amber)
+            } else {
+                ProgressView().controlSize(.small)
+            }
+        }
+        .padding(14)
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Brand.cardFill))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
+    }
+
+    private var engineSubtitle: String {
+        guard let engine else { return NSLocalizedString("Checking…", comment: "") }
+        return engine.installed
+            ? NSLocalizedString("Ready — Burrow drives it for every clean and scan.", comment: "")
+            : NSLocalizedString("Not found. Install it to enable cleaning.", comment: "")
+    }
+
+    /// Probe off the main actor — version() may spawn `mo --version`.
+    private func probeEngine() async {
+        let status: EngineStatus = await Task.detached(priority: .userInitiated) {
+            guard MoleCLI.findExecutable() != nil else { return EngineStatus(installed: false, version: nil) }
+            return EngineStatus(installed: true, version: MoleCLI.version())
+        }.value
+        engine = status
     }
 
     // MARK: - Slide 2 · free & open source

--- a/Sources/OperationCenter.swift
+++ b/Sources/OperationCenter.swift
@@ -23,19 +23,25 @@ final class OperationCenter: ObservableObject {
         var phase: Phase
         var detail: String
         var startedAt: Date
+        /// Post a user notification when this op ends — long,
+        /// user-initiated work only (real cleans / optimize /
+        /// uninstalls; never previews or scans).
+        var notifiesOnEnd: Bool = false
     }
 
     @Published private(set) var ops: [Op] = []
 
     var hasActivity: Bool { !ops.isEmpty }
 
-    func begin(_ id: UUID, label: String) {
+    func begin(_ id: UUID, label: String, notifiesOnEnd: Bool = false) {
         if let i = ops.firstIndex(where: { $0.id == id }) {
             ops[i].label = label
             ops[i].phase = .running
             ops[i].detail = ""
+            ops[i].notifiesOnEnd = notifiesOnEnd
         } else {
-            ops.insert(Op(id: id, label: label, phase: .running, detail: "", startedAt: Date()), at: 0)
+            ops.insert(Op(id: id, label: label, phase: .running, detail: "", startedAt: Date(),
+                          notifiesOnEnd: notifiesOnEnd), at: 0)
         }
         if ops.count > 6 { ops = Array(ops.prefix(6)) }
     }
@@ -51,6 +57,13 @@ final class OperationCenter: ObservableObject {
         guard let i = ops.firstIndex(where: { $0.id == id }) else { return }
         ops[i].phase = success ? .done : .failed
         if !detail.isEmpty { ops[i].detail = detail }
+        // Completion notice for opted-in ops (clean / optimize /
+        // uninstall). The notifier stays quiet when Burrow is frontmost
+        // or the Settings toggle is off.
+        if ops[i].notifiesOnEnd {
+            BurrowNotifier.shared.operationCompleted(label: ops[i].label, success: success,
+                                                     detail: ops[i].detail)
+        }
         DispatchQueue.main.asyncAfter(deadline: .now() + 22) { [weak self] in
             guard let self, let j = self.ops.firstIndex(where: { $0.id == id }) else { return }
             // The runner reuses its id across runs (dry-run → real run):

--- a/Sources/OperationCenter.swift
+++ b/Sources/OperationCenter.swift
@@ -44,6 +44,10 @@ final class OperationCenter: ObservableObject {
                           notifiesOnEnd: notifiesOnEnd), at: 0)
         }
         if ops.count > 6 { ops = Array(ops.prefix(6)) }
+        // Settle notification permission now, while the op runs, so the
+        // completion notice can fire the moment it ends (even if the window
+        // has been closed by then).
+        if notifiesOnEnd { BurrowNotifier.shared.prepareAuthorization() }
     }
 
     func detail(_ id: UUID, _ text: String) {

--- a/Sources/OperationFlow.swift
+++ b/Sources/OperationFlow.swift
@@ -126,6 +126,18 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
     private var currentElevated = false
     private var currentLabel: String?
     private var cancelRequested = false
+    /// One-shot per run: Burrow has already reclaimed focus from the auth
+    /// dialog, don't keep stealing it.
+    private var reactivated = false
+
+    /// Pull key focus back to Burrow after an elevated run's auth dialog
+    /// relinquished it elsewhere. No-op for un-elevated runs (no dialog) and
+    /// after the first call.
+    private func reactivateIfElevated(_ op: ToolOperation<Report>) {
+        guard op.elevated, !reactivated else { return }
+        reactivated = true
+        NSApp.activate(ignoringOtherApps: true)
+    }
 
     init(process: any ProcessPort = SystemProcessPort(),
          hasFullDiskAccess: @escaping () -> Bool = Privacy.hasFullDiskAccess,
@@ -165,6 +177,7 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         currentElevated = op.elevated
         currentLabel = op.label
         cancelRequested = false
+        reactivated = false
         if let label = op.label { center.begin(opID, label: label, notifiesOnEnd: op.notifyOnEnd) }
 
         let stream = process.events(spec)
@@ -175,6 +188,11 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
                 guard let self, !Task.isCancelled else { return }
                 switch event {
                 case .line(let l):
+                    // The macOS auth dialog (osascript) takes key focus and
+                    // hands it back to whatever, not us — so the first output
+                    // of an elevated run (auth just cleared) is the cue to pull
+                    // focus back to Burrow, instead of making the user ⌘-tab.
+                    self.reactivateIfElevated(op)
                     lines.append(l)
                     self.report = op.reduce(lines)
                     if op.label != nil, !l.trimmingCharacters(in: .whitespaces).isEmpty {
@@ -182,6 +200,7 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
                     }
                 case .exited(let code):
                     guard !self.cancelRequested else { return }
+                    self.reactivateIfElevated(op)   // backstop: no-output runs
                     self.report = op.reduce(lines)
                     if op.elevated, code != 0, lines.isEmpty {
                         // The auth prompt was dismissed — osascript exits

--- a/Sources/OperationFlow.swift
+++ b/Sources/OperationFlow.swift
@@ -63,6 +63,14 @@ struct ToolOperation<Report: Sendable> {
     /// Optional line → HUD detail mapping (clean/optimize use
     /// TaskReportText.line); nil shows the raw line.
     var hudLine: (@Sendable (String) -> String)? = nil
+    /// Post a user notification when this run finishes — real cleans /
+    /// optimize / uninstalls, never previews. The post itself lives in
+    /// OperationCenter.end → BurrowNotifier.
+    var notifyOnEnd: Bool = false
+    /// Final OperationCenter detail derived from the finished report —
+    /// the result line a completion notification carries (freed bytes
+    /// etc.). nil keeps the last streamed line.
+    var finalDetail: (@Sendable (Report) -> String)? = nil
 
     /// "Scan with admin": the same operation, elevated — root bypasses TCC
     /// so the gate no longer applies.
@@ -157,7 +165,7 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         currentElevated = op.elevated
         currentLabel = op.label
         cancelRequested = false
-        if let label = op.label { center.begin(opID, label: label) }
+        if let label = op.label { center.begin(opID, label: label, notifiesOnEnd: op.notifyOnEnd) }
 
         let stream = process.events(spec)
         let id = opID
@@ -182,7 +190,13 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
                         if op.label != nil { self.center.end(id, success: false) }
                     } else {
                         self.state = .finished(.done(exit: code))
-                        if op.label != nil { self.center.end(id, success: code == 0) }
+                        if op.label != nil {
+                            // Replace the last streamed line with the parsed
+                            // result line where the op provides one — that's
+                            // what a completion notification shows.
+                            let detail = self.report.map { op.finalDetail?($0) ?? "" } ?? ""
+                            self.center.end(id, success: code == 0, detail: detail)
+                        }
                     }
                 }
             }
@@ -211,12 +225,17 @@ typealias TaskRunReport = (groups: [TaskGroup], summary: TaskSummary?)
 
 extension ToolOperation where Report == TaskRunReport {
     /// A streaming `mo` run rendered through TaskReportView — the shape
-    /// clean and optimize share.
+    /// clean and optimize share. `notifyOnEnd` rides through to the
+    /// completion notification, with the parsed summary (freed bytes)
+    /// as the final detail line.
     static func moleStream(_ args: [String], gate: Gate = .none,
-                           elevated: Bool = false, label: String?) -> ToolOperation {
+                           elevated: Bool = false, label: String?,
+                           notifyOnEnd: Bool = false) -> ToolOperation {
         ToolOperation(label: label, arguments: args, gate: gate, elevated: elevated,
                       reduce: { parseTaskReport($0) },
-                      hudLine: { TaskReportText.line($0) })
+                      hudLine: { TaskReportText.line($0) },
+                      notifyOnEnd: notifyOnEnd,
+                      finalDetail: { $0.summary?.completionLine ?? "" })
     }
 }
 

--- a/Sources/OptimizeView.swift
+++ b/Sources/OptimizeView.swift
@@ -112,20 +112,33 @@ struct OptimizeView: View {
     }
 
     private func operation(_ args: [String], gate: ToolOperation<OptimizeReport>.Gate,
-                           elevated: Bool, label: String) -> ToolOperation<OptimizeReport> {
-        ToolOperation(label: label, arguments: args, gate: gate, elevated: elevated,
-                      reduce: { lines in
-                          let (groups, summary) = parseTaskReport(lines)
-                          return (groups, summary, TaskTicker.reduce(lines))
-                      },
-                      hudLine: { TaskReportText.line($0) })
+                           elevated: Bool, label: String,
+                           notify: Bool = false) -> ToolOperation<OptimizeReport> {
+        // Final detail = the figure the done-banner shows; previews keep
+        // the last streamed line instead ("refreshed" would be a lie for
+        // a dry run).
+        var finalDetail: (@Sendable (OptimizeReport) -> String)?
+        if notify {
+            finalDetail = { report in
+                String(format: NSLocalizedString("%d areas refreshed", comment: ""), report.groups.count)
+            }
+        }
+        return ToolOperation(label: label, arguments: args, gate: gate, elevated: elevated,
+                             reduce: { lines in
+                                 let (groups, summary) = parseTaskReport(lines)
+                                 return (groups, summary, TaskTicker.reduce(lines))
+                             },
+                             hudLine: { TaskReportText.line($0) },
+                             notifyOnEnd: notify,
+                             finalDetail: finalDetail)
     }
 
     /// Optimize already runs elevated (root) → no flood, no gate.
     private func runOptimize() {
         preview = false
         flow.start(operation(["optimize"], gate: .none, elevated: true,
-                             label: NSLocalizedString("Optimizing", comment: "")))
+                             label: NSLocalizedString("Optimizing", comment: ""),
+                             notify: true))
     }
 
     private func runPreview() {

--- a/Sources/PopupView.swift
+++ b/Sources/PopupView.swift
@@ -235,7 +235,7 @@ struct PopupView: View {
             ValueTile(variant: .hud, eyebrow: "GPU", glyph: "cpu.fill", accent: Brand.orange,
                       value: gpuValue(s).0, unit: gpuValue(s).1,
                       chip: (s.thermal?.gpuTemp).flatMap { $0 > 0 ? (String(format: "%.0f°C", $0), Brand.orange) : nil },
-                      values: model.gpuHist, chartStyle: .area,
+                      values: model.gpuHist, chartStyle: .bars,
                       footnote: (s.gpu?.first?.name ?? "GPU").replacingOccurrences(of: "Apple ", with: ""))
             ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: Brand.amber,
                       value: String(format: "%.0f", s.memory.usedPercent), unit: "%",

--- a/Sources/PopupView.swift
+++ b/Sources/PopupView.swift
@@ -279,7 +279,9 @@ struct PopupView: View {
         .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
-    /// FAN tile — read-only v1 (same rule as Status: no placebo buttons).
+    /// FAN tile — read-only v1 (same rule as Status: no placebo buttons,
+    /// and the RPM sparkline only exists when fans were detected; an
+    /// all-zero series means parked fans, which is real data).
     private func fanTile(_ s: MoleStatus) -> some View {
         let fanCount = s.thermal?.fanCount ?? 0
         let rpm = s.thermal?.fanSpeed ?? 0
@@ -295,6 +297,9 @@ struct PopupView: View {
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text(fanCount > 0 ? "\(rpm)" : "—").font(Brand.mono(15, .semibold)).foregroundStyle(Brand.textPrimary)
                 if fanCount > 0 { Text("RPM").font(Brand.mono(9)).foregroundStyle(Brand.textSecondary) }
+            }
+            if fanCount > 0 {
+                MiniChart(values: model.fanHist, color: PowerAccent.fan, style: .area).frame(height: 13)
             }
             Text(fanCount > 0 ? NSLocalizedString("macOS manages speed", comment: "")
                               : NSLocalizedString("No fan data", comment: ""))
@@ -566,6 +571,9 @@ final class HUDModel: ObservableObject {
     @Published var memHist: [Double] = []
     @Published var netHist: [Double] = []
     @Published var gpuHist: [Double] = []
+    /// Fan RPM series — kept only for snapshots that reported fans
+    /// (fanCount > 0); see the fan tile's rule.
+    @Published var fanHist: [Double] = []
     /// Heaviest process by average CPU over the last hour of samples.
     @Published var topDrain: (name: String, avgCPU: Double)?
     /// Lifetime cleanup totals from `mo history`; nil = not loaded or
@@ -640,6 +648,7 @@ final class HUDModel: ObservableObject {
     private func refreshHistory() {
         let now = Int(Date().timeIntervalSince1970)
         var cpu: [Double] = [], mem: [Double] = [], net: [Double] = [], gpu: [Double] = []
+        var fan: [Double] = []
         var processLists: [[ProcessInfo]] = []
         for stored in MetricsStore(db: db).snapshots(.init(since: now - 60 * 60, until: now), maxPoints: 60) {
             let s = stored.status
@@ -647,11 +656,15 @@ final class HUDModel: ObservableObject {
             mem.append(s.memory.usedPercent)
             net.append(s.network.reduce(0.0) { $0 + $1.rxRateMbs + $1.txRateMbs })
             gpu.append(max(0, s.gpu?.first?.usage ?? 0))
+            if let thermal = s.thermal, (thermal.fanCount ?? 0) > 0 {
+                fan.append(Double(thermal.fanSpeed))
+            }
             if let procs = s.topProcesses { processLists.append(procs) }
         }
         // Sparklines stay ~30 min; the drain ranking uses the full hour.
         cpuHist = Array(cpu.suffix(30)); memHist = Array(mem.suffix(30))
         netHist = Array(net.suffix(30)); gpuHist = Array(gpu.suffix(30))
+        fanHist = Array(fan.suffix(30))
         topDrain = TopDrain.heaviest(processLists)
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -214,6 +214,14 @@ struct SettingsView: View {
                 footnote("On: Burrow retreats to the menu bar when you close the window. Off: it stays in the Dock. With the menu-bar icon hidden, the Dock icon always stays — otherwise the app would be unreachable.")
                 toggleRow("Skip Intro Screens", isOn: $skipIntro) { Store.skipIntro = $0 }
                 footnote("Jumps past the tools' idle screens where a read-only preview can start right away (Clean starts its scan when you open the tab).")
+                HStack {
+                    Text(NSLocalizedString("Onboarding", comment: "")).font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
+                    Spacer()
+                    PillButton(title: "Replay onboarding", filled: false) {
+                        if #available(macOS 14, *) { AppDelegate.shared?.replayOnboarding() }
+                    }
+                }
+                footnote("Shows the first-run slides again (permissions, what's included). Finishing them marks onboarding done as usual.")
             }
 
             section("About", "info.circle") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -43,6 +43,10 @@ struct SettingsView: View {
 
     // General
     @State private var fdaGranted = Privacy.hasFullDiskAccess()
+    /// FDA state when Settings opened. The running process only gains FDA
+    /// on relaunch, so a false→true flip (the user granted it just now)
+    /// means a relaunch is needed before scans can reach protected caches.
+    private let fdaAtOpen = Privacy.hasFullDiskAccess()
     @State private var appLanguage: String = Store.appLanguage
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var hideDockIcon: Bool = Store.hideDockIcon
@@ -177,7 +181,11 @@ struct SettingsView: View {
                         : NSLocalizedString("Off. Safe scan in use — most system caches stay out of reach.", comment: ""),
                     granted: fdaGranted,
                     onOpenSettings: { Privacy.openFullDiskAccessSettings() },
-                    onCheck: { fdaGranted = Privacy.hasFullDiskAccess() })
+                    onCheck: { fdaGranted = Privacy.hasFullDiskAccess() },
+                    // Granted this session → macOS only hands FDA to a fresh
+                    // process, so offer a one-click relaunch instead of the
+                    // system's "quit it yourself" prompt.
+                    onRelaunch: (fdaGranted && !fdaAtOpen) ? { Privacy.relaunch() } : nil)
             }
 
             section("Language", "globe") {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -47,6 +47,8 @@ struct SettingsView: View {
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var hideDockIcon: Bool = Store.hideDockIcon
     @State private var skipIntro: Bool = Store.skipIntro
+    @State private var notifyOnCompletion: Bool = Store.notifyOnCompletion
+    @State private var smartReminders: Bool = Store.smartRemindersEnabled
 
     // Maintenance
     @State private var whitelistPatterns: [String] = []
@@ -222,6 +224,15 @@ struct SettingsView: View {
                     }
                 }
                 footnote("Shows the first-run slides again (permissions, what's included). Finishing them marks onboarding done as usual.")
+            }
+
+            section("Notifications", "bell.badge") {
+                toggleRow("Notify when long operations finish", isOn: $notifyOnCompletion) {
+                    Store.notifyOnCompletion = $0
+                }
+                footnote("Clean, Optimize and Uninstall post a notice with the result (e.g. space freed) when they finish while Burrow is in the background. macOS asks for notification permission the first time one fires.")
+                toggleRow("Smart reminders", isOn: $smartReminders) { Store.smartRemindersEnabled = $0 }
+                footnote("Occasional, throttled nudges: it's been a couple of weeks since your last clean, free disk space dropped under 10%, or the Trash is holding more than 5 GB. Each fires at most once a week, never while you're in the app. Off by default.")
             }
 
             section("About", "info.circle") {

--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -665,7 +665,8 @@ final class SoftwareModel: ObservableObject {
             return (app, paths)
         }
         let opId = UUID()
-        OperationCenter.shared.begin(opId, label: NSLocalizedString("Removing reviewed files", comment: ""))
+        OperationCenter.shared.begin(opId, label: NSLocalizedString("Removing reviewed files", comment: ""),
+                                     notifiesOnEnd: true)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             var moved = 0, failed = 0
             for (_, paths) in work {
@@ -692,7 +693,8 @@ final class SoftwareModel: ObservableObject {
         loading = true
         // Surface the run in the menu-bar HUD's Activity section too.
         let opId = UUID()
-        OperationCenter.shared.begin(opId, label: "Uninstalling \(targets.count) app\(targets.count == 1 ? "" : "s")")
+        OperationCenter.shared.begin(opId, label: "Uninstalling \(targets.count) app\(targets.count == 1 ? "" : "s")",
+                                     notifiesOnEnd: true)
         DispatchQueue.global(qos: .userInitiated).async {
             // Pre-flight (audit H4): mo does its own name matching, so before
             // answering any prompt, verify what it MATCHED equals what the

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -177,9 +177,9 @@ struct StatusView: View {
         return ValueTile(
             eyebrow: "Network", glyph: "network", accent: Brand.green,
             value: value, unit: unit, chip: chip,
-            // Tile sparkline = the recent 5 min of the 1 s ring; longer
+            // Tile sparkline = the recent 2 min of the 1 s ring; longer
             // windows live in the History tab (they flattened the tile).
-            values: useLive ? io.netHistory(lastSeconds: 300) : model.netHist, chartStyle: .area,
+            values: useLive ? io.netHistory(lastSeconds: 120) : model.netHist, chartStyle: .area,
             footnote: "↓ \(Fmt.rate(rx))  ↑ \(Fmt.rate(tx)) · \(snapNet?.name ?? "—") · \(snapNet?.ip ?? "—")")
     }
 }

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -494,7 +494,10 @@ struct ProcessCard: View {
                 header(count: rows.count)
                 Rectangle().fill(Brand.hairline).frame(height: 1)
                 // The table scrolls on its own, under a sticky header,
-                // independent of the page scroll (design 3.2).
+                // independent of the page scroll (design 3.2). Kept compact
+                // on purpose — ~6½ rows (each row is 30 pt: 18 pt content +
+                // 2×6 pt padding) with the half row hinting there's more to
+                // scroll, instead of one long box that dominates the page.
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         ForEach(rows, id: \.pid) { p in
@@ -507,7 +510,7 @@ struct ProcessCard: View {
                     }
                 }
                 .scrollIndicators(.automatic)
-                .frame(height: 380)
+                .frame(height: 195)
             }
         }
     }

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -172,9 +172,9 @@ struct StatusView: View {
         return ValueTile(
             eyebrow: "Network", glyph: "network", accent: Brand.green,
             value: value, unit: unit, chip: chip,
-            // Tile sparkline = the recent 10 min of the 1 s ring; the full
-            // hour lives in the History tab (it flattened the tile).
-            values: useLive ? io.netHistory(lastSeconds: 600) : model.netHist, chartStyle: .area,
+            // Tile sparkline = the recent 5 min of the 1 s ring; longer
+            // windows live in the History tab (they flattened the tile).
+            values: useLive ? io.netHistory(lastSeconds: 300) : model.netHist, chartStyle: .area,
             footnote: "↓ \(Fmt.rate(rx))  ↑ \(Fmt.rate(tx)) · \(snapNet?.name ?? "—") · \(snapNet?.ip ?? "—")")
     }
 }

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -117,7 +117,7 @@ struct StatusView: View {
             eyebrow: "GPU", glyph: "cpu.fill", accent: Brand.orange,
             value: hasUsage ? String(format: "%.0f", g!.usage) : "—",
             unit: hasUsage ? "%" : "",
-            chip: chip, values: model.gpuHist, chartStyle: .area,
+            chip: chip, values: model.gpuHist, chartStyle: .bars,
             footnote: cores > 0 ? "\(name) · \(cores) cores" : name)
     }
 

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -2,11 +2,11 @@
 //  StatusView.swift
 //  Burrow
 //
-//  The Status dashboard — Burrow's faithful take on mole.fit's Status
-//  ("Sun") screen, built on the data the SnapshotProducer already
-//  writes (`mo status --json` → SQLite). Two rows of glass metric cards
-//  (Health / CPU / Memory / GPU, then Disk / Network / Battery) over a
-//  sortable, pinnable process table.
+//  The Status dashboard — Burrow's live-metrics ("Sun") screen, built
+//  on the data the SnapshotProducer already writes (`mo status --json`
+//  → SQLite). Two rows of glass metric cards (Health / CPU / Memory /
+//  GPU, then Disk / Network / Battery) over a sortable, pinnable
+//  process table.
 //
 //  Live values come from `LiveFeed.lastSnapshot` (in-memory, refreshed
 //  each tick); the sparklines pull ~30 min of history from the DB.
@@ -124,7 +124,10 @@ struct StatusView: View {
     /// FAN tile — v1 read-only (design 3.2): RPM + "macOS manages
     /// speed". Mode controls wait for the privileged helper; no disabled
     /// placebo buttons. fanCount 0 means mole couldn't read any fan
-    /// (normal on Apple Silicon) → say "no fan data", not "idle".
+    /// (normal on Apple Silicon) → say "no fan data", not "idle" — and
+    /// draw no graph. With fans present the RPM sparkline renders like
+    /// the other tiles; an all-zero series (parked fans) is real data
+    /// and shows as a flat baseline, never hidden.
     private func fanTile(_ s: MoleStatus) -> some View {
         let fanCount = s.thermal?.fanCount ?? 0
         let rpm = s.thermal?.fanSpeed ?? 0
@@ -147,6 +150,8 @@ struct StatusView: View {
                             Text("Idle").font(Brand.sans(11)).foregroundStyle(Brand.textTertiary).padding(.leading, 4)
                         }
                     }
+                    MiniChart(values: model.fanHist, color: PowerAccent.fan, style: .area)
+                        .frame(height: 30)
                 } else {
                     Text("—").font(Brand.mono(26, .semibold)).foregroundStyle(Brand.textTertiary)
                 }
@@ -709,6 +714,10 @@ final class StatusModel: ObservableObject {
     @Published var memHist: [Double] = []
     @Published var gpuHist: [Double] = []
     @Published var netHist: [Double] = []
+    /// Fan RPM series. Samples are kept only when that snapshot actually
+    /// reported fans (fanCount > 0) — 0 RPM with fans present is real
+    /// data (parked), no fans detected contributes nothing.
+    @Published var fanHist: [Double] = []
     @Published var sortKey: ProcSort = .cpu
     @Published var sortAsc = false
     @Published var pinned: Set<Int> = []
@@ -808,6 +817,7 @@ final class StatusModel: ObservableObject {
         let now = Int(Date().timeIntervalSince1970)
         let since = now - 30 * 60
         var cpu: [Double] = [], mem: [Double] = [], gpu: [Double] = [], net: [Double] = []
+        var fan: [Double] = []
         for stored in MetricsStore(db: db).snapshots(.init(since: since, until: now), maxPoints: 40) {
             let s = stored.status
             cpu.append(s.cpu.usage)
@@ -816,7 +826,12 @@ final class StatusModel: ObservableObject {
             let rx = s.network.reduce(0.0) { $0 + $1.rxRateMbs }
             let tx = s.network.reduce(0.0) { $0 + $1.txRateMbs }
             net.append(rx + tx)
+            // Same rule as the History chart: plot RPM whenever fans are
+            // detected — including 0 (parked) — skip fan-less snapshots.
+            if let thermal = s.thermal, (thermal.fanCount ?? 0) > 0 {
+                fan.append(Double(thermal.fanSpeed))
+            }
         }
-        cpuHist = cpu; memHist = mem; gpuHist = gpu; netHist = net
+        cpuHist = cpu; memHist = mem; gpuHist = gpu; netHist = net; fanHist = fan
     }
 }

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -345,6 +345,48 @@ enum Store {
         else { d.removeObject(forKey: action.storeKey); d.synchronize() }
     }
 
+    // MARK: - Notifications
+
+    /// Completion notices for long operations (real clean / optimize /
+    /// uninstall), posted only when Burrow isn't frontmost. ON by
+    /// default — "tell me when the thing I started finishes" is the
+    /// quiet, useful default.
+    static var notifyOnCompletion: Bool {
+        get { d.object(forKey: "notify_on_completion") as? Bool ?? true }
+        set { write(newValue, "notify_on_completion") }
+    }
+
+    /// Smart reminders (clean cadence / low disk / full Trash). Opt-in:
+    /// nudges are a taste thing and the default must stay quiet.
+    static var smartRemindersEnabled: Bool {
+        get { d.object(forKey: "smart_reminders_enabled") as? Bool ?? false }
+        set { write(newValue, "smart_reminders_enabled") }
+    }
+
+    // Reminder throttle state (not user-facing): hysteresis flags so a
+    // metric hovering at its threshold can't flap, timestamps for the
+    // weekly cooldowns. See ReminderRules (Notifications.swift).
+
+    static var diskLowNoticeActive: Bool {
+        get { d.object(forKey: "disk_low_notice_active") as? Bool ?? false }
+        set { write(newValue, "disk_low_notice_active") }
+    }
+
+    static var trashNoticeActive: Bool {
+        get { d.object(forKey: "trash_notice_active") as? Bool ?? false }
+        set { write(newValue, "trash_notice_active") }
+    }
+
+    static var lastCleanReminderAt: Date? {
+        get { d.object(forKey: "last_clean_reminder_at") as? Date }
+        set { write(newValue, "last_clean_reminder_at") }
+    }
+
+    static var lastTrashReminderAt: Date? {
+        get { d.object(forKey: "last_trash_reminder_at") as? Date }
+        set { write(newValue, "last_trash_reminder_at") }
+    }
+
     // MARK: - Onboarding
 
     /// Whether the user has finished (or skipped past) the first-run

--- a/Sources/TaskReport.swift
+++ b/Sources/TaskReport.swift
@@ -53,6 +53,18 @@ struct TaskSummary {
     let categories: String     // "20"
     var freeChange: String = "" // "+1.39GB" — real run only (disk freed)
     var freeNow: String = ""    // "2.50GB"  — real run only (free space after)
+
+    /// One-line result the Clean done-banner AND a completion
+    /// notification show: the real freed-space numbers when the engine
+    /// printed them, the tracked-cleanup size otherwise.
+    var completionLine: String {
+        var parts: [String] = []
+        if !freeChange.isEmpty { parts.append(String(format: NSLocalizedString("Freed %@", comment: ""), freeChange)) }
+        else if !space.isEmpty { parts.append(String(format: NSLocalizedString("Cleaned %@", comment: ""), space)) }
+        if !freeNow.isEmpty { parts.append(String(format: NSLocalizedString("%@ free now", comment: ""), freeNow)) }
+        if !items.isEmpty { parts.append(String(format: NSLocalizedString("%@ items", comment: ""), items)) }
+        return parts.isEmpty ? NSLocalizedString("Done", comment: "") : parts.joined(separator: " · ")
+    }
 }
 
 enum TaskReportText {

--- a/Sources/Tool.swift
+++ b/Sources/Tool.swift
@@ -2,12 +2,11 @@
 //  Tool.swift
 //  Burrow
 //
-//  The five tools, each with its own colour identity and a window tint —
-//  the same "each tool re-themes the whole window" idea mole.fit uses,
-//  but with Burrow's own palette and our own taglines (no planets, no
-//  borrowed copy). `navOrder` is the left-to-right order in the top
-//  pill nav; `.status` is where Burrow opens because the live dashboard
-//  is the thing that's actually built.
+//  The five tools, each with its own colour identity and a window tint
+//  that re-themes the whole window as you switch — Burrow's own palette
+//  and taglines. `navOrder` is the left-to-right order in the top pill
+//  nav; `.status` is where Burrow opens because the live dashboard is
+//  the thing that's actually built.
 //
 
 import SwiftUI

--- a/Tests/NotificationsTests.swift
+++ b/Tests/NotificationsTests.swift
@@ -1,0 +1,119 @@
+//
+//  NotificationsTests.swift
+//  BurrowTests
+//
+//  The pure reminder rules behind the opt-in smart reminders: low-disk
+//  hysteresis, the full-Trash re-arm-on-empty, the weekly cooldowns,
+//  and the "never invent a cadence nudge without a previous clean"
+//  guarantee. The notifier itself stays inert under XCTest by design
+//  (it must never prompt for permission from a test run), so what's
+//  testable is exactly this decision layer.
+//
+
+import XCTest
+@testable import Burrow
+
+final class NotificationsTests: XCTestCase {
+    private let day: TimeInterval = 86_400
+
+    // MARK: - Low disk (hysteresis)
+
+    func testDiskLow_firesOnCrossing_thenStaysQuietWhileActive() {
+        let first = ReminderRules.diskLow(freeFraction: 0.08, active: false)
+        XCTAssertTrue(first.notify)
+        XCTAssertTrue(first.nowActive)
+        // Still low on the next sweep — already told them once.
+        let again = ReminderRules.diskLow(freeFraction: 0.07, active: true)
+        XCTAssertFalse(again.notify)
+        XCTAssertTrue(again.nowActive)
+    }
+
+    func testDiskLow_hysteresisBandHolds_recoveryRearms() {
+        // 10–12% is the dead band: no notice, no re-arm — a disk
+        // hovering at the threshold must not flap.
+        let band = ReminderRules.diskLow(freeFraction: 0.11, active: true)
+        XCTAssertFalse(band.notify)
+        XCTAssertTrue(band.nowActive)
+        let recovered = ReminderRules.diskLow(freeFraction: 0.13, active: true)
+        XCTAssertFalse(recovered.notify)
+        XCTAssertFalse(recovered.nowActive, "recovery past 12% re-arms the rule")
+        XCTAssertFalse(ReminderRules.diskLow(freeFraction: 0.50, active: false).notify)
+    }
+
+    // MARK: - Full Trash
+
+    func testTrashFull_firesOnCross_quietWhileFull_rearmsOnEmpty() {
+        let now = Date()
+        let cross = ReminderRules.trashFull(bytes: 6 << 30, active: false, lastNotice: nil, now: now)
+        XCTAssertTrue(cross.notify)
+        XCTAssertTrue(cross.nowActive)
+        // Trash stays full → one notice was enough.
+        let still = ReminderRules.trashFull(bytes: 7 << 30, active: true, lastNotice: now, now: now)
+        XCTAssertFalse(still.notify)
+        XCTAssertTrue(still.nowActive)
+        // Emptied (below half the threshold) → re-armed for next time.
+        let emptied = ReminderRules.trashFull(bytes: 100, active: true, lastNotice: now, now: now)
+        XCTAssertFalse(emptied.notify)
+        XCTAssertFalse(emptied.nowActive)
+    }
+
+    func testTrashFull_weeklyCooldownBlocksRefire() {
+        let now = Date()
+        // Emptied and refilled within two days: cooled-down rule waits.
+        let blocked = ReminderRules.trashFull(bytes: 6 << 30, active: false,
+                                              lastNotice: now.addingTimeInterval(-2 * day), now: now)
+        XCTAssertFalse(blocked.notify)
+        XCTAssertFalse(blocked.nowActive, "not consumed — it may fire once the cooldown passes")
+        let cooled = ReminderRules.trashFull(bytes: 6 << 30, active: false,
+                                             lastNotice: now.addingTimeInterval(-8 * day), now: now)
+        XCTAssertTrue(cooled.notify)
+    }
+
+    // MARK: - Clean cadence
+
+    func testCleanLapsed_requiresAPreviousClean() {
+        XCTAssertNil(ReminderRules.cleanLapsedDays(lastClean: nil, lastNotice: nil),
+                     "a Mac that never cleaned gets no invented cadence nudge")
+    }
+
+    func testCleanLapsed_firesAfterTwoWeeks_throttledWeekly() {
+        let now = Date()
+        let old = now.addingTimeInterval(-20 * day)
+        XCTAssertEqual(ReminderRules.cleanLapsedDays(lastClean: old, lastNotice: nil, now: now), 20)
+        // Reminded three days ago → quiet.
+        XCTAssertNil(ReminderRules.cleanLapsedDays(lastClean: old,
+                                                   lastNotice: now.addingTimeInterval(-3 * day), now: now))
+        // Cleaned five days ago → not lapsed at all.
+        XCTAssertNil(ReminderRules.cleanLapsedDays(lastClean: now.addingTimeInterval(-5 * day),
+                                                   lastNotice: nil, now: now))
+    }
+
+    // MARK: - mo history parsing
+
+    private func session(_ command: String, startedAt: String, endedAt: String) -> HistorySession {
+        HistorySession(command: command, startedAt: startedAt, endedAt: endedAt,
+                       items: 0, size: "", operationCount: 1,
+                       removed: 0, trashed: 0, skipped: 0, failed: 0)
+    }
+
+    func testLastCompletedClean_picksNewestCompleteCleanOnly() throws {
+        let last = ReminderRules.lastCompletedClean([
+            session("clean", startedAt: "2026-06-01 10:00:00", endedAt: "2026-06-01 10:02:00"),
+            session("clean", startedAt: "2026-06-06 20:33:49", endedAt: "2026-06-06 20:35:23"),
+            session("clean", startedAt: "2026-06-09 09:00:00", endedAt: ""),       // crashed mid-run
+            session("optimize", startedAt: "2026-06-10 09:00:00", endedAt: "2026-06-10 09:01:00"),
+            session("clean", startedAt: "not a date", endedAt: "also not"),        // drift → ignored
+        ])
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        XCTAssertEqual(try XCTUnwrap(last), fmt.date(from: "2026-06-06 20:33:49"))
+    }
+
+    func testLastCompletedClean_emptyOrNoCleansIsNil() {
+        XCTAssertNil(ReminderRules.lastCompletedClean([]))
+        XCTAssertNil(ReminderRules.lastCompletedClean([
+            session("optimize", startedAt: "2026-06-10 09:00:00", endedAt: "2026-06-10 09:01:00"),
+        ]))
+    }
+}

--- a/Tests/OperationFlowTests.swift
+++ b/Tests/OperationFlowTests.swift
@@ -159,6 +159,26 @@ final class OperationFlowTests: XCTestCase {
         XCTAssertEqual(op.label, "Scanning caches")
         XCTAssertEqual(op.phase, .done)
         XCTAssertFalse(op.detail.isEmpty, "HUD detail fed from the stream")
+        XCTAssertFalse(op.notifiesOnEnd, "preview-style ops never notify")
+    }
+
+    // The real-clean shape: notifyOnEnd rides into the OperationCenter op
+    // and the parsed summary replaces the last streamed line as the final
+    // detail — that's the body a completion notification carries.
+    func testNotifyOnEnd_andFinalDetail_reachOperationCenter() async throws {
+        let port = FakeProcessPort(script: Self.cannedClean)
+        let center = OperationCenter()
+        let flow = OperationFlow<TaskRunReport>(process: port, hasFullDiskAccess: { true },
+                                                resolveMo: { _ in "/usr/local/bin/mo" }, center: center)
+
+        flow.start(.moleStream(["clean"], label: "Cleaning caches", notifyOnEnd: true))
+        await settle(flow)
+
+        let op = try XCTUnwrap(center.ops.first)
+        XCTAssertTrue(op.notifiesOnEnd)
+        XCTAssertEqual(op.phase, .done)
+        XCTAssertEqual(op.detail, "Cleaned 383.8MB · 372 items",
+                       "final detail is the parsed summary, not the last raw line")
     }
 
     func testElevationDeclined_failsWithNoOutput() async throws {

--- a/Tests/SnapshotProducerTests.swift
+++ b/Tests/SnapshotProducerTests.swift
@@ -70,6 +70,12 @@ final class SnapshotPatcherTests: XCTestCase {
         let patched = dict(SnapshotPatcher.patch(json: hole, fill: fill))
         XCTAssertEqual(((patched["gpu"] as? [[String: Any]])?.first?["usage"] as? NSNumber)?.doubleValue, 43)
 
+        // Apple Silicon: Mole can't read GPU% and reports 0 (not -1). The
+        // native reading must still fill, or every stored sample sits at 0.
+        let zero = #"{"gpu":[{"name":"G","usage":0}]}"#
+        let filled = dict(SnapshotPatcher.patch(json: zero, fill: fill))
+        XCTAssertEqual(((filled["gpu"] as? [[String: Any]])?.first?["usage"] as? NSNumber)?.doubleValue, 43)
+
         let real = #"{"gpu":[{"name":"G","usage":12}]}"#
         let kept = dict(SnapshotPatcher.patch(json: real, fill: fill))
         XCTAssertEqual(((kept["gpu"] as? [[String: Any]])?.first?["usage"] as? NSNumber)?.doubleValue, 12)

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -56,6 +56,25 @@ final class StoreTests: XCTestCase {
         XCTAssertTrue(Store.mcpIrreversibleEnabled)
     }
 
+    // Notification defaults: completion notices are on (quietly useful),
+    // smart reminders are strictly opt-in.
+    func testNotificationDefaults_completionOnRemindersOff() {
+        XCTAssertTrue(Store.notifyOnCompletion)
+        XCTAssertFalse(Store.smartRemindersEnabled)
+        XCTAssertFalse(Store.diskLowNoticeActive)
+        XCTAssertNil(Store.lastCleanReminderAt)
+        Store.smartRemindersEnabled = true
+        XCTAssertTrue(Store.smartRemindersEnabled)
+    }
+
+    // The first-launch consent notice must show exactly once: not yet
+    // acknowledged on a fresh install, sticky once answered.
+    func testTelemetryNotice_defaultsUnacknowledgedAndPersists() {
+        XCTAssertFalse(Store.telemetryNoticeAcknowledged)
+        Store.telemetryNoticeAcknowledged = true
+        XCTAssertTrue(Store.telemetryNoticeAcknowledged)
+    }
+
     // Issue #4: the menu-bar icon is on by default; the off-switch must
     // persist (it's read once at launch to decide menu-bar vs Dock mode).
     func testShowMenuBarIcon_defaultsTrueAndPersists() {

--- a/Tests/TaskReportTests.swift
+++ b/Tests/TaskReportTests.swift
@@ -50,4 +50,19 @@ final class TaskReportTests: XCTestCase {
         XCTAssertEqual(summary.freeNow, "")
         XCTAssertEqual(result.groups.count, 1)
     }
+
+    // The one-line result shared by the Clean done-banner and the
+    // completion notification: real freed-space numbers when present,
+    // the tracked size otherwise.
+    func testCompletionLine_prefersRealFreedSpace() {
+        let real = TaskSummary(space: "1.02GB", items: "337", categories: "35",
+                               freeChange: "+1.39GB", freeNow: "2.50GB")
+        XCTAssertEqual(real.completionLine, "Freed +1.39GB · 2.50GB free now · 337 items")
+
+        let tracked = TaskSummary(space: "383.8MB", items: "372", categories: "20")
+        XCTAssertEqual(tracked.completionLine, "Cleaned 383.8MB · 372 items")
+
+        let empty = TaskSummary(space: "", items: "", categories: "")
+        XCTAssertEqual(empty.completionLine, "Done")
+    }
 }

--- a/project.yml
+++ b/project.yml
@@ -50,8 +50,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.6.7"
-        CFBundleVersion: "7"
+        CFBundleShortVersionString: "0.7.0"
+        CFBundleVersion: "8"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Friendly, one-time prompts for the standard folders Mole scans
         # (purge/installer touch these). Full Disk Access still covers the


### PR DESCRIPTION
Polish + fixes pass on top of the 2026-06 redesign (#61), cut as **0.7.0** — a minor release: the redesign plus everything since is a meaningful step, not a patch.

## Onboarding
- Drop the inline telemetry toggle (stays opt-out, Settings-only) and gate the slides on the `mo` engine, with a visible install-state + version row.

## Status / popover
- Compact, scrollable Top Processes (native `ps` sampler — `mo status` caps at 5).
- Network sparkline windowed to recent minutes (was the full 1 h ring, which flattened it).
- Fan tile gets an RPM-over-time sparkline; GPU sparkline renders as bars like CPU.
- One documented battery/fan accent mapping; deduped the "macOS macOS" version text.
- Popover height tracks content live; Wipe gets an armed state.

## History
- CPU / GPU / health-score charts render as **bars**, plotted by index (uniform, Status-style) at a geometry-derived pixel width — fixes the empty/overlapping bars across ranges.

## Metrics
- **Persist real GPU usage**: Apple Silicon `mo` reports `0` (not −1), so the strict patch test left every stored sample at 0 while the live tile showed the real figure. Filled on `<= 0`, pinned by a test.

## Notifications
- Completion notices (clean / optimize / uninstall) + opt-in smart reminders (low disk, full Trash, clean cadence) with hysteresis + weekly cooldowns. Authorization settled at op-start; `willPresent` shows foreground banners.
  - Note: local **ad-hoc-signed Debug builds can't register** for notifications (unstable identity + duplicate bundle registrations); works in the signed/notarized release.

## Settings / FDA
- Settings restyled as a first-class pane (no close chrome); truthful Touch ID copy (it covers terminal `sudo`, not Burrow's own osascript prompts).
- One-click **Relaunch** when Full Disk Access is granted mid-session.

## Clean safety
- Whitelist session paths glob-escaped; unreadable-whitelist aborts instead of wiping; session restore owned by the run; trash subset assertion is fail-closed.

Tests: 339 green (LocalizationTests skipped in worktrees; CI runs it). Elevation single-auth + live clean output and Touch-ID-for-app are deferred to the 0.8 privileged-helper RFC.
