### PR TITLE
refactor(mo): MoEngine facade for capture + elevated; migrate capture callers (#48)

### DIFF
--- a/Sources/DiskScanner.swift
+++ b/Sources/DiskScanner.swift
@@ -77,13 +77,14 @@ enum DiskScanner {
     /// for each direct child; drill in by calling again with the child's
     /// path.
     static func scan(_ path: String) throws -> DiskScanResult {
-        guard MoleCLI.findExecutable() != nil else {
+        guard case .installed = MoEngine.shared.availability() else {
             throw DiskScanError.moNotFound
         }
         // 5-minute timeout — `mo analyze` on the home dir is usually a
         // few seconds, but a cold cache + large external volume + no
         // indexing can stretch it. Beyond 5 min something's wrong.
-        let result = try MoleCLI.run(args: ["analyze", "--json", path], timeout: 300)
+        let result = try MoEngine.shared.capture(
+            MoCommand(target: .mo, args: ["analyze", "--json", path], timeout: 300))
         guard result.exitCode == 0 else {
             if indicatesMissingJSONSupport(stderr: result.stderr) {
                 throw DiskScanError.moTooOld(found: MoleCLI.version())

--- a/Sources/MCP.swift
+++ b/Sources/MCP.swift
@@ -538,7 +538,8 @@ struct ToolCatalog {
     /// object when `mo` isn't installed so the tool never throws.
     private func callCleanupHistory(_ args: [String: Any]) -> String {
         let limit = max(1, min((args["limit"] as? Int) ?? 20, 200))
-        let res = try? MoleCLI.run(args: ["history", "--json", "--limit", "\(limit)"], timeout: 15)
+        let res = try? MoEngine.shared.capture(
+            MoCommand(target: .mo, args: ["history", "--json", "--limit", "\(limit)"], timeout: 15))
         return Self.cleanupHistoryResult(exitCode: res?.exitCode ?? 127, stdout: res?.stdout ?? "")
     }
 
@@ -605,7 +606,8 @@ struct ToolCatalog {
     private static func deletionsLogPath() -> String {
         let fallback = (NSHomeDirectory() as NSString)
             .appendingPathComponent("Library/Logs/mole/deletions.log")
-        guard let res = try? MoleCLI.run(args: ["history", "--json"], timeout: 10),
+        guard let res = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: ["history", "--json"], timeout: 10)),
               res.exitCode == 0,
               let data = res.stdout.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -713,8 +715,12 @@ struct ToolCatalog {
     /// Run `mo` with the given args, never throwing — a missing binary
     /// becomes exit code 127 so callers can degrade gracefully.
     private static func runMo(_ args: [String], stdin: String? = nil, timeout: TimeInterval) -> MoleCLI.Result {
-        (try? MoleCLI.run(args: args, stdin: stdin, timeout: timeout))
-            ?? MoleCLI.Result(stdout: "", stderr: "mo not found", exitCode: 127)
+        guard let cap = try? MoEngine.shared.capture(
+            MoCommand(target: .mo, args: args, stdin: stdin, timeout: timeout)) else {
+            return MoleCLI.Result(stdout: "", stderr: "mo not found", exitCode: 127)
+        }
+        return MoleCLI.Result(stdout: cap.stdout, stderr: cap.stderr,
+                              exitCode: cap.exitCode, timedOut: cap.timedOut)
     }
 
     /// Strip ANSI/VT100 escape sequences so mo's TUI coloring doesn't leak

--- a/Sources/MoEngine.swift
+++ b/Sources/MoEngine.swift
@@ -1,0 +1,183 @@
+//
+//  MoEngine.swift
+//  Burrow
+//
+//  The single entry point to the `mo` runners (issue #48). Burrow grew three
+//  process shapes — capture (small one-shot commands), streaming (clean /
+//  optimize), and PTY (purge / installer) — plus a one-shot elevated path,
+//  each found and spawned at its own call site. `MoEngine` is the ONE facade
+//  callers reach for so "how do I run mo?" has a single answer.
+//
+//  This slice (slice 2) wraps the CAPTURE + ELEVATED entry points and the
+//  discovery lookup, delegating to the existing, tested ports — it does NOT
+//  reimplement them. The streaming (`OperationFlow`/`SystemProcessPort`) and
+//  interactive PTY (`MoInteractive`/`PTYTask`) shapes are deliberately left in
+//  place; folding those onto the facade is the next slice.
+//
+//  Behavior is preserved exactly: a `capture(_:)` call produces the same argv,
+//  stdin, environment, timeout, and result fields that `MoleCLI.run` did, and
+//  `runElevatedClassified` routes through the same `PrivilegeBroker` against
+//  the same trusted-location resolution. The ports are injected (production
+//  defaults are the real ones) so the facade is testable with scripted fakes,
+//  matching the seams `MoleCLI`/`MoleProcess`/`PrivilegeBroker` already expose.
+//
+
+import Foundation
+
+// MARK: - Command shape
+
+/// One `mo` invocation, described once. `target` chooses how the executable is
+/// resolved (the discovered `mo`, or an explicit path like Homebrew's `brew`);
+/// the rest mirrors what the capture runner already accepts so migrating a
+/// `MoleCLI.run(...)` call is a 1:1 translation.
+struct MoCommand: Equatable {
+    enum Target: Equatable {
+        /// Resolve through discovery (`MoLocator.locate`); falls back to a
+        /// non-existent path so a missing `mo` surfaces as a nonzero exit, the
+        /// same degradation `MoleCLI.run` had.
+        case mo
+        /// Run this exact executable path (the brew straggler, test binaries).
+        case executable(String)
+    }
+
+    var target: Target
+    var args: [String]
+    var stdin: String?
+    var environment: [String: String]?
+    /// Same default as `MoleCLI.run` (10 s) so an unspecified timeout behaves
+    /// identically to the pre-facade call.
+    var timeout: TimeInterval
+
+    init(target: Target,
+         args: [String],
+         stdin: String? = nil,
+         environment: [String: String]? = nil,
+         timeout: TimeInterval = 10) {
+        self.target = target
+        self.args = args
+        self.stdin = stdin
+        self.environment = environment
+        self.timeout = timeout
+    }
+}
+
+// MARK: - Capture result
+
+/// What a captured run produced. A thin rename of `MoleProcessResult` /
+/// `MoleCLI.Result` so the typed parsers keep reading the same fields; the
+/// success convention is still `exitCode == 0`, and `timedOut` distinguishes a
+/// timeout kill from a genuine nonzero exit (issue #48's "no exit-15 lie").
+struct Captured: Equatable {
+    let stdout: String
+    let stderr: String
+    let exitCode: Int32
+    var timedOut: Bool = false
+}
+
+// MARK: - Discovery
+
+/// Where `mo` is, or that it's missing. Mirrors `MoleCLI.findExecutable()`
+/// returning `String?`, but names the miss so call sites read intent.
+enum Availability: Equatable {
+    case installed(path: String)
+    case missing
+}
+
+/// Discovery seam. Production resolves through `MoleCLI` (PATH + known
+/// locations, cached + revalidated for normal lookups; trusted-locations-only
+/// for elevated runs); tests inject a fake to drive resolution deterministically.
+protocol MoLocator: Sendable {
+    /// The `mo` for a normal (unelevated) run — PATH allowed.
+    func locate() -> String?
+    /// The `mo` for an ELEVATED run — known install locations ONLY, never a
+    /// user-writable PATH entry (running an attacker-shadowed binary as root is
+    /// the whole threat model).
+    func locateTrusted() -> String?
+}
+
+/// The production locator: delegates to `MoleCLI`'s existing discovery so the
+/// caching/revalidation and trusted-only semantics stay in one place.
+struct SystemMoLocator: MoLocator {
+    func locate() -> String? { MoleCLI.findExecutable() }
+    func locateTrusted() -> String? { MoleCLI.trustedExecutable() }
+}
+
+// MARK: - Facade
+
+/// The one runner facade. Capture + elevated + discovery in this slice; the
+/// ports are injected so every path is testable in memory.
+final class MoEngine {
+    private let processPort: MoleProcessPort
+    private let privilegeBroker: PrivilegeBroker
+    private let locator: MoLocator
+
+    /// Production singleton. Wraps the real capture runner, the real osascript
+    /// broker, and `MoleCLI` discovery — the exact spawn paths the migrated
+    /// call sites used before, just funneled through one type.
+    static let shared = MoEngine()
+
+    init(processPort: MoleProcessPort = SystemMoleProcess(),
+         privilegeBroker: PrivilegeBroker = SystemPrivilegeBroker(),
+         locator: MoLocator = SystemMoLocator()) {
+        self.processPort = processPort
+        self.privilegeBroker = privilegeBroker
+        self.locator = locator
+    }
+
+    // MARK: Discovery
+
+    /// Is `mo` installed, and where? Uses the normal (PATH-allowed) lookup.
+    func availability() -> Availability {
+        if let path = locator.locate() { return .installed(path: path) }
+        return .missing
+    }
+
+    // MARK: Capture
+
+    /// Capture stdout + stderr of one command. Blocks until the child exits —
+    /// call off the main thread. A `.mo` target that can't be resolved runs
+    /// `/usr/bin/false`, so a missing binary degrades to a nonzero exit instead
+    /// of throwing, exactly as `MoleCLI.run` did. Times out per `command`; on
+    /// timeout the child is killed and `Captured.timedOut` is set (the run
+    /// returns a nonzero exit, it does NOT throw for the timeout).
+    @discardableResult
+    func capture(_ command: MoCommand) throws -> Captured {
+        let executable: String
+        switch command.target {
+        case .mo:
+            // `/usr/bin/false` mirrors `MoleCLI.run`'s fallback: an unresolved
+            // `mo` yields a clean nonzero exit, never a crash.
+            executable = locator.locate() ?? "/usr/bin/false"
+        case .executable(let path):
+            executable = path
+        }
+
+        let result = try MoleProcess.capture(
+            executable: executable,
+            args: command.args,
+            stdin: command.stdin,
+            environment: command.environment,
+            timeout: command.timeout,
+            port: processPort
+        )
+        return Captured(
+            stdout: result.stdout,
+            stderr: result.stderr,
+            exitCode: result.exitCode,
+            timedOut: result.timedOut
+        )
+    }
+
+    // MARK: Elevated one-shot
+
+    /// Run `mo <args>` ONCE with administrator rights, returning the classified
+    /// outcome (`.authCancelled` distinguished from a command that ran and
+    /// failed). Resolves through the TRUSTED locations only — never PATH — and
+    /// routes through the same `PrivilegeBroker` the one-shot config commands
+    /// (`touchid enable/disable`) already use. No `mo` in a trusted spot →
+    /// `.launchFailed`, matching the old guard.
+    func runElevatedClassified(args: [String]) -> ElevatedOutcome {
+        guard let mo = locator.locateTrusted() else { return .launchFailed }
+        return privilegeBroker.openElevated(executable: mo, args: args)
+    }
+}

--- a/Sources/MoleClient.swift
+++ b/Sources/MoleClient.swift
@@ -21,7 +21,8 @@ enum MoleClient {
     /// Installed apps + the exact names `mo uninstall` accepts. Sizes can take a
     /// while on a full /Applications, so callers give it room.
     static func listApps(timeout: TimeInterval = 180) -> [InstalledApp] {
-        guard let res = try? MoleCLI.run(args: ["uninstall", "--list"], timeout: timeout),
+        guard let res = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: ["uninstall", "--list"], timeout: timeout)),
               res.exitCode == 0 else { return [] }
         return parseApps(Data(res.stdout.utf8))
     }
@@ -71,7 +72,8 @@ enum MoleClient {
     /// The periodic producer does NOT use this — it keeps the raw JSON to store +
     /// patch — but one-shot readers can.
     static func status(timeout: TimeInterval = 8) -> MoleStatus? {
-        guard let res = try? MoleCLI.run(args: ["status", "--json"], timeout: timeout),
+        guard let res = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: ["status", "--json"], timeout: timeout)),
               res.exitCode == 0,
               let s = try? JSONDecoder().decode(MoleStatus.self, from: Data(res.stdout.utf8))
         else { return nil }

--- a/Sources/MoleHistory.swift
+++ b/Sources/MoleHistory.swift
@@ -50,7 +50,8 @@ enum MoleHistory {
 
     /// Run `mo history --json` and parse it. Synchronous — call off-main.
     static func load() -> [HistorySession] {
-        guard let res = try? MoleCLI.run(args: ["history", "--json"], timeout: 30),
+        guard let res = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: ["history", "--json"], timeout: 30)),
               res.exitCode == 0,
               let data = res.stdout.data(using: .utf8) else { return [] }
         return parse(data)

--- a/Sources/SnapshotProducer.swift
+++ b/Sources/SnapshotProducer.swift
@@ -335,7 +335,8 @@ final class SnapshotProducer {
 /// or nonzero exit so the engine's failure model stays "skip this tick".
 struct MoCLIStatusSource: StatusSource {
     func statusJSON() throws -> String {
-        let result = try MoleCLI.run(args: ["status", "--json"], timeout: 8)
+        let result = try MoEngine.shared.capture(
+            MoCommand(target: .mo, args: ["status", "--json"], timeout: 8))
         guard result.exitCode == 0 else {
             throw NSError(domain: "Burrow.MoStatus", code: Int(result.exitCode), userInfo: [
                 NSLocalizedDescriptionKey: "mo status exit=\(result.exitCode) stderr=\(result.stderr.prefix(200))",

--- a/Sources/SoftwareView.swift
+++ b/Sources/SoftwareView.swift
@@ -538,7 +538,8 @@ final class SoftwareModel: ObservableObject {
         let name = app.uninstallName
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             // EOF after the prompt makes --dry-run print the enumeration and exit.
-            let res = try? MoleCLI.run(args: ["uninstall", "--dry-run", name], stdin: "y\n", timeout: 120)
+            let res = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: ["uninstall", "--dry-run", name], stdin: "y\n", timeout: 120))
             let text = Ansi.strip((res?.stdout ?? "") + "\n" + (res?.stderr ?? ""))
             let preview = UninstallPreview.parse(text.components(separatedBy: "\n"))
             Task { @MainActor in
@@ -709,7 +710,8 @@ final class SoftwareModel: ObservableObject {
             // user CONFIRMED. `--dry-run` changes nothing and exits at its
             // prompt on stdin EOF; an unparseable result aborts (fail closed).
             let pre = ticket.action.preflightCommand!
-            let dry = try? MoleCLI.run(args: pre.args, stdin: pre.stdin, timeout: pre.timeout ?? 120)
+            let dry = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: pre.args, stdin: pre.stdin, timeout: pre.timeout ?? 120))
             let dryText = (dry?.stdout ?? "") + "\n" + (dry?.stderr ?? "")
             let matched = UninstallGuard.matchedApps(inDryRunOutput: dryText)
             let problem: String?
@@ -738,8 +740,9 @@ final class SoftwareModel: ObservableObject {
             // Verified — the ticket's stdin answers mo's prompts (proceed +
             // final confirm); they only ever apply to the set the dry run
             // just pinned.
-            let res = try? MoleCLI.run(args: ticket.command.args, stdin: ticket.command.stdin,
-                                       timeout: ticket.command.timeout ?? 600)
+            let res = try? MoEngine.shared.capture(
+                MoCommand(target: .mo, args: ticket.command.args, stdin: ticket.command.stdin,
+                          timeout: ticket.command.timeout ?? 600))
             let ok = (res?.exitCode ?? 1) == 0
             let parsed = Self.fetch()
             Task { @MainActor in

--- a/Sources/UpdatesView.swift
+++ b/Sources/UpdatesView.swift
@@ -417,12 +417,9 @@ final class UpdatesModel: ObservableObject {
         let dir = (brew as NSString).deletingLastPathComponent
         env["PATH"] = "\(dir):/usr/bin:/bin:/usr/sbin:/sbin:" + (env["PATH"] ?? "")
         do {
-            let result = try MoleProcess.capture(
-                executable: brew,
-                args: args,
-                environment: env,
-                timeout: timeout
-            )
+            let result = try MoEngine.shared.capture(
+                MoCommand(target: .executable(brew), args: args,
+                          environment: env, timeout: timeout))
             return BrewResult(out: result.stdout, err: result.stderr, code: result.exitCode)
         } catch {
             return BrewResult(out: "", err: "\(error)", code: -1)

--- a/Tests/MoEngineTests.swift
+++ b/Tests/MoEngineTests.swift
@@ -1,0 +1,222 @@
+//
+//  MoEngineTests.swift
+//  BurrowTests
+//
+//  Boundary tests for the unified runner facade (issue #48, slice 2). The
+//  capture + elevated + discovery entry points all delegate to injected ports,
+//  so they're driven here with scripted fakes — same seam style as
+//  MoleProcessTests (capture port) and PrivilegeBrokerTests (elevation port).
+//
+//  The point of these tests is the WIRING: that a `MoCommand` lands on the
+//  capture runner as the exact argv/stdin/env/timeout it described, that a
+//  `.mo` target resolves through the locator (and degrades to a clean nonzero
+//  exit when `mo` is missing), and that the elevated path routes the TRUSTED
+//  binary to the broker — never a PATH lookup.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MoEngineTests: XCTestCase {
+    private enum FakeError: Error { case launchFailed }
+
+    // MARK: - Scripted ports
+
+    /// Records the capture call and replays a canned result (or throws).
+    private final class FakeCapturePort: MoleProcessPort {
+        var result = MoleProcessResult(stdout: "", stderr: "", exitCode: 0)
+        var error: Error?
+
+        private(set) var receivedExecutable: String?
+        private(set) var receivedArgs: [String]?
+        private(set) var receivedStdin: String?
+        private(set) var receivedEnvironment: [String: String]?
+        private(set) var receivedTimeout: TimeInterval?
+
+        func capture(executable: String,
+                     args: [String],
+                     stdin: String?,
+                     environment: [String: String]?,
+                     timeout: TimeInterval) throws -> MoleProcessResult {
+            receivedExecutable = executable
+            receivedArgs = args
+            receivedStdin = stdin
+            receivedEnvironment = environment
+            receivedTimeout = timeout
+            if let error { throw error }
+            return result
+        }
+    }
+
+    /// Canned discovery: the normal lookup and the trusted-only lookup are
+    /// separately settable so a test can prove the elevated path takes the
+    /// trusted one.
+    private struct FakeLocator: MoLocator {
+        var located: String?
+        var trusted: String?
+        func locate() -> String? { located }
+        func locateTrusted() -> String? { trusted }
+    }
+
+    /// In-memory stand-in for osascript: records the elevated (exe, args) and
+    /// replays a canned outcome — no auth dialog.
+    private final class FakeBroker: PrivilegeBroker, @unchecked Sendable {
+        private(set) var calls: [(executable: String, args: [String])] = []
+        var outcome: ElevatedOutcome
+        init(outcome: ElevatedOutcome) { self.outcome = outcome }
+        func openElevated(executable: String, args: [String]) -> ElevatedOutcome {
+            calls.append((executable, args))
+            return outcome
+        }
+    }
+
+    // MARK: - capture: command → port wiring
+
+    func testCapture_resolvesMoTargetThroughLocatorAndForwardsTheCommand() throws {
+        let port = FakeCapturePort()
+        port.result = MoleProcessResult(stdout: "out", stderr: "err", exitCode: 0)
+        let engine = MoEngine(processPort: port,
+                              locator: FakeLocator(located: "/fake/bin/mo"))
+
+        let captured = try engine.capture(MoCommand(
+            target: .mo,
+            args: ["status", "--json"],
+            stdin: "y\n",
+            environment: ["PATH": "/tmp"],
+            timeout: 8))
+
+        // The result maps field-for-field from the port's MoleProcessResult.
+        XCTAssertEqual(captured.stdout, "out")
+        XCTAssertEqual(captured.stderr, "err")
+        XCTAssertEqual(captured.exitCode, 0)
+        // The discovered path, args, stdin, env, and timeout reach the runner
+        // unchanged — behavior-preserving translation of the old MoleCLI.run.
+        XCTAssertEqual(port.receivedExecutable, "/fake/bin/mo")
+        XCTAssertEqual(port.receivedArgs, ["status", "--json"])
+        XCTAssertEqual(port.receivedStdin, "y\n")
+        XCTAssertEqual(port.receivedEnvironment, ["PATH": "/tmp"])
+        XCTAssertEqual(port.receivedTimeout, 8)
+    }
+
+    func testCapture_explicitExecutableTargetBypassesDiscovery() throws {
+        let port = FakeCapturePort()
+        // A locator that would resolve a different mo — proving the explicit
+        // path (the brew straggler's shape) wins.
+        let engine = MoEngine(processPort: port,
+                              locator: FakeLocator(located: "/fake/bin/mo"))
+
+        _ = try engine.capture(MoCommand(
+            target: .executable("/opt/homebrew/bin/brew"),
+            args: ["outdated", "--json=v2"],
+            timeout: 120))
+
+        XCTAssertEqual(port.receivedExecutable, "/opt/homebrew/bin/brew")
+        XCTAssertEqual(port.receivedArgs, ["outdated", "--json=v2"])
+    }
+
+    func testCapture_unresolvedMoFallsBackToFalseForACleanNonzeroExit() throws {
+        // The locator misses (mo not installed). The facade must NOT throw —
+        // it runs /usr/bin/false so the run degrades to a nonzero exit, exactly
+        // the way MoleCLI.run did. Uses the REAL capture port for the actual
+        // exit code.
+        let engine = MoEngine(locator: FakeLocator(located: nil))
+
+        let captured = try engine.capture(MoCommand(target: .mo, args: ["status"], timeout: 5))
+
+        XCTAssertNotEqual(captured.exitCode, 0, "a missing mo degrades to a nonzero exit, not a crash")
+    }
+
+    func testCapture_propagatesLaunchFailureFromPort() {
+        let port = FakeCapturePort()
+        port.error = FakeError.launchFailed
+        let engine = MoEngine(processPort: port,
+                              locator: FakeLocator(located: "/fake/bin/mo"))
+
+        XCTAssertThrowsError(try engine.capture(MoCommand(target: .mo, args: [])))
+    }
+
+    func testCapture_carriesTimedOutFlagThrough() throws {
+        let port = FakeCapturePort()
+        port.result = MoleProcessResult(stdout: "", stderr: "", exitCode: 15, timedOut: true)
+        let engine = MoEngine(processPort: port,
+                              locator: FakeLocator(located: "/fake/bin/mo"))
+
+        let captured = try engine.capture(MoCommand(target: .mo, args: ["analyze"], timeout: 1))
+
+        // Issue #48: a timeout says so — the flag rides through the facade so a
+        // caller can tell a kill apart from a genuine nonzero exit.
+        XCTAssertTrue(captured.timedOut)
+        XCTAssertEqual(captured.exitCode, 15)
+    }
+
+    func testCapture_defaultTimeoutMatchesTheOldTenSecondDefault() throws {
+        let port = FakeCapturePort()
+        let engine = MoEngine(processPort: port,
+                              locator: FakeLocator(located: "/fake/bin/mo"))
+
+        _ = try engine.capture(MoCommand(target: .mo, args: []))
+
+        XCTAssertEqual(port.receivedTimeout, 10, "unspecified timeout preserves MoleCLI.run's 10s default")
+    }
+
+    /// End-to-end through the REAL capture port with a tiny system binary, the
+    /// same local-substitutable style MoleCLITests uses for the runner.
+    func testCapture_capturesEchoThroughTheRealPort() throws {
+        let engine = MoEngine()
+        let captured = try engine.capture(MoCommand(
+            target: .executable("/bin/echo"), args: ["hello world"]))
+
+        XCTAssertEqual(captured.exitCode, 0)
+        XCTAssertEqual(captured.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "hello world")
+    }
+
+    // MARK: - Discovery availability
+
+    func testAvailability_installedReportsTheLocatedPath() {
+        let engine = MoEngine(locator: FakeLocator(located: "/fake/bin/mo"))
+        XCTAssertEqual(engine.availability(), .installed(path: "/fake/bin/mo"))
+    }
+
+    func testAvailability_missingWhenLocatorFindsNothing() {
+        let engine = MoEngine(locator: FakeLocator(located: nil))
+        XCTAssertEqual(engine.availability(), .missing)
+    }
+
+    // MARK: - Elevated one-shot
+
+    func testRunElevatedClassified_routesTrustedBinaryToTheBroker() {
+        let broker = FakeBroker(outcome: .exited(0))
+        // The normal lookup points one place; the elevated path must use the
+        // TRUSTED lookup — never PATH — so a shadowed binary can't get root.
+        let engine = MoEngine(privilegeBroker: broker,
+                              locator: FakeLocator(located: "/untrusted/mo",
+                                                   trusted: "/opt/homebrew/bin/mo"))
+
+        let outcome = engine.runElevatedClassified(args: ["touchid", "enable"])
+
+        XCTAssertEqual(outcome, .exited(0))
+        XCTAssertEqual(broker.calls.count, 1)
+        XCTAssertEqual(broker.calls.first?.executable, "/opt/homebrew/bin/mo",
+                       "elevated runs resolve through the trusted list, never the normal lookup")
+        XCTAssertEqual(broker.calls.first?.args, ["touchid", "enable"])
+    }
+
+    func testRunElevatedClassified_noTrustedBinaryIsLaunchFailedAndNeverReachesTheBroker() {
+        let broker = FakeBroker(outcome: .exited(0))
+        let engine = MoEngine(privilegeBroker: broker,
+                              locator: FakeLocator(located: "/untrusted/mo", trusted: nil))
+
+        XCTAssertEqual(engine.runElevatedClassified(args: ["touchid", "enable"]), .launchFailed)
+        XCTAssertTrue(broker.calls.isEmpty, "a missing trusted mo must never reach the elevation spawn")
+    }
+
+    func testRunElevatedClassified_authCancelIsDistinctFromCommandFailure() {
+        let cancel = MoEngine(privilegeBroker: FakeBroker(outcome: .authCancelled),
+                              locator: FakeLocator(trusted: "/opt/homebrew/bin/mo"))
+        XCTAssertEqual(cancel.runElevatedClassified(args: ["touchid", "enable"]), .authCancelled)
+
+        let failed = MoEngine(privilegeBroker: FakeBroker(outcome: .exited(2)),
+                              locator: FakeLocator(trusted: "/opt/homebrew/bin/mo"))
+        XCTAssertEqual(failed.runElevatedClassified(args: ["touchid", "disable"]), .exited(2))
+    }
+}


### PR DESCRIPTION
Next slice of #48 — a single `MoEngine` facade so "how do I run mo?" has one answer. **Additive and behavior-preserving**: wraps the existing, tested ports (capture via `MoleProcessPort`, elevated via `PrivilegeBroker`, discovery via `MoleCLI`) without reimplementing them.

## What landed
- New `Sources/MoEngine.swift`: `MoCommand` (target/args/stdin/env/timeout, same 10s default as `MoleCLI.run`), `Captured` (preserves `timedOut`), `Availability` + `MoLocator` port, `capture(_:)`, `runElevatedClassified(...)`. Ports injected → testable in memory.
- Migrated the **seven capture-style callers** off `MoleCLI.run` onto `MoEngine.shared.capture`: DiskScanner (analyze), MCP read tools, MoleClient (uninstall --list), MoleHistory, SnapshotProducer (status --json), SoftwareView (uninstall capture), UpdatesView (brew straggler via `.executable`). 1:1 translations — same argv/stdin/timeout/results, same `/usr/bin/false` missing-binary degradation.
- `Tests/MoEngineTests.swift` for the facade (scripted port → captured output, discovery availability).

**Deliberately left for the next slice:** streaming (`OperationFlow`/`SystemProcessPort`) and interactive PTY (`MoInteractive`). The destructive elevated-clean execution is untouched.

Tests: **423 green** (LocalizationTests skipped in worktree; CI runs it). Builds on slice 1 (#68, the PrivilegeBroker).