### PR TITLE
feat(feeds): migrate HUD/Status/Activity onto FeedHub, dedup the double-poll (#53)

### DIFF
--- a/Sources/ActivityView.swift
+++ b/Sources/ActivityView.swift
@@ -10,7 +10,11 @@
 import SwiftUI
 
 struct ActivityView: View {
-    @StateObject private var model = ActivityModel()
+    @StateObject private var model: ActivityModel
+
+    init(feeds: FeedHub) {
+        _model = StateObject(wrappedValue: ActivityModel(feeds: feeds))
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -19,7 +23,11 @@ struct ActivityView: View {
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { model.loadIfNeeded() }
+        // The whole load/refresh lifecycle is one task-scoped feed
+        // subscription (issue #53): the `history.sessions` pump ticks only
+        // while this pane is on screen, and leaving it cancels the task,
+        // which detaches the pump. No view-owned timer, no off-screen poll.
+        .task { await model.subscribe() }
     }
 
     private var header: some View {
@@ -121,18 +129,37 @@ private struct SessionRow: View {
 final class ActivityModel: ObservableObject {
     @Published var sessions: [HistorySession] = []
     @Published var loading = false
-    private var started = false
 
-    func loadIfNeeded() { guard !started else { return }; started = true; reload() }
+    private let feeds: FeedHub
+    /// The subscribed sessions feed — held so the toolbar's manual refresh
+    /// can poke it; lifecycle belongs to the view's `.task` below.
+    private var feed: Feed<[HistorySession]>?
 
+    init(feeds: FeedHub) {
+        self.feeds = feeds
+    }
+
+    /// Park on the shared `history.sessions` pump (1 h cadence — the
+    /// cleanup log doesn't move minute to minute) and apply every value
+    /// until the surrounding task is cancelled.
+    func subscribe() async {
+        let feed = feeds.feed("history.sessions", cadence: 3600) {
+            await Task.detached(priority: .userInitiated) {
+                MoleClient.history()
+            }.value
+        }
+        self.feed = feed
+        loading = sessions.isEmpty
+        for await parsed in feed.subscribeValues() {
+            sessions = parsed
+            loading = false
+        }
+    }
+
+    /// The toolbar refresh button: poke the shared pump for an immediate
+    /// re-read (coalesced with any in-flight fetch).
     func reload() {
         loading = true
-        DispatchQueue.global(qos: .userInitiated).async {
-            let parsed = MoleClient.history()
-            Task { @MainActor in
-                self.sessions = parsed
-                self.loading = false
-            }
-        }
+        feed?.refresh()
     }
 }

--- a/Sources/HomeView.swift
+++ b/Sources/HomeView.swift
@@ -88,9 +88,9 @@ struct HomeView: View {
     @ViewBuilder
     private var content: some View {
         switch section {
-        case .overview: StatusView(db: db, live: live)
+        case .overview: StatusView(db: db, live: live, feeds: feeds)
         case .history:  HistoryView(db: db, live: live, feeds: feeds)
-        case .activity: ActivityView()
+        case .activity: ActivityView(feeds: feeds)
         }
     }
 }

--- a/Sources/MetricsFeeds.swift
+++ b/Sources/MetricsFeeds.swift
@@ -1,0 +1,135 @@
+//
+//  MetricsFeeds.swift
+//  Burrow
+//
+//  The shared metric queries for the two live dashboards (issue #53):
+//  the menu-bar HUD (PopupView) and the Status pane both want the latest
+//  snapshot and a 30-min sparkline set — so they ask the hub for the SAME
+//  keys and get ONE pump each (one timer, one read, two observers). Before
+//  this, the HUD ran a 1 s + 20 s timer pair and Status ran a 2 s + 15 s
+//  pair, double-polling the same `LiveFeed` snapshot and the same DB
+//  history window. Now the popover and the Status pane stop double-polling
+//  the moment they bind to these keys.
+//
+//  The fetch closures live here, once, so the two screens can never drift
+//  to slightly-different keys (which would silently un-share the pump).
+//  Pure aggregation helpers (`Sparklines.from`) are split out so the
+//  manual-clock tests can assert them without a DB.
+//
+
+import Foundation
+
+// MARK: - Value types
+
+/// The latest decoded snapshot plus when it was sampled — the 1 s "live"
+/// payload both dashboards read straight off `LiveFeed` (no `mo` spawn:
+/// the SnapshotProducer already published it).
+struct LiveSnapshot {
+    let snap: MoleStatus?
+    let sampledAt: Date?
+}
+
+/// The ~30-min sparkline set + the hour's heaviest process. Computed from
+/// one DB history read so the HUD's six tiles, the battery card's top
+/// drain, and the Status sparklines all come from a single pass.
+struct MetricSparklines: Hashable {
+    var cpu: [Double] = []
+    var mem: [Double] = []
+    var net: [Double] = []
+    var gpu: [Double] = []
+    /// RPM series — only the snapshots that reported fans (fanCount > 0)
+    /// contribute, matching the tiles' "no placebo zeros" rule.
+    var fan: [Double] = []
+    /// Heaviest process by average CPU over the window (battery card).
+    /// Stored as the named-tuple parts so the struct stays Equatable —
+    /// the change token can fold identical windows into zero republishes.
+    var drainName: String?
+    var drainCPU: Double = 0
+
+    var topDrain: (name: String, avgCPU: Double)? {
+        drainName.map { ($0, drainCPU) }
+    }
+}
+
+/// One `ps` pass (the full live process set) paired with each row's
+/// cumulative billed energy (nJ) — published together so a row and its
+/// PWR value always belong to the same pass. Status-only: the HUD shows
+/// the engine top five, not the full table.
+struct ProcessSample {
+    let processes: [ProcessInfo]
+    let energies: [Int: UInt64]
+}
+
+// MARK: - Pure aggregation
+
+/// Projects a window of stored snapshots into the sparkline set. Pure (no
+/// DB, no clock) so it's unit-testable; the feed wraps it around a read.
+enum Sparklines {
+    /// `tailPoints` keeps the sparkline length the tiles expect (~30)
+    /// while the drain ranking still sees the whole window.
+    static func from(_ statuses: [MoleStatus], tailPoints: Int = 30) -> MetricSparklines {
+        var cpu: [Double] = [], mem: [Double] = [], net: [Double] = [], gpu: [Double] = []
+        var fan: [Double] = []
+        var processLists: [[ProcessInfo]] = []
+        for s in statuses {
+            cpu.append(s.cpu.usage)
+            mem.append(s.memory.usedPercent)
+            net.append(s.network.reduce(0.0) { $0 + $1.rxRateMbs + $1.txRateMbs })
+            gpu.append(max(0, s.gpu?.first?.usage ?? 0))
+            if let thermal = s.thermal, (thermal.fanCount ?? 0) > 0 {
+                fan.append(Double(thermal.fanSpeed))
+            }
+            if let procs = s.topProcesses { processLists.append(procs) }
+        }
+        // Sparklines stay ~30 points; the drain ranking uses the full hour.
+        let drain = TopDrain.heaviest(processLists)
+        return MetricSparklines(
+            cpu: Array(cpu.suffix(tailPoints)),
+            mem: Array(mem.suffix(tailPoints)),
+            net: Array(net.suffix(tailPoints)),
+            gpu: Array(gpu.suffix(tailPoints)),
+            fan: Array(fan.suffix(tailPoints)),
+            drainName: drain?.name,
+            drainCPU: drain?.avgCPU ?? 0)
+    }
+}
+
+// MARK: - Shared metric queries (the dedup point)
+
+extension FeedHub {
+    /// The live snapshot pump — `snapshot.live`, 1 s. Reads the already
+    /// published `LiveFeed` value on the main actor (no engine spawn); the
+    /// HUD and Status share this one instance. The change token folds runs
+    /// of identical samples so a 1 Hz poll over an unchanged row causes no
+    /// republish churn in either screen.
+    func liveSnapshot(_ live: LiveFeed) -> Feed<LiveSnapshot> {
+        feed("snapshot.live", cadence: 1,
+             changeToken: { $0.sampledAt.map(AnyHashable.init) }) {
+            await MainActor.run {
+                LiveSnapshot(snap: live.lastSnapshot, sampledAt: live.sampledAt)
+            }
+        }
+    }
+
+    /// The 30-min sparkline pump — `metrics.sparklines.30m`, 15 s (the
+    /// lower of the HUD's old 20 s and Status's old 15 s, so neither loses
+    /// resolution). Reads a single 1-hour DB window off-main and projects
+    /// it; the HUD renders the tiles + top drain, Status renders the
+    /// sparklines, both off the ONE read. The token is the projected value
+    /// itself, so a tick that re-reads an unchanged window (no new sample
+    /// landed since the last) skips the republish in both screens.
+    func metricSparklines(db: DB) -> Feed<MetricSparklines> {
+        feed("metrics.sparklines.30m", cadence: 15,
+             changeToken: { AnyHashable($0) }) {
+            await Task.detached(priority: .userInitiated) {
+                let now = Int(Date().timeIntervalSince1970)
+                // One hour so the drain ranking has the full window; the
+                // sparklines are the trailing ~30 points of it.
+                let stored = MetricsStore(db: db)
+                    .snapshots(.init(since: now - 60 * 60, until: now), maxPoints: 60)
+                    .snapshots
+                return Sparklines.from(stored.map(\.status))
+            }.value
+        }
+    }
+}

--- a/Sources/PopupView.swift
+++ b/Sources/PopupView.swift
@@ -21,8 +21,8 @@ struct PopupView: View {
     @ObservedObject private var cleanScreen = CleanScreen.shared
     private weak var delegate: AppDelegate?
 
-    init(db: DB, live: LiveFeed, delegate: AppDelegate) {
-        _model = StateObject(wrappedValue: HUDModel(db: db, live: live))
+    init(db: DB, live: LiveFeed, feeds: FeedHub, delegate: AppDelegate) {
+        _model = StateObject(wrappedValue: HUDModel(db: db, live: live, feeds: feeds))
         self.delegate = delegate
     }
 
@@ -53,8 +53,13 @@ struct PopupView: View {
         .frame(width: 334)
         .fixedSize(horizontal: false, vertical: true)
         .environment(\.colorScheme, .dark)
-        .onAppear { model.start() }
-        .onDisappear { model.stop() }
+        // Three task-scoped subscriptions replace the old 1 s + 20 s timer
+        // pair (issue #53): the snapshot and sparkline pumps are shared with
+        // the Status pane, and closing the popover cancels these tasks,
+        // which detaches the pumps — nothing ticks behind a closed popover.
+        .task { await model.subscribeSnapshot() }
+        .task { await model.subscribeSparklines() }
+        .task { await model.subscribeCleanWatch() }
     }
 
     // MARK: Header — health glyph + score + headline issue + free space
@@ -582,33 +587,56 @@ final class HUDModel: ObservableObject {
 
     private let db: DB
     private let live: LiveFeed
-    private var liveTimer: Timer?
-    private var histTimer: Timer?
+    private let feeds: FeedHub
 
-    /// `mo history` is spawned at most once a day — the footer is a
-    /// lifetime figure, it doesn't move minute to minute.
-    private static var cleanWatchCache: (at: Date, totals: CleanWatch.Totals)?
-
-    init(db: DB, live: LiveFeed) {
+    init(db: DB, live: LiveFeed, feeds: FeedHub) {
         self.db = db
         self.live = live
+        self.feeds = feeds
     }
 
-    func start() {
-        refreshCurrent()
-        refreshHistory()
-        loadCleanWatch()
-        liveTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refreshCurrent() }
-        }
-        histTimer = Timer.scheduledTimer(withTimeInterval: 20, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refreshHistory() }
+    // MARK: Feed subscriptions (issue #53)
+    //
+    // No view-owned timers: each `subscribe…` parks on a shared, demand-
+    // counted pump and applies its values until the surrounding task is
+    // cancelled (the popover closing IS the unsubscribe). The snapshot and
+    // sparkline pumps are the SAME instances the Status pane binds to — one
+    // timer, one read, two observers — so the popover and Status stop
+    // double-polling the moment both are on screen.
+
+    /// Latest snapshot + freshness, off the 1 s `snapshot.live` pump.
+    func subscribeSnapshot() async {
+        for await v in feeds.liveSnapshot(live).subscribeValues() {
+            snap = v.snap
+            if let when = v.sampledAt {
+                freshness = String(format: NSLocalizedString("%ds ago", comment: ""), Int(Date().timeIntervalSince(when)))
+            } else {
+                freshness = NSLocalizedString("no samples yet", comment: "")
+            }
         }
     }
 
-    func stop() {
-        liveTimer?.invalidate(); liveTimer = nil
-        histTimer?.invalidate(); histTimer = nil
+    /// Sparklines + top drain, off the 15 s `metrics.sparklines.30m` pump.
+    func subscribeSparklines() async {
+        for await v in feeds.metricSparklines(db: db).subscribeValues() {
+            cpuHist = v.cpu; memHist = v.mem; netHist = v.net; gpuHist = v.gpu; fanHist = v.fan
+            topDrain = v.topDrain
+        }
+    }
+
+    /// Clean Watch lifetime totals, off the daily `history.cleanwatch`
+    /// pump. `mo history` is a lifetime figure; the day cadence keeps the
+    /// old once-a-day spawn behaviour, now demand-driven (it only runs
+    /// while the popover is open) instead of a process-wide static cache.
+    func subscribeCleanWatch() async {
+        let feed = feeds.feed("history.cleanwatch", cadence: 86_400) {
+            await Task.detached(priority: .utility) {
+                CleanWatch.totals(from: MoleHistory.load())
+            }.value
+        }
+        for await totals in feed.subscribeValues() {
+            cleanWatch = totals
+        }
     }
 
     // MARK: External volumes
@@ -636,49 +664,4 @@ final class HUDModel: ObservableObject {
         }
     }
 
-    private func refreshCurrent() {
-        snap = live.lastSnapshot
-        if let when = live.sampledAt {
-            freshness = String(format: NSLocalizedString("%ds ago", comment: ""), Int(Date().timeIntervalSince(when)))
-        } else {
-            freshness = NSLocalizedString("no samples yet", comment: "")
-        }
-    }
-
-    private func refreshHistory() {
-        let now = Int(Date().timeIntervalSince1970)
-        var cpu: [Double] = [], mem: [Double] = [], net: [Double] = [], gpu: [Double] = []
-        var fan: [Double] = []
-        var processLists: [[ProcessInfo]] = []
-        for stored in MetricsStore(db: db).snapshots(.init(since: now - 60 * 60, until: now), maxPoints: 60).snapshots {
-            let s = stored.status
-            cpu.append(s.cpu.usage)
-            mem.append(s.memory.usedPercent)
-            net.append(s.network.reduce(0.0) { $0 + $1.rxRateMbs + $1.txRateMbs })
-            gpu.append(max(0, s.gpu?.first?.usage ?? 0))
-            if let thermal = s.thermal, (thermal.fanCount ?? 0) > 0 {
-                fan.append(Double(thermal.fanSpeed))
-            }
-            if let procs = s.topProcesses { processLists.append(procs) }
-        }
-        // Sparklines stay ~30 min; the drain ranking uses the full hour.
-        cpuHist = Array(cpu.suffix(30)); memHist = Array(mem.suffix(30))
-        netHist = Array(net.suffix(30)); gpuHist = Array(gpu.suffix(30))
-        fanHist = Array(fan.suffix(30))
-        topDrain = TopDrain.heaviest(processLists)
-    }
-
-    private func loadCleanWatch() {
-        if let cached = Self.cleanWatchCache, Date().timeIntervalSince(cached.at) < 86_400 {
-            cleanWatch = cached.totals
-            return
-        }
-        DispatchQueue.global(qos: .utility).async { [weak self] in
-            let totals = CleanWatch.totals(from: MoleHistory.load())
-            Task { @MainActor in
-                Self.cleanWatchCache = (Date(), totals)
-                self?.cleanWatch = totals
-            }
-        }
-    }
 }

--- a/Sources/StatusBarController.swift
+++ b/Sources/StatusBarController.swift
@@ -43,7 +43,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         // then drives the real (screen-capped) size via preferredContentSize.
         popover.contentSize = NSSize(width: 334, height: 560)
         popover.contentViewController = HUDController(
-            root: PopupView(db: db, live: producer.live, delegate: delegate))
+            root: PopupView(db: db, live: producer.live, feeds: delegate.feeds, delegate: delegate))
         self.popover = popover
 
         super.init()

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -20,8 +20,8 @@ struct StatusView: View {
     @StateObject private var model: StatusModel
     @ObservedObject private var io: LiveFeed
 
-    init(db: DB, live: LiveFeed) {
-        _model = StateObject(wrappedValue: StatusModel(db: db, live: live))
+    init(db: DB, live: LiveFeed, feeds: FeedHub) {
+        _model = StateObject(wrappedValue: StatusModel(db: db, live: live, feeds: feeds))
         self.io = live
     }
 
@@ -57,8 +57,14 @@ struct StatusView: View {
         }
         .scrollIndicators(.hidden)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear { model.start() }
-        .onDisappear { model.stop() }
+        // Three task-scoped subscriptions replace the old 2 s + 15 s timer
+        // pair (issue #53). The snapshot and sparkline pumps are shared with
+        // the popover HUD; the process pump is Status-only. Leaving Home or
+        // closing the window unmounts this view, which cancels the tasks and
+        // detaches the pumps — no polling off-screen.
+        .task { await model.subscribeSnapshot() }
+        .task { await model.subscribeSparklines() }
+        .task { await model.subscribeProcesses() }
     }
 
     private var waiting: some View {
@@ -730,30 +736,69 @@ final class StatusModel: ObservableObject {
 
     private let db: DB
     private let live: LiveFeed
-    private var liveTimer: Timer?
-    private var histTimer: Timer?
-    /// Drop overlapping `ps` passes if one ever outlives the 2 s tick.
-    private var samplingProcesses = false
+    private let feeds: FeedHub
 
-    init(db: DB, live: LiveFeed) {
+    init(db: DB, live: LiveFeed, feeds: FeedHub) {
         self.db = db
         self.live = live
+        self.feeds = feeds
     }
 
-    func start() {
-        refreshCurrent()
-        refreshHistory()
-        liveTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refreshCurrent() }
-        }
-        histTimer = Timer.scheduledTimer(withTimeInterval: 15, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refreshHistory() }
+    // MARK: Feed subscriptions (issue #53)
+    //
+    // No view-owned timers: each `subscribe…` parks on a shared, demand-
+    // counted pump until the surrounding task is cancelled (the view
+    // unmounting — leaving Home or closing the window — IS the unsubscribe).
+    // The snapshot and sparkline pumps are the SAME instances the popover
+    // HUD binds to (one timer, one read, two observers), so Status and the
+    // HUD stop double-polling the moment both are on screen. The full
+    // process list is Status-only, so it gets its own pump.
+
+    /// Latest snapshot, off the shared 1 s `snapshot.live` pump.
+    func subscribeSnapshot() async {
+        for await v in feeds.liveSnapshot(live).subscribeValues() {
+            snap = v.snap
         }
     }
 
-    func stop() {
-        liveTimer?.invalidate(); liveTimer = nil
-        histTimer?.invalidate(); histTimer = nil
+    /// Sparklines, off the shared 15 s `metrics.sparklines.30m` pump (the
+    /// HUD reads the same pump for its tiles + top drain).
+    func subscribeSparklines() async {
+        for await v in feeds.metricSparklines(db: db).subscribeValues() {
+            cpuHist = v.cpu; memHist = v.mem; gpuHist = v.gpu; netHist = v.net; fanHist = v.fan
+        }
+    }
+
+    /// The full live process list + per-pid energy, off the 2 s
+    /// `processes.full` pump. One `ps` pass + the PWR lookups, off the main
+    /// thread (the spawn blocks ~10–30 ms), published together so a row and
+    /// its energy always belong to the same pass. In-flight coalescing in
+    /// the feed drops overlapping passes — the role the old
+    /// `samplingProcesses` flag played.
+    func subscribeProcesses() async {
+        let live = self.live
+        let feed = feeds.feed("processes.full", cadence: 2) {
+            // The energy lookups need a row set even when `ps` returns
+            // nothing (spawn failure): fall back to the snapshot's engine
+            // top five so the PWR column still fills for those rows, exactly
+            // as the old refreshProcesses did. (`lastSnapshot` is a
+            // main-thread-confined published value — read it on the main
+            // actor.)
+            let fallback = await MainActor.run { live.lastSnapshot?.topProcesses ?? [] }
+            return await Task.detached(priority: .userInitiated) {
+                let sampled = ProcessSampler.sample()
+                let rows = sampled.isEmpty ? fallback : sampled
+                var energies: [Int: UInt64] = [:]
+                for p in rows { energies[p.pid] = ProcessActions.energyNanojoules(pid: p.pid) }
+                return ProcessSample(processes: sampled, energies: energies)
+            }.value
+        }
+        for await v in feed.subscribeValues() {
+            // Empty pass (spawn failure) keeps the table on the snapshot's
+            // engine top five — sortedProcesses() falls back when empty.
+            processes = v.processes
+            energies = v.energies
+        }
     }
 
     func setSort(_ key: ProcSort) {
@@ -783,55 +828,4 @@ final class StatusModel: ObservableObject {
         return pin + rest
     }
 
-    private func refreshCurrent() {
-        snap = live.lastSnapshot
-        refreshProcesses()
-    }
-
-    /// One `ps` pass + the PWR lookups, off the main thread (the spawn
-    /// blocks ~10–30 ms), published together so a row and its energy
-    /// always belong to the same pass. Best-effort PWR per pid; "—"
-    /// where the kernel says nothing (other users' processes, kernel
-    /// tasks).
-    private func refreshProcesses() {
-        guard !samplingProcesses else { return }
-        samplingProcesses = true
-        let fallback = snap?.topProcesses ?? []
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let sampled = ProcessSampler.sample()
-            let rows = sampled.isEmpty ? fallback : sampled
-            var out: [Int: UInt64] = [:]
-            for p in rows {
-                out[p.pid] = ProcessActions.energyNanojoules(pid: p.pid)
-            }
-            Task { @MainActor in
-                guard let self else { return }
-                self.samplingProcesses = false
-                self.processes = sampled
-                self.energies = out
-            }
-        }
-    }
-
-    private func refreshHistory() {
-        let now = Int(Date().timeIntervalSince1970)
-        let since = now - 30 * 60
-        var cpu: [Double] = [], mem: [Double] = [], gpu: [Double] = [], net: [Double] = []
-        var fan: [Double] = []
-        for stored in MetricsStore(db: db).snapshots(.init(since: since, until: now), maxPoints: 40).snapshots {
-            let s = stored.status
-            cpu.append(s.cpu.usage)
-            mem.append(s.memory.usedPercent)
-            gpu.append(max(0, s.gpu?.first?.usage ?? 0))
-            let rx = s.network.reduce(0.0) { $0 + $1.rxRateMbs }
-            let tx = s.network.reduce(0.0) { $0 + $1.txRateMbs }
-            net.append(rx + tx)
-            // Same rule as the History chart: plot RPM whenever fans are
-            // detected — including 0 (parked) — skip fan-less snapshots.
-            if let thermal = s.thermal, (thermal.fanCount ?? 0) > 0 {
-                fan.append(Double(thermal.fanSpeed))
-            }
-        }
-        cpuHist = cpu; memHist = mem; gpuHist = gpu; netHist = net; fanHist = fan
-    }
 }

--- a/Tests/FeedsTests.swift
+++ b/Tests/FeedsTests.swift
@@ -172,6 +172,185 @@ final class FeedsTests: XCTestCase {
         XCTAssertEqual(v, 1)
         feed.detach()
     }
+
+    // MARK: Migration — the shared metric pumps (issue #53 remainder)
+    //
+    // The headline of the migration: the popover HUD and the Status pane
+    // used to run their own timer pairs polling the same `LiveFeed`
+    // snapshot and the same DB history window. Now both ask the hub for the
+    // SAME keys, so each query is ONE pump — one timer, one read, two
+    // observers. These assert that property end-to-end with the real
+    // `liveSnapshot`/`metricSparklines` factories.
+
+    func testMetricPumps_sameKeyAcrossTwoScreens_isOnePump() throws {
+        let db = try Self.tempDB()
+        defer { Self.removeDB(db) }
+        let live = LiveFeed()
+
+        // "HUD" and "Status" each resolve the snapshot + sparkline queries.
+        let hudSnap = hub.liveSnapshot(live)
+        let statusSnap = hub.liveSnapshot(live)
+        let hudSpark = hub.metricSparklines(db: db.db)
+        let statusSpark = hub.metricSparklines(db: db.db)
+
+        XCTAssertTrue(hudSnap === statusSnap, "both screens share ONE snapshot pump")
+        XCTAssertTrue(hudSpark === statusSpark, "both screens share ONE sparkline pump")
+        // …and the two queries are distinct pumps (different keys).
+        XCTAssertFalse((hudSnap as AnyObject) === (hudSpark as AnyObject))
+    }
+
+    func testSharedSnapshotPump_twoSubscribers_oneFetchPerTick() async throws {
+        let live = LiveFeed()
+        // The HUD and the Status pane both bind the live-snapshot pump.
+        let hud = hub.liveSnapshot(live)
+        let status = hub.liveSnapshot(live)
+        XCTAssertTrue(hud === status)
+
+        hud.attach()                       // popover opens
+        await settle()
+        XCTAssertEqual(hud.fetchCount, 1, "first subscriber takes an immediate sample")
+
+        status.attach()                    // Status pane mounts onto the same pump
+        clock.advance()
+        await settle()
+        XCTAssertEqual(hud.fetchCount, 2,
+                       "two subscribers + one tick = ONE upstream read, not two")
+
+        status.detach()                    // leave Status; popover still open
+        clock.advance()
+        await settle()
+        XCTAssertEqual(hud.fetchCount, 3, "one subscriber left → still ticking")
+
+        hud.detach()                       // popover closes
+        clock.advance()
+        clock.advance()
+        await settle()
+        XCTAssertEqual(hud.fetchCount, 3, "zero subscribers → zero reads, structurally")
+    }
+
+    func testMetricSparklines_identicalWindow_suppressesRepublish() async throws {
+        let db = try Self.tempDB()
+        defer { Self.removeDB(db) }
+        // Two rows, fixed — the window doesn't change between ticks, so the
+        // projected value is identical and the change token must fold it.
+        try db.insertSnapshot(ts: 100, cpu: 10)
+        try db.insertSnapshot(ts: 200, cpu: 20)
+
+        let feed = hub.metricSparklines(db: db.db)
+        var publishes = 0
+        let sub = feed.objectWillChange.sink { publishes += 1 }
+        defer { sub.cancel() }
+
+        feed.attach()
+        await settle()
+        let afterFirst = publishes
+        clock.advance()
+        clock.advance()
+        await settle()
+        XCTAssertEqual(publishes, afterFirst,
+                       "an unchanged DB window must cause zero republishes across ticks")
+        feed.detach()
+    }
+
+    // MARK: Migration — Sparklines aggregation (pure helper)
+
+    func testSparklines_projectsEachSeriesAndRanksTopDrain() throws {
+        // Two snapshots: rising CPU, a fan-reporting machine, and one
+        // process ("hog") that out-CPUs the rest on average.
+        let s1 = try Self.status(cpu: 10, memPct: 40, rx: 1, tx: 2, gpu: 5,
+                                 fanCount: 2, fanSpeed: 1200,
+                                 procs: [("hog", 80), ("idle", 1)])
+        let s2 = try Self.status(cpu: 30, memPct: 50, rx: 3, tx: 4, gpu: 15,
+                                 fanCount: 2, fanSpeed: 1400,
+                                 procs: [("hog", 90), ("idle", 2)])
+
+        let out = Sparklines.from([s1, s2])
+        XCTAssertEqual(out.cpu, [10, 30])
+        XCTAssertEqual(out.mem, [40, 50])
+        XCTAssertEqual(out.net, [3, 7], "net is rx+tx summed across interfaces")
+        XCTAssertEqual(out.gpu, [5, 15])
+        XCTAssertEqual(out.fan, [1200, 1400], "RPM kept only when fans are reported")
+        XCTAssertEqual(out.topDrain?.name, "hog", "heaviest process by average CPU")
+        XCTAssertEqual(out.topDrain?.avgCPU ?? 0, 85, accuracy: 0.001)
+    }
+
+    func testSparklines_dropsFanlessSnapshots_andTrimsToTail() throws {
+        // No fans on this machine → the fan series stays empty even though
+        // the other series have points (the "no placebo zeros" rule).
+        let noFan = try Self.status(cpu: 1, memPct: 1, rx: 0, tx: 0, gpu: 0,
+                                    fanCount: 0, fanSpeed: 0, procs: [])
+        let out1 = Sparklines.from([noFan, noFan, noFan])
+        XCTAssertEqual(out1.fan, [], "fan-less snapshots contribute nothing")
+        XCTAssertEqual(out1.cpu.count, 3)
+        XCTAssertNil(out1.topDrain, "no processes → no drain")
+
+        // tailPoints trims the sparkline to its newest N while keeping order.
+        let many = try (0..<10).map { try Self.status(cpu: Double($0), memPct: 0, rx: 0, tx: 0,
+                                                       gpu: 0, fanCount: 0, fanSpeed: 0, procs: []) }
+        let out2 = Sparklines.from(many, tailPoints: 3)
+        XCTAssertEqual(out2.cpu, [7, 8, 9], "keeps the newest tailPoints in order")
+    }
+}
+
+// MARK: - Migration test plumbing (snapshot/DB builders)
+
+extension FeedsTests {
+    /// A throwaway on-disk DB plus a tiny snapshot writer, mirroring the
+    /// MetricsStoreTests pattern (real SQLite, no mocks).
+    final class TempDB {
+        let db: DB
+        let dir: URL
+        init() throws {
+            dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("burrow-feeds-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            db = try DB(at: dir.appendingPathComponent("burrow.db"))
+        }
+        func insertSnapshot(ts: Int, cpu: Double) throws {
+            try db.insert(prefix: MetricsStore.snapshotPrefix, ts: ts,
+                          json: FeedsTests.statusJSON(cpu: cpu))
+        }
+    }
+
+    nonisolated static func tempDB() throws -> TempDB { try TempDB() }
+    nonisolated static func removeDB(_ t: TempDB) { try? FileManager.default.removeItem(at: t.dir) }
+
+    /// Minimal valid `mo status --json` for a CPU value (the sparkline test
+    /// only needs the window to be non-empty and stable).
+    nonisolated static func statusJSON(cpu: Double) -> String {
+        """
+        {"collected_at":"2026-06-08T03:16:25.068057-07:00","host":"h","platform":"darwin",
+         "uptime_seconds":100,"procs":1,
+         "hardware":{"model":"Mac","cpu_model":"M","total_ram":"24 GB","disk_size":"460 GB","os_version":"26"},
+         "health_score":90,"health_score_msg":"Good",
+         "cpu":{"usage":\(cpu),"load1":1,"load5":1,"load15":1,"core_count":10,"logical_cpu":10},
+         "memory":{"used":1,"total":2,"used_percent":50,"swap_used":0,"swap_total":0,"pressure":""},
+         "disk_io":{"read_rate":0,"write_rate":0}}
+        """
+    }
+
+    /// Decode a synthetic MoleStatus for the pure-aggregation tests.
+    nonisolated static func status(cpu: Double, memPct: Double, rx: Double, tx: Double, gpu: Double,
+                                   fanCount: Int, fanSpeed: Int,
+                                   procs: [(name: String, cpu: Double)]) throws -> MoleStatus {
+        let top = procs.map {
+            "{\"pid\":1,\"name\":\"\($0.name)\",\"command\":\"\($0.name)\",\"cpu\":\($0.cpu),\"memory\":0}"
+        }.joined(separator: ",")
+        let json = """
+        {"collected_at":"2026-06-08T03:16:25.068057-07:00","host":"h","platform":"darwin",
+         "uptime_seconds":100,"procs":1,
+         "hardware":{"model":"Mac","cpu_model":"M","total_ram":"24 GB","disk_size":"460 GB","os_version":"26"},
+         "health_score":90,"health_score_msg":"Good",
+         "cpu":{"usage":\(cpu),"load1":1,"load5":1,"load15":1,"core_count":10,"logical_cpu":10},
+         "memory":{"used":1,"total":2,"used_percent":\(memPct),"swap_used":0,"swap_total":0,"pressure":""},
+         "disk_io":{"read_rate":0,"write_rate":0},
+         "network":[{"name":"en0","rx_rate_mbs":\(rx),"tx_rate_mbs":\(tx),"ip":"10.0.0.1"}],
+         "gpu":[{"name":"GPU","usage":\(gpu),"memory_used":0,"memory_total":0,"core_count":8}],
+         "thermal":{"cpu_temp":0,"gpu_temp":0,"fan_speed":\(fanSpeed),"fan_count":\(fanCount),"system_power":0},
+         "top_processes":[\(top)]}
+        """
+        return try JSONDecoder().decode(MoleStatus.self, from: Data(json.utf8))
+    }
 }
 
 // MARK: - Test plumbing


### PR DESCRIPTION
Completes #53's remainder: the three remaining per-view models (HUDModel, StatusModel, ActivityModel) move off view-owned `Timer`s onto shared `FeedHub` pumps, and the popup↔Status double-poll is deduped.

## What changed
- **New `Sources/MetricsFeeds.swift`** — shared-key factories so the HUD and Status pane can't drift to different keys: `liveSnapshot(_:)` (key `snapshot.live`, 1 s) and `metricSparklines(db:)` (key `metrics.sparklines.30m`, 15 s). One 1-hour DB read → projected once into CPU/mem/net/gpu/fan + top-drain. Pure `Sparklines.from(_:)` split out for unit testing.
- **PopupView/HUDModel, StatusView/StatusModel, ActivityView/ActivityModel** — timers removed, replaced by `.task`-scoped feed subscriptions (nothing ticks behind a closed popover / off-screen pane). Plumbed `feeds` through StatusBarController + HomeView.
- **Dedup:** both surfaces resolve the SAME `Feed` instance → one timer, one fetch per tick, N observers; the 30-min sparkline read collapses from two DB queries to one when both are visible.

## Behavior notes
- Status sparkline now shows the trailing ~30 pts of the shared 60-min read (materially the same recent window); the live 1 Hz net ring the net tile prefers is untouched.
- Clean Watch: the per-view 24 h static cache is gone; the feed shows its last value instantly and refetches `mo history` once per popover open (cheap, background) — the demand-driven tradeoff for a fresher footer.

Tests: +5 FeedsTests (shared-pump, leak-freedom, change-token suppression, pure projection); 392 green (LocalizationTests skipped in worktree). Builds with 0 warnings.

Part of #53 (HUD/Status/Activity done; the feed core + HistoryView shipped earlier).