### PR TITLE
fix(history): stop the ≥2s SwiftUI layout hang in bar charts (#57)

### DIFF
--- a/Sources/HistoryView.swift
+++ b/Sources/HistoryView.swift
@@ -334,6 +334,16 @@ struct HistoryView: View {
         return (0..<n).map { (Double($0) * Double(count - 1) / Double(n - 1)).rounded() }
     }
 
+    /// Cap a bar series to a count a chart card can actually render — a
+    /// ~380 pt card maxes out around `cap` bars; beyond that they're
+    /// sub-pixel and only cost layout (the #57 hang). Strides evenly,
+    /// keeping the first and last sample.
+    static func capBars(_ pts: [ChartPoint], max cap: Int = 140) -> [ChartPoint] {
+        guard pts.count > cap, cap > 1 else { return pts }
+        let step = Double(pts.count - 1) / Double(cap - 1)
+        return (0..<cap).map { pts[Int((Double($0) * step).rounded())] }
+    }
+
     private func chartCard(_ title: String, _ subtitle: String,
                            _ series: [(name: String, points: [ChartPoint], color: Color)],
                            marks: ChartMarks = .line) -> some View {
@@ -355,46 +365,53 @@ struct HistoryView: View {
                 } else if marks == .bars {
                     // Bars are plotted BY INDEX (like the Status sparklines):
                     // each sample gets an equal slot, so width and gaps are
-                    // uniform at every range. On a continuous time axis the
-                    // bars bunched up where samples clustered and stretched
-                    // where they were sparse — index spacing fixes both. An
-                    // integer x has a unit step of 1, so .ratio sizes the bar
-                    // as a clean fraction of that slot. Axis labels map a few
-                    // indices back to their real timestamps.
-                    let pts = series.first?.points ?? []
-                    // Width is a real pixel value from the plot geometry —
-                    // .ratio never establishes a unit on this scale (the bars
-                    // vanished), and a fixed point width renders reliably and
-                    // scales with the sample count so it never overlaps.
-                    GeometryReader { geo in
-                        let barW = max(1.0, geo.size.width / CGFloat(max(pts.count, 1)) * 0.6)
-                        Chart {
-                            ForEach(series, id: \.name) { s in
-                                ForEach(Array(s.points.enumerated()), id: \.offset) { idx, p in
-                                    BarMark(x: .value("Sample", Double(idx)), y: .value("Value", p.value),
-                                            width: .fixed(barW))
-                                        .foregroundStyle(s.color.opacity(0.85))
+                    // uniform at every range. Axis labels map a few indices
+                    // back to their real timestamps.
+                    //
+                    // #57: a 90-day range stride-samples to 720 points, and a
+                    // BarMark per point is a layout node — 720 × several bar
+                    // cards drove SwiftUI's alignment layout into a recursive
+                    // explosion (a ≥2 s main-thread hang; `explicitAlignment` +
+                    // chkstk in the trace). Two fixes:
+                    //   1. CAP the bar count — a ~380 pt card can't render more
+                    //      than ~140 bars meaningfully, so down-sample there.
+                    //   2. NO GeometryReader — its size → barW → mark-layout →
+                    //      size feedback was the cycle that recursed. The width
+                    //      is a fixed pixel value derived from the (capped)
+                    //      count instead. (.ratio renders nothing on this
+                    //      index scale — keep .fixed.)
+                    let capped = series.map {
+                        (name: $0.name, points: Self.capBars($0.points), color: $0.color)
+                    }
+                    let n = max(capped.map(\.points.count).max() ?? 0, 1)
+                    let labelPts = capped.first?.points ?? []
+                    let barW = max(1.5, min(12.0, 360.0 / CGFloat(n) * 0.6))
+                    Chart {
+                        ForEach(capped, id: \.name) { s in
+                            ForEach(Array(s.points.enumerated()), id: \.offset) { idx, p in
+                                BarMark(x: .value("Sample", Double(idx)), y: .value("Value", p.value),
+                                        width: .fixed(barW))
+                                    .foregroundStyle(s.color.opacity(0.85))
+                            }
+                        }
+                    }
+                    .chartXScale(domain: -0.5 ... (Double(n) - 0.5))
+                    .chartXAxis {
+                        AxisMarks(values: barAxisTicks(labelPts.count, desired: style.desiredCount)) { v in
+                            AxisGridLine().foregroundStyle(Brand.hairline)
+                            if let d = v.as(Double.self) {
+                                let i = Int(d.rounded())
+                                if i >= 0, i < labelPts.count {
+                                    AxisValueLabel { Text(labelPts[i].time, format: style.format) }
+                                        .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
                                 }
                             }
                         }
-                        .chartXScale(domain: -0.5 ... (Double(max(pts.count, 1)) - 0.5))
-                        .chartXAxis {
-                            AxisMarks(values: barAxisTicks(pts.count, desired: style.desiredCount)) { v in
-                                AxisGridLine().foregroundStyle(Brand.hairline)
-                                if let d = v.as(Double.self) {
-                                    let i = Int(d.rounded())
-                                    if i >= 0, i < pts.count {
-                                        AxisValueLabel { Text(pts[i].time, format: style.format) }
-                                            .foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
-                                    }
-                                }
-                            }
-                        }
-                        .chartYAxis {
-                            AxisMarks { _ in
-                                AxisGridLine().foregroundStyle(Brand.hairline)
-                                AxisValueLabel().foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
-                            }
+                    }
+                    .chartYAxis {
+                        AxisMarks { _ in
+                            AxisGridLine().foregroundStyle(Brand.hairline)
+                            AxisValueLabel().foregroundStyle(Brand.textTertiary).font(Brand.mono(8))
                         }
                     }
                     .frame(height: 170)

--- a/Tests/HistoryViewTests.swift
+++ b/Tests/HistoryViewTests.swift
@@ -1,0 +1,55 @@
+//
+//  HistoryViewTests.swift
+//  BurrowTests
+//
+//  The bar-chart down-sample cap (#57): a 90-day range stride-samples to
+//  720 points, and a BarMark per point is a SwiftUI layout node — 720 ×
+//  several bar cards drove the layout engine into a recursive explosion
+//  (a ≥2 s main-thread hang). capBars bounds the mark count to something a
+//  card can actually render, evenly, keeping the first and last sample.
+//
+
+import XCTest
+@testable import Burrow
+
+final class HistoryViewTests: XCTestCase {
+    private func points(_ n: Int) -> [ChartPoint] {
+        (0..<n).map { ChartPoint(time: Date(timeIntervalSince1970: TimeInterval($0)),
+                                 value: Double($0)) }
+    }
+
+    func testCapBars_underCapIsUnchanged() {
+        let pts = points(100)
+        let capped = HistoryView.capBars(pts, max: 140)
+        XCTAssertEqual(capped.count, 100)
+        XCTAssertEqual(capped.map(\.value), pts.map(\.value))
+    }
+
+    func testCapBars_atCapIsUnchanged() {
+        XCTAssertEqual(HistoryView.capBars(points(140), max: 140).count, 140)
+    }
+
+    func testCapBars_overCapStridesDownToCap() {
+        // The worst case: a 90-day range stride-sampled to 720 points.
+        let capped = HistoryView.capBars(points(720), max: 140)
+        XCTAssertEqual(capped.count, 140, "bounded to the cap so layout can't explode")
+    }
+
+    func testCapBars_keepsFirstAndLastSample() {
+        let pts = points(720)
+        let capped = HistoryView.capBars(pts, max: 140)
+        XCTAssertEqual(capped.first?.value, pts.first?.value)
+        XCTAssertEqual(capped.last?.value, pts.last?.value)
+    }
+
+    func testCapBars_preservesAscendingOrder() {
+        let capped = HistoryView.capBars(points(500), max: 120)
+        XCTAssertEqual(capped.map(\.value), capped.map(\.value).sorted(),
+                       "down-sampling must not reorder time")
+    }
+
+    func testCapBars_emptyAndTiny() {
+        XCTAssertTrue(HistoryView.capBars([], max: 140).isEmpty)
+        XCTAssertEqual(HistoryView.capBars(points(1), max: 140).count, 1)
+    }
+}


### PR DESCRIPTION
Fixes the **App Hanging** Sentry regression (#57) — a ≥2s main-thread freeze hitting 28 users on Apple Silicon, with an `explicitAlignment` + `chkstk` layout-recursion signature.

## Cause
The 0.7.0 bar-width fix wrapped each History bar Chart in a `GeometryReader` and fed `geo.size.width` back into every `BarMark`'s `.fixed` width — a **size → width → mark-layout → size feedback cycle**. With up to **720 marks per card** (90-day range, stride-sampled) across three bar charts (CPU/GPU/Health), SwiftUI's alignment layout recursed and froze the main thread.

## Fix
- **Remove the GeometryReader** — break the feedback cycle; derive bar width from the (capped) sample count, no geometry dependency. (`.ratio` renders nothing on this by-index scale — confirmed earlier — so `.fixed` stays.)
- **Cap bar series to ~140 points** (`capBars`) — a ~380pt card can't render more bars meaningfully, and the cap also bounds the cost for the pre-0.7.0 manifestation (the hang was first seen in 0.6.7). Pinned by 6 `HistoryViewTests`.

No visual regression: bars stay uniform and visible at every range; long ranges actually read **better** (≤140 visible bars vs a sub-pixel block).

Tests: 393 green (LocalizationTests skipped in worktree; CI runs it).

Note: 0.7.0 crashes aren't symbolicated in Sentry (dSYMs not uploaded by the release workflow) — worth a separate follow-up so future 0.7.x hangs name their frames.