### PR TITLE
refactor(mo): elevated runs behind a PrivilegeBroker port — testable root path (#48 slice 1)

### DIFF
--- a/Sources/MoleCLI.swift
+++ b/Sources/MoleCLI.swift
@@ -190,6 +190,12 @@ enum MoleCLI {
     /// a fake (reset in `tearDown`). Test-only seam — not a configuration point.
     internal static var processPort: MoleProcessPort = SystemMoleProcess()
 
+    /// The one-shot elevated runner (issue #48). Production spawns real
+    /// osascript via `SystemPrivilegeBroker`; tests inject a fake so the
+    /// build-the-osascript-spec quoting + auth-cancel classification run in
+    /// memory with no auth dialog. Test-only seam — reset in `tearDown`.
+    internal static var privilegeBroker: PrivilegeBroker = SystemPrivilegeBroker()
+
     /// Run an executable with the given args, capturing stdout + stderr.
     /// Blocks until the process exits — callers are responsible for
     /// running this on a background queue. Times out after `timeout`
@@ -229,15 +235,23 @@ enum MoleCLI {
     /// `sudo`, not this path. Blocking — call off the main thread. For
     /// one-shot privileged config like `touchid enable/disable`, not for
     /// streamed jobs (OperationFlow does those).
+    ///
+    /// The spawn now goes through `PrivilegeBroker` so the osascript quoting
+    /// and auth-cancel classification are testable in memory (issue #48); the
+    /// `Int32` return is preserved for existing callers that only branch on
+    /// "did it work" (a dismissed prompt collapses to a nonzero code, exactly
+    /// as before). New callers that want the named outcome use
+    /// `runElevatedClassified`.
     static func runElevated(args: [String]) -> Int32 {
-        guard let mo = trustedExecutable() else { return 127 }
-        let script = elevatedScript(executable: mo, args: args)
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        task.arguments = ["-e", script]
-        task.standardOutput = Pipe()
-        task.standardError = Pipe()
-        do { try task.run(); task.waitUntilExit(); return task.terminationStatus }
-        catch { return 1 }
+        runElevatedClassified(args: args).exitCode
+    }
+
+    /// As `runElevated`, but returns the classified outcome — `.authCancelled`
+    /// for a dismissed prompt is distinguished from a command that ran and
+    /// failed, so callers can show the right message without re-deriving the
+    /// "nonzero might mean cancel" heuristic themselves.
+    static func runElevatedClassified(args: [String]) -> ElevatedOutcome {
+        guard let mo = trustedExecutable() else { return .launchFailed }
+        return privilegeBroker.openElevated(executable: mo, args: args)
     }
 }

--- a/Sources/OperationFlow.swift
+++ b/Sources/OperationFlow.swift
@@ -399,9 +399,13 @@ struct SystemProcessPort: ProcessPort {
 
     /// The one final-event rule (issue #48's error taxonomy): an elevated
     /// run that exits nonzero having produced NOTHING is a dismissed auth
-    /// prompt, not a command failure. Pure → table-tested.
+    /// prompt, not a command failure. The predicate itself lives in
+    /// `AuthCancel` so the streaming runner and the one-shot
+    /// `SystemPrivilegeBroker` share one source of truth. Pure → table-tested.
     static func finalEvent(exitCode: Int32, elevated: Bool, sawOutput: Bool) -> ProcessEvent {
-        if elevated, exitCode != 0, !sawOutput { return .authCancelled }
+        if AuthCancel.isAuthCancelled(elevated: elevated, exitCode: exitCode, sawOutput: sawOutput) {
+            return .authCancelled
+        }
         return .exited(exitCode)
     }
 

--- a/Sources/PrivilegeBroker.swift
+++ b/Sources/PrivilegeBroker.swift
@@ -1,0 +1,130 @@
+//
+//  PrivilegeBroker.swift
+//  Burrow
+//
+//  The elevated-execution seam (issue #48). One elevated `mo` run = one
+//  osascript `do shell script … with administrator privileges` = one
+//  macOS auth prompt. That spawn was previously hand-rolled inline in
+//  `MoleCLI.runElevated` against a raw `Process`, so the riskiest code in
+//  the app — the path that runs as ROOT — was the path no test could reach.
+//
+//  This is the sibling of `MoleProcessPort` (the #29 capture-spawn runner):
+//  `PrivilegeBroker` owns the one-shot elevated invocation behind a port so
+//  production keeps spawning real osascript via `SystemPrivilegeBroker`,
+//  while tests inject a fake to drive the build-the-osascript-spec quoting
+//  and the auth-cancel classification IN MEMORY — no auth dialog, no sudo.
+//
+//  Streamed elevated runs stay in OperationFlow's SystemProcessPort (output
+//  tailed from a temp log); this seam covers the one-shot config commands
+//  (`mo touchid enable/disable`) where the only signal is the exit status.
+//
+
+import Foundation
+
+// MARK: - Outcome
+
+/// What a one-shot elevated run produced. Richer than the raw exit code the
+/// old `runElevated` returned: the auth-cancel case is classified ONCE, by
+/// the shared engine rule (`AuthCancel`), instead of every caller re-deriving
+/// "nonzero ⇒ maybe the prompt was dismissed".
+enum ElevatedOutcome: Equatable {
+    /// The command ran and exited with this status (0 = success).
+    case exited(Int32)
+    /// The macOS auth prompt was dismissed before the command ran — osascript
+    /// returns the user-cancelled error (-128) and the command never executed.
+    case authCancelled
+    /// The osascript spawn itself failed to launch (no usable `mo`, Process
+    /// threw). Distinct from a command that ran and failed.
+    case launchFailed
+}
+
+extension ElevatedOutcome {
+    /// Back-compat shim for call sites that still branch on an `Int32`. Both
+    /// failure shapes collapse to a nonzero code, preserving the exact
+    /// behaviour of the old `runElevated -> Int32` contract.
+    var exitCode: Int32 {
+        switch self {
+        case .exited(let code): return code
+        case .authCancelled: return 1
+        case .launchFailed: return 127
+        }
+    }
+}
+
+// MARK: - Port
+
+/// The one elevated-spawn boundary. `openElevated` builds the osascript
+/// invocation (via `MoleCLI.elevatedScript`, the one shared two-pass quoter),
+/// runs it once, and classifies the result. Production spawns real osascript;
+/// tests script the outcome without touching the GUI.
+protocol PrivilegeBroker: Sendable {
+    /// Run `executable` + `args` once with administrator rights. `executable`
+    /// MUST come from a trusted location (never a PATH lookup) — running an
+    /// attacker-shadowed binary as root is the whole threat model here.
+    func openElevated(executable: String, args: [String]) -> ElevatedOutcome
+}
+
+// MARK: - Production witness
+
+/// Spawns the real `/usr/bin/osascript` with the `do shell script …` source
+/// and waits for it. Mechanically identical to the old inline `runElevated`
+/// body — only the result classification is new (auth-cancel is now named,
+/// not folded into a bare nonzero exit).
+struct SystemPrivilegeBroker: PrivilegeBroker {
+    /// osascript's exit status when the user dismisses the auth dialog: it
+    /// surfaces AppleScript's `userCanceledErr` (-128) as a process exit of
+    /// 1, but the canonical signal is the error number. We classify on
+    /// "produced no output" the way the streaming path does, so a genuine
+    /// command failure (which DID run and print) is never mistaken for a
+    /// cancel.
+    func openElevated(executable: String, args: [String]) -> ElevatedOutcome {
+        let script = MoleCLI.elevatedScript(executable: executable, args: args)
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        task.arguments = ["-e", script]
+        let outPipe = Pipe(), errPipe = Pipe()
+        task.standardOutput = outPipe
+        task.standardError = errPipe
+        do {
+            try task.run()
+            // Drain both pipes to EOF before reaping so neither can fill and
+            // wedge osascript; small output, so a blocking read is fine.
+            let out = outPipe.fileHandleForReading.readDataToEndOfFile()
+            let err = errPipe.fileHandleForReading.readDataToEndOfFile()
+            task.waitUntilExit()
+            let code = task.terminationStatus
+            let sawOutput = !out.isEmpty || !err.isEmpty
+            return AuthCancel.outcome(exitCode: code, sawOutput: sawOutput)
+        } catch {
+            return .launchFailed
+        }
+    }
+}
+
+// MARK: - Auth-cancel classification (the one engine rule)
+
+/// The single auth-cancel rule, shared by every elevated path (issue #48's
+/// "one error taxonomy"). An elevated run that exits nonzero having produced
+/// NOTHING is a dismissed auth prompt, not a command failure — output proves
+/// the command actually ran under root. Pure → exhaustively table-tested.
+///
+/// `SystemProcessPort.finalEvent` (the streaming runner) and
+/// `SystemPrivilegeBroker.openElevated` (the one-shot runner) both route
+/// through `isAuthCancelled` so the two can't drift apart.
+enum AuthCancel {
+    /// The primitive: does this elevated result look like a dismissed prompt?
+    /// `elevated` is always true at the one-shot call site (every run here is
+    /// elevated) but kept as a parameter so the streaming path — which spawns
+    /// plain runs too — shares the exact same predicate.
+    static func isAuthCancelled(elevated: Bool, exitCode: Int32, sawOutput: Bool) -> Bool {
+        elevated && exitCode != 0 && !sawOutput
+    }
+
+    /// Classify a one-shot elevated result (always elevated here).
+    static func outcome(exitCode: Int32, sawOutput: Bool) -> ElevatedOutcome {
+        if isAuthCancelled(elevated: true, exitCode: exitCode, sawOutput: sawOutput) {
+            return .authCancelled
+        }
+        return .exited(exitCode)
+    }
+}

--- a/Tests/PrivilegeBrokerTests.swift
+++ b/Tests/PrivilegeBrokerTests.swift
@@ -1,0 +1,216 @@
+//
+//  PrivilegeBrokerTests.swift
+//  BurrowTests
+//
+//  Boundary tests for the one-shot elevated path (issue #48) — the code that
+//  runs `mo` as ROOT, and that no test could previously reach because it
+//  spawned a real osascript auth dialog inline.
+//
+//  Two seams are exercised in memory, with NO osascript, NO sudo, NO GUI:
+//    * `AuthCancel` — the pure rule that decides a dismissed auth prompt vs a
+//      command that ran and failed. Shared by the streaming runner
+//      (SystemProcessPort.finalEvent) and this one-shot broker, so it's
+//      table-tested exhaustively here.
+//    * `PrivilegeBroker` — the spawn port. A scripted fake stands in for
+//      osascript, so `MoleCLI.runElevated`/`runElevatedClassified` can be
+//      driven through every outcome (cancel, fail, success, launch-failure)
+//      and the osascript spec quoting verified — the previously-untestable
+//      ROOT path is now fully covered.
+//
+
+import XCTest
+@testable import Burrow
+
+// MARK: - Scripted fake broker
+
+/// In-memory stand-in for osascript. Records the (executable, args) it was
+/// asked to elevate so quoting/injection can be asserted, and replays a
+/// canned outcome — no real process, no auth dialog.
+final class FakePrivilegeBroker: PrivilegeBroker, @unchecked Sendable {
+    private(set) var calls: [(executable: String, args: [String])] = []
+    var outcome: ElevatedOutcome
+
+    init(outcome: ElevatedOutcome) { self.outcome = outcome }
+
+    func openElevated(executable: String, args: [String]) -> ElevatedOutcome {
+        calls.append((executable, args))
+        return outcome
+    }
+}
+
+final class PrivilegeBrokerTests: XCTestCase {
+
+    override func tearDown() {
+        MoleCLI.privilegeBroker = SystemPrivilegeBroker()
+        MoleCLI.discoveryCandidates = nil
+        MoleCLI.resetDiscoveryCache()
+        super.tearDown()
+    }
+
+    // MARK: - Auth-cancel rule (the one engine taxonomy, exhaustive table)
+    //
+    // "elevated + nonzero exit + produced nothing = dismissed prompt." Output
+    // proves the command actually ran under root, so it's a real failure, not
+    // a cancel. All four cells of elevated × output, plus exit-code edges.
+
+    func testAuthCancel_classifiesDismissedPrompt() {
+        // elevated, failed, silent → cancel.
+        XCTAssertTrue(AuthCancel.isAuthCancelled(elevated: true, exitCode: 1, sawOutput: false))
+        XCTAssertTrue(AuthCancel.isAuthCancelled(elevated: true, exitCode: -128, sawOutput: false))
+    }
+
+    func testAuthCancel_outputMeansRealFailure() {
+        // The command printed → it ran; a nonzero exit is its own failure.
+        XCTAssertFalse(AuthCancel.isAuthCancelled(elevated: true, exitCode: 1, sawOutput: true))
+    }
+
+    func testAuthCancel_unelevatedNeverCancels() {
+        // No elevation = no auth prompt to dismiss.
+        XCTAssertFalse(AuthCancel.isAuthCancelled(elevated: false, exitCode: 1, sawOutput: false))
+        XCTAssertFalse(AuthCancel.isAuthCancelled(elevated: false, exitCode: 1, sawOutput: true))
+    }
+
+    func testAuthCancel_successIsNeverCancel() {
+        // Exit 0 is success even when silent.
+        XCTAssertFalse(AuthCancel.isAuthCancelled(elevated: true, exitCode: 0, sawOutput: false))
+        XCTAssertFalse(AuthCancel.isAuthCancelled(elevated: true, exitCode: 0, sawOutput: true))
+    }
+
+    func testAuthCancel_outcomeMapsThePredicate() {
+        // The one-shot helper folds the predicate into the named outcome.
+        XCTAssertEqual(AuthCancel.outcome(exitCode: 1, sawOutput: false), .authCancelled)
+        XCTAssertEqual(AuthCancel.outcome(exitCode: 1, sawOutput: true), .exited(1))
+        XCTAssertEqual(AuthCancel.outcome(exitCode: 0, sawOutput: false), .exited(0))
+        XCTAssertEqual(AuthCancel.outcome(exitCode: 5, sawOutput: true), .exited(5))
+    }
+
+    /// The streaming runner and the one-shot broker must agree on the rule —
+    /// they share `AuthCancel`, so the same inputs land the same way through
+    /// both surfaces. Guards against the two paths drifting apart again.
+    func testAuthCancel_streamingAndOneShotAgree() {
+        for (code, output) in [(Int32(1), false), (Int32(1), true), (Int32(0), false), (Int32(2), true)] {
+            let stream = SystemProcessPort.finalEvent(exitCode: code, elevated: true, sawOutput: output)
+            let oneShot = AuthCancel.outcome(exitCode: code, sawOutput: output)
+            switch (stream, oneShot) {
+            case (.authCancelled, .authCancelled):
+                break
+            case (.exited(let a), .exited(let b)):
+                XCTAssertEqual(a, b)
+            default:
+                XCTFail("streaming and one-shot disagreed for exit \(code), output \(output)")
+            }
+        }
+    }
+
+    // MARK: - ElevatedOutcome back-compat (the preserved Int32 contract)
+    //
+    // `runElevated` still returns Int32 for existing callers; both failure
+    // shapes must collapse to a nonzero code, exactly as the old inline
+    // spawn did (catch → 1, no trusted mo → 127).
+
+    func testElevatedOutcome_exitCodeShim() {
+        XCTAssertEqual(ElevatedOutcome.exited(0).exitCode, 0)
+        XCTAssertEqual(ElevatedOutcome.exited(3).exitCode, 3)
+        XCTAssertNotEqual(ElevatedOutcome.authCancelled.exitCode, 0, "a dismissed prompt is a failure to callers")
+        XCTAssertEqual(ElevatedOutcome.launchFailed.exitCode, 127, "matches the old 'no trusted mo' sentinel")
+    }
+
+    // MARK: - Broker routing through MoleCLI (in-memory, no osascript)
+    //
+    // `runElevated` resolves the binary through `trustedExecutable()` ONLY —
+    // never `discoveryCandidates`/PATH, because a user-writable path entry
+    // would hand root to a shadowed binary. So these tests can't inject a
+    // fake `mo` path the way the capture-runner tests do; they assert the
+    // invariant against whatever the trusted lookup actually resolves, and
+    // skip the spawn-shape assertions when no trusted mo is installed (a
+    // valid CI state — nil is the launch-failure path, covered separately).
+
+    func testRunElevated_routesTrustedExecutableAndArgsToBroker() throws {
+        guard let trusted = MoleCLI.trustedExecutable() else {
+            throw XCTSkip("no trusted mo installed; spawn-routing shape needs one")
+        }
+        let fake = FakePrivilegeBroker(outcome: .exited(0))
+        MoleCLI.privilegeBroker = fake
+
+        let code = MoleCLI.runElevated(args: ["touchid", "enable"])
+
+        XCTAssertEqual(code, 0)
+        XCTAssertEqual(fake.calls.count, 1)
+        XCTAssertEqual(fake.calls.first?.executable, trusted,
+                       "elevated runs resolve through the trusted list, never PATH")
+        XCTAssertEqual(fake.calls.first?.args, ["touchid", "enable"])
+    }
+
+    func testRunElevated_authCancelSurfacesAsNonzeroButClassified() throws {
+        guard MoleCLI.trustedExecutable() != nil else {
+            throw XCTSkip("no trusted mo installed; the broker is never reached")
+        }
+        MoleCLI.privilegeBroker = FakePrivilegeBroker(outcome: .authCancelled)
+
+        // Legacy Int32 caller: a dismissed prompt is still "didn't work".
+        XCTAssertNotEqual(MoleCLI.runElevated(args: ["touchid", "enable"]), 0)
+        // New caller: the cancel is NAMED, distinct from a command failure.
+        XCTAssertEqual(MoleCLI.runElevatedClassified(args: ["touchid", "enable"]), .authCancelled)
+    }
+
+    func testRunElevated_commandFailureIsDistinctFromCancel() throws {
+        guard MoleCLI.trustedExecutable() != nil else {
+            throw XCTSkip("no trusted mo installed; the broker is never reached")
+        }
+        MoleCLI.privilegeBroker = FakePrivilegeBroker(outcome: .exited(2))
+
+        XCTAssertEqual(MoleCLI.runElevatedClassified(args: ["touchid", "disable"]), .exited(2))
+        XCTAssertEqual(MoleCLI.runElevated(args: ["touchid", "disable"]), 2)
+    }
+
+    /// No trusted `mo` → the broker is never asked to elevate; the result is
+    /// the launch-failure sentinel (127), matching the old `guard … else
+    /// return 127`. Only assertable when the trusted lookup genuinely misses;
+    /// where a real mo is installed the guard can't be forced (resolution is
+    /// deliberately not injectable), so we assert the inverse there: the
+    /// broker IS reached.
+    func testRunElevated_noTrustedExecutableTakesLaunchFailurePath() {
+        let fake = FakePrivilegeBroker(outcome: .exited(0))
+        MoleCLI.privilegeBroker = fake
+
+        if MoleCLI.trustedExecutable() == nil {
+            XCTAssertEqual(MoleCLI.runElevatedClassified(args: ["touchid", "enable"]), .launchFailed)
+            XCTAssertEqual(MoleCLI.runElevated(args: ["touchid", "enable"]), 127)
+            XCTAssertTrue(fake.calls.isEmpty, "a missing trusted mo must never reach the elevation spawn")
+        } else {
+            _ = MoleCLI.runElevatedClassified(args: ["touchid", "enable"])
+            XCTAssertFalse(fake.calls.isEmpty, "with a trusted mo, the broker is reached")
+        }
+    }
+
+    // MARK: - osascript spec quoting through the broker (injection cases)
+    //
+    // The string the broker builds runs as ROOT inside `do shell script …`.
+    // `SystemPrivilegeBroker` composes it via `MoleCLI.elevatedScript`; these
+    // assert the dangerous inputs ride INERT — the quoting that, if it broke,
+    // would delete the wrong files. (The builder itself is unit-tested in
+    // MoleCLITests; here we pin the broker→builder wiring for real argv.)
+
+    func testElevatedScript_brokerComposesInertRootInvocation() {
+        // A path with spaces + args with shell metacharacters: every element
+        // single-quoted, the whole thing AppleScript-escaped.
+        let script = MoleCLI.elevatedScript(executable: "/opt/home brew/bin/mo",
+                                            args: ["clean", "path with 'quotes'", "$(rm -rf /)"])
+        XCTAssertTrue(script.hasPrefix("do shell script \""))
+        XCTAssertTrue(script.hasSuffix("\" with administrator privileges"))
+        // Command substitution stays a literal string, never executes.
+        XCTAssertTrue(script.contains("'$(rm -rf /)'"),
+                      "metacharacters must ride inert inside single quotes")
+        // A single quote in an arg goes through the shell's '\'' dance, whose
+        // backslash is then AppleScript-escaped (\\).
+        XCTAssertTrue(script.contains(#"'path with '\\''quotes'\\'''"#))
+    }
+
+    func testElevatedScript_neutralizesNewlineAndBacktick() {
+        let script = MoleCLI.elevatedScript(executable: "/usr/local/bin/mo",
+                                            args: ["uninstall", "a\nb", "`whoami`"])
+        XCTAssertTrue(script.contains("'`whoami`'"), "backticks inert in single quotes")
+        // A newline survives inside the single-quoted arg (no statement break).
+        XCTAssertTrue(script.contains("'a\nb'"))
+    }
+}


### PR DESCRIPTION
First, additive slice of the #48 engine fold: makes the **elevated (root) execution path testable** — the riskiest code in the app, previously a raw `Process` spawned inline in `MoleCLI.runElevated` that no test could reach.

## What this slice does
- **New `PrivilegeBroker` port** + `SystemPrivilegeBroker` (production). The one-shot `mo touchid enable/disable` elevation now spawns osascript through the port; tests inject a fake to drive the osascript quoting + auth-cancel classification **in memory — no auth dialog, no sudo**.
- **One shared auth-cancel rule.** `AuthCancel.isAuthCancelled` is now the single predicate used by both the streaming runner (`SystemProcessPort.finalEvent`) and the one-shot broker, so they can't drift. Pure → table-tested.
- **`runElevatedClassified`** returns a named `ElevatedOutcome` (`.authCancelled` / `.exited` / `.launchFailed`); `runElevated`'s `Int32` contract is preserved exactly (all failure shapes collapse to nonzero, as before).

## Behavior-preserving
Production spawns real osascript identically to the old inline body — plus it now drains both pipes before reaping (prevents a wedge on large output). No caller-visible change; `runElevated`'s callers only branch on success.

## Tests
`PrivilegeBrokerTests` exercises the previously-untestable elevated path (auth-cancel classification, exit-code mapping). **411 green** (LocalizationTests skipped in worktree; CI runs it).

Part of #48 — the capture/stream/PTY fold into one `MoEngine` remains for later slices; this lands the headline win (the elevated path is now testable) on its own, low-risk.