### PR TITLE
refactor(mo): fold streaming + PTY onto MoEngine — completes the engine fold (#48)

### DIFF
--- a/Sources/InstallerView.swift
+++ b/Sources/InstallerView.swift
@@ -40,6 +40,10 @@ final class MoInteractiveRunner: ObservableObject {
 
     let title: String
     private let subcommand: String
+    /// The interactive PTY session. Production takes a fresh one from the
+    /// MoEngine facade (MoEngine.shared.interactive(), the real PTYTask); tests
+    /// inject a scripted FakePTY. Raw, escape-preserving output either way — the
+    /// SelectionSession reducer parses Mole's redraw frames.
     private var pty: PTYPort
     private let tickInterval: TimeInterval
     /// Resolved `mo` path, or nil to look it up at `start()`. Injectable so a
@@ -50,7 +54,7 @@ final class MoInteractiveRunner: ObservableObject {
     private var timer: DispatchSourceTimer?
 
     init(subcommand: String, title: String,
-         pty: PTYPort = PTYTask(), tickInterval: TimeInterval = 0.06,
+         pty: PTYPort = MoEngine.shared.interactive(), tickInterval: TimeInterval = 0.06,
          executablePath: String? = nil) {
         self.subcommand = subcommand
         self.title = title

--- a/Sources/MoEngine.swift
+++ b/Sources/MoEngine.swift
@@ -8,18 +8,23 @@
 //  each found and spawned at its own call site. `MoEngine` is the ONE facade
 //  callers reach for so "how do I run mo?" has a single answer.
 //
-//  This slice (slice 2) wraps the CAPTURE + ELEVATED entry points and the
-//  discovery lookup, delegating to the existing, tested ports — it does NOT
-//  reimplement them. The streaming (`OperationFlow`/`SystemProcessPort`) and
-//  interactive PTY (`MoInteractive`/`PTYTask`) shapes are deliberately left in
-//  place; folding those onto the facade is the next slice.
+//  All FOUR process shapes now hang off this one facade (issue #48 complete):
+//  CAPTURE + ELEVATED + DISCOVERY (slice 2) plus STREAMING (clean / optimize)
+//  and interactive PTY (purge / installer), added here. Every shape delegates
+//  to the existing, tested port — the facade does NOT reimplement any spawn,
+//  elevation, or PTY internals; it just funnels "how do I run mo?" to one type.
 //
 //  Behavior is preserved exactly: a `capture(_:)` call produces the same argv,
-//  stdin, environment, timeout, and result fields that `MoleCLI.run` did, and
+//  stdin, environment, timeout, and result fields that `MoleCLI.run` did;
 //  `runElevatedClassified` routes through the same `PrivilegeBroker` against
-//  the same trusted-location resolution. The ports are injected (production
-//  defaults are the real ones) so the facade is testable with scripted fakes,
-//  matching the seams `MoleCLI`/`MoleProcess`/`PrivilegeBroker` already expose.
+//  the same trusted-location resolution; `stream(_:)` hands back the SAME
+//  `AsyncStream<ProcessEvent>` `SystemProcessPort` already produced (the
+//  elevated-osascript-tail, auth-cancel classification, and line-splitting are
+//  untouched); and `interactive()` vends a FRESH `PTYTask` whose raw,
+//  escape-preserving output the `SelectionSession` reducer depends on. The
+//  ports are injected (production defaults are the real ones) so every shape is
+//  testable with scripted fakes, matching the seams `MoleCLI`/`MoleProcess`/
+//  `PrivilegeBroker`/`ProcessPort`/`PTYPort` already expose.
 //
 
 import Foundation
@@ -104,24 +109,40 @@ struct SystemMoLocator: MoLocator {
 
 // MARK: - Facade
 
-/// The one runner facade. Capture + elevated + discovery in this slice; the
-/// ports are injected so every path is testable in memory.
+/// The one runner facade. All four `mo` process shapes — capture, elevated
+/// one-shot, streaming, and interactive PTY — plus discovery hang off this
+/// type; the ports are injected so every path is testable in memory.
 final class MoEngine {
     private let processPort: MoleProcessPort
     private let privilegeBroker: PrivilegeBroker
     private let locator: MoLocator
+    /// The streaming-op spawn port (clean / optimize). Exposed (not just used
+    /// by `stream(_:)`) so `OperationFlow`, which holds an `any ProcessPort`
+    /// and drives its own reduce/notify/auth-cancel loop, can take the facade's
+    /// production port as its default without the facade reaching into that loop.
+    let streamPort: ProcessPort
+    /// Vends a FRESH interactive PTY session per call. A factory, not a shared
+    /// instance, because a `PTYTask` is stateful per launch and each selection
+    /// host (purge / installer) must own its own — two hosts sharing one pty
+    /// would stomp each other's child and keystrokes.
+    private let makePTY: @Sendable () -> PTYPort
 
     /// Production singleton. Wraps the real capture runner, the real osascript
-    /// broker, and `MoleCLI` discovery — the exact spawn paths the migrated
-    /// call sites used before, just funneled through one type.
+    /// broker, `MoleCLI` discovery, the real streaming port, and the real PTY —
+    /// the exact spawn paths the migrated call sites used before, just funneled
+    /// through one type.
     static let shared = MoEngine()
 
     init(processPort: MoleProcessPort = SystemMoleProcess(),
          privilegeBroker: PrivilegeBroker = SystemPrivilegeBroker(),
-         locator: MoLocator = SystemMoLocator()) {
+         locator: MoLocator = SystemMoLocator(),
+         streamPort: ProcessPort = SystemProcessPort(),
+         makePTY: @escaping @Sendable () -> PTYPort = { PTYTask() }) {
         self.processPort = processPort
         self.privilegeBroker = privilegeBroker
         self.locator = locator
+        self.streamPort = streamPort
+        self.makePTY = makePTY
     }
 
     // MARK: Discovery
@@ -179,5 +200,31 @@ final class MoEngine {
     func runElevatedClassified(args: [String]) -> ElevatedOutcome {
         guard let mo = locator.locateTrusted() else { return .launchFailed }
         return privilegeBroker.openElevated(executable: mo, args: args)
+    }
+
+    // MARK: Streaming (clean / optimize)
+
+    /// Stream a long-running `mo` op line-by-line. Hands the spec straight to
+    /// the injected streaming port and returns its `AsyncStream<ProcessEvent>`
+    /// unchanged — the plain/elevated spawn, the osascript temp-log tail, the
+    /// ANSI strip + line split, and the auth-cancel classification all stay in
+    /// `SystemProcessPort`. Cancelling the consuming task still terminates the
+    /// child via the stream's `onTermination`, exactly as before. The caller
+    /// (`OperationFlow`) owns the reduce/notify/cancel loop; this is only the
+    /// spawn source.
+    func stream(_ spec: ProcessSpec) -> AsyncStream<ProcessEvent> {
+        streamPort.events(spec)
+    }
+
+    // MARK: Interactive PTY (purge / installer)
+
+    /// Open a FRESH interactive PTY session for a selection TUI (`mo purge` /
+    /// `mo installer`). Each call returns its own `PTYPort` because the session
+    /// is stateful (one child per launch, mutable callbacks) and each host must
+    /// own its own. The session delivers RAW, escape-preserving output — the
+    /// `SelectionSession` reducer parses Mole's redraw frames, so nothing here
+    /// strips or rewrites the bytes.
+    func interactive() -> PTYPort {
+        makePTY()
     }
 }

--- a/Sources/OperationFlow.swift
+++ b/Sources/OperationFlow.swift
@@ -9,11 +9,12 @@
 //  descriptor (args, stdin, gate, elevation, a pure reduce closure) —
 //  never a subclass.
 //
-//  The process boundary is one method behind ProcessPort. Production uses
-//  SystemProcessPort for the streaming op runs (Clean/Optimize); tests
-//  script a fake. This is the sibling of MoleProcess (the #29 capture-spawn
-//  runner): SystemProcessPort streams long-running ops, MoleProcess captures
-//  one-shot output — they coexist by use-case.
+//  The process boundary is one method behind ProcessPort. Production takes its
+//  streaming port from the MoEngine facade (MoEngine.shared.streamPort, the real
+//  SystemProcessPort) so "how do I run mo?" has one answer; tests still script a
+//  fake by injecting `process:` directly. SystemProcessPort streams long-running
+//  ops (Clean/Optimize); MoleProcess (the #29 capture-spawn runner) captures
+//  one-shot output — both now hang off MoEngine, coexisting by use-case.
 //
 
 import Foundation
@@ -143,7 +144,7 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    init(process: any ProcessPort = SystemProcessPort(),
+    init(process: any ProcessPort = MoEngine.shared.streamPort,
          hasFullDiskAccess: @escaping () -> Bool = Privacy.hasFullDiskAccess,
          resolveMo: @escaping (_ elevated: Bool) -> String? = {
              $0 ? MoleCLI.trustedExecutable() : MoleCLI.findExecutable()

--- a/Tests/MoEngineTests.swift
+++ b/Tests/MoEngineTests.swift
@@ -11,7 +11,11 @@
 //  capture runner as the exact argv/stdin/env/timeout it described, that a
 //  `.mo` target resolves through the locator (and degrades to a clean nonzero
 //  exit when `mo` is missing), and that the elevated path routes the TRUSTED
-//  binary to the broker — never a PATH lookup.
+//  binary to the broker — never a PATH lookup. The streaming and PTY shapes
+//  (slice 3, completing #48) are wired the same way: `stream(_:)` forwards the
+//  spec to the injected `ProcessPort` and returns its events untouched, and
+//  `interactive()` vends a FRESH session from the injected PTY factory each
+//  call — so two hosts can never share one stateful pty.
 //
 
 import XCTest
@@ -68,6 +72,33 @@ final class MoEngineTests: XCTestCase {
             calls.append((executable, args))
             return outcome
         }
+    }
+
+    /// Records the streamed spec and replays a canned event script — no real
+    /// process, no pipes. Same seam as OperationFlowTests.FakeProcessPort.
+    private final class FakeStreamPort: ProcessPort, @unchecked Sendable {
+        var script: [ProcessEvent]
+        private(set) var specs: [ProcessSpec] = []
+        init(script: [ProcessEvent]) { self.script = script }
+        func events(_ spec: ProcessSpec) -> AsyncStream<ProcessEvent> {
+            specs.append(spec)
+            let s = script
+            return AsyncStream { cont in
+                for e in s { cont.yield(e) }
+                cont.finish()
+            }
+        }
+    }
+
+    /// A throwaway PTY session that records nothing but its own identity — the
+    /// interactive() test only needs to prove each call returns a DISTINCT
+    /// instance (a shared one would let two hosts stomp each other).
+    private final class FakePTY: PTYPort {
+        var onOutput: ((String) -> Void)?
+        var onExit: ((Int32) -> Void)?
+        func launch(_ executable: String, _ args: [String]) throws {}
+        func send(_ bytes: [UInt8]) {}
+        func terminate() {}
     }
 
     // MARK: - capture: command → port wiring
@@ -218,5 +249,108 @@ final class MoEngineTests: XCTestCase {
         let failed = MoEngine(privilegeBroker: FakeBroker(outcome: .exited(2)),
                               locator: FakeLocator(trusted: "/opt/homebrew/bin/mo"))
         XCTAssertEqual(failed.runElevatedClassified(args: ["touchid", "disable"]), .exited(2))
+    }
+
+    // MARK: - Streaming (clean / optimize)
+
+    func testStream_forwardsTheSpecToThePortUntouched() {
+        let port = FakeStreamPort(script: [.exited(0)])
+        let engine = MoEngine(streamPort: port)
+
+        let spec = ProcessSpec(executable: "/usr/local/bin/mo",
+                               arguments: ["clean", "--dry-run"],
+                               stdin: nil, elevated: false, timeout: 30)
+        _ = engine.stream(spec)
+
+        // The facade is a pass-through: the port sees the exact spec, never a
+        // rewritten one. (Argv/elevation are destructive-path inputs — they
+        // must reach SystemProcessPort byte-for-byte.)
+        XCTAssertEqual(port.specs.count, 1)
+        XCTAssertEqual(port.specs.first, spec)
+    }
+
+    func testStream_replaysThePortsEventsInOrder() async {
+        let port = FakeStreamPort(script: [
+            .line("➤ Developer tools"),
+            .line("  → npm cache, 191.8MB"),
+            .exited(0),
+        ])
+        let engine = MoEngine(streamPort: port)
+
+        var lines: [String] = []
+        var exit: Int32?
+        for await event in engine.stream(ProcessSpec(executable: "/usr/local/bin/mo",
+                                                     arguments: ["clean"], stdin: nil,
+                                                     elevated: false, timeout: nil)) {
+            switch event {
+            case .line(let l): lines.append(l)
+            case .exited(let c): exit = c
+            case .authCancelled: XCTFail("the fake never emits auth-cancel")
+            }
+        }
+
+        // The stream the facade returns IS the port's — same events, same order.
+        XCTAssertEqual(lines, ["➤ Developer tools", "  → npm cache, 191.8MB"])
+        XCTAssertEqual(exit, 0)
+    }
+
+    func testStream_carriesElevatedAuthCancelClassificationThrough() async {
+        // The runner classifies auth-cancel; the facade just relays the event.
+        let port = FakeStreamPort(script: [.authCancelled])
+        let engine = MoEngine(streamPort: port)
+
+        var sawAuthCancel = false
+        for await event in engine.stream(ProcessSpec(executable: "/usr/local/bin/mo",
+                                                     arguments: ["clean"], stdin: nil,
+                                                     elevated: true, timeout: nil)) {
+            if case .authCancelled = event { sawAuthCancel = true }
+        }
+        XCTAssertTrue(sawAuthCancel)
+    }
+
+    func testStream_productionDefaultIsTheRealSystemPort() async {
+        // Default-constructed facade streams through SystemProcessPort, against a
+        // tiny system binary — the same local-substitutable style the capture
+        // echo test uses. Proves the production wiring spawns for real.
+        let engine = MoEngine()
+        var lines: [String] = []
+        var exit: Int32?
+        for await event in engine.stream(ProcessSpec(executable: "/bin/sh",
+                                                     arguments: ["-c", "printf 'a\\nb\\n'; exit 0"],
+                                                     stdin: nil, elevated: false, timeout: nil)) {
+            switch event {
+            case .line(let l): lines.append(l)
+            case .exited(let c): exit = c
+            case .authCancelled: XCTFail("un-elevated runs never classify as auth-cancel")
+            }
+        }
+        XCTAssertEqual(lines, ["a", "b"])
+        XCTAssertEqual(exit, 0)
+    }
+
+    // MARK: - Interactive PTY (purge / installer)
+
+    func testInteractive_vendsTheInjectedFactorysSession() {
+        let made = FakePTY()
+        let engine = MoEngine(makePTY: { made })
+        XCTAssertTrue(engine.interactive() === made, "interactive() returns the factory's session")
+    }
+
+    func testInteractive_vendsAFreshSessionEachCall() {
+        // A counter-backed factory: two calls must yield two DISTINCT sessions.
+        // A shared pty would let the purge and installer hosts stomp each other's
+        // child and keystrokes — the safety reason interactive() is a factory.
+        let engine = MoEngine(makePTY: { FakePTY() })
+        let first = engine.interactive()
+        let second = engine.interactive()
+        XCTAssertFalse(first === second, "each interactive() call owns its own pty session")
+    }
+
+    func testInteractive_productionDefaultIsARealPTYTask() {
+        // The default factory builds the real PTYTask — the session the purge /
+        // installer hosts drive. (Behavioral PTY coverage lives in
+        // MoInteractiveHostTests; here we only assert the production type.)
+        let engine = MoEngine()
+        XCTAssertTrue(engine.interactive() is PTYTask)
     }
 }


### PR DESCRIPTION
Final slice of #48: the streaming (clean/optimize) and interactive PTY (purge/installer) shapes now hang off the single `MoEngine` facade, so **all four `mo` process shapes — capture / stream / PTY / elevated — have one entry point behind injected ports.**

## What changed (additive, behavior-preserving)
- `MoEngine` gains `stream(_ spec:) -> AsyncStream<ProcessEvent>` (→ `SystemProcessPort`) and `interactive() -> PTYPort` (a **factory** → fresh `PTYTask` per call, so purge and installer hosts can't stomp each other).
- Two one-line consumer reroutes via default args: `OperationFlow.init(process:)` now defaults to `MoEngine.shared.streamPort`; `MoInteractiveRunner.init(pty:)` to `MoEngine.shared.interactive()`.
- The streaming reduce/notify/auth-cancel/cancel loop and the PTY reducer are **untouched** — only the spawn source moved.

## Destructive paths are byte-identical (verified)
`SelectionSession.swift` (purge/installer confirm→Enter) and `PrivilegeBroker.swift` (elevated osascript + auth-cancel) have **0 line changes**. `SystemProcessPort.events` and `PTYTask` bodies are untouched (every diff there is a comment or a default value). The destructive clean/optimize argv, uninstall stdin, and raw PTY frame bytes all reach the unchanged runners verbatim.

Tests: **430 green** (19 MoEngineTests incl. 7 new for stream/PTY; OperationFlowTests / MoInteractive*Tests / SelectionSessionTests pass unchanged). Independently rebuilt + retested.

Builds on slices 1 (#68) + 2. Closes #48.