### PR TITLE
fix: four main-thread hangs + an AttributeGraph crash from Sentry triage (#72–#75)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -63,12 +63,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         // No engine yet → guided install instead of a dead-end quit. The
         // window's Recheck calls startServices() once `mo` is found.
-        guard MoleCLI.findExecutable() != nil else {
-            Telemetry.capture("engine_missing")
-            showInstallWindow()
-            return
+        //
+        // Discovery can shell out to `which mo` (MoleCLI.discover) when mo
+        // isn't in a trusted Homebrew path — a blocking Process wait that must
+        // never run on the main thread at launch (issue #72 / Sentry BURROW-1:
+        // a ~2 s+ app-hang on cold launch). Probe off-main, then gate startup
+        // back on the main thread. The brief window with no UI is fine; the
+        // status item / install window appear a beat later instead of after a
+        // freeze.
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let found = MoleCLI.findExecutable() != nil
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if found {
+                    self.startServices()
+                } else {
+                    Telemetry.capture("engine_missing")
+                    self.showInstallWindow()
+                }
+            }
         }
-        startServices()
     }
 
     /// Guided onboarding window when `mo` is missing. Stays a regular Dock

--- a/Sources/Components/MiniChart.swift
+++ b/Sources/Components/MiniChart.swift
@@ -18,6 +18,13 @@ struct MiniChart: View {
     var color: Color
     var style: Style = .area
 
+    /// Defensive cap: the live feeds hand this ~30 points, but no caller should
+    /// ever be able to drive an unbounded series into the per-bar geometry
+    /// (issue #75 / Sentry BURROW-K — AttributeGraph fault on the popover
+    /// chart). `.bars` also renders as a single `Path` regardless; this only
+    /// bounds the point count feeding the scale.
+    private var samples: [Double] { values.count > 120 ? Array(values.suffix(120)) : values }
+
     var body: some View {
         GeometryReader { geo in
             let w = geo.size.width
@@ -25,7 +32,7 @@ struct MiniChart: View {
             let (lo, hi) = bounds()
             let denom = max(hi - lo, 0.0001)
 
-            if values.count < 2 {
+            if samples.count < 2 {
                 // Flat baseline so an empty card doesn't look broken.
                 Path { p in
                     p.move(to: CGPoint(x: 0, y: h - 1))
@@ -47,8 +54,9 @@ struct MiniChart: View {
 
     @ViewBuilder
     private func area(w: CGFloat, h: CGFloat, lo: Double, denom: Double) -> some View {
-        let n = values.count
-        let pts: [CGPoint] = values.enumerated().map { i, v in
+        let vals = samples
+        let n = vals.count
+        let pts: [CGPoint] = vals.enumerated().map { i, v in
             CGPoint(x: w * CGFloat(i) / CGFloat(n - 1), y: y(v, h, lo, denom))
         }
         ZStack {
@@ -71,28 +79,33 @@ struct MiniChart: View {
         }
     }
 
-    @ViewBuilder
     private func bars(w: CGFloat, h: CGFloat, lo: Double, denom: Double) -> some View {
-        let n = values.count
+        // One `Path` of bottom-anchored rounded bars rather than N
+        // RoundedRectangle subviews offset off `geo.size.width`: a single
+        // layout node, so the chart can't feed an unbounded per-point subtree
+        // into AttributeGraph during a popover transition (issue #75).
+        let vals = samples
+        let n = max(vals.count, 1)
         let slot = w / CGFloat(n)
         let barW = max(1.5, slot * 0.62)
-        ZStack(alignment: .bottomLeading) {
-            ForEach(Array(values.enumerated()), id: \.offset) { i, v in
-                let bh = max(1.5, (1.0 - (1.0 - CGFloat((v - lo) / denom))) * h)
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(color.opacity(0.85))
-                    .frame(width: barW, height: bh)
-                    .offset(x: CGFloat(i) * slot + (slot - barW) / 2)
+        return Path { p in
+            for (i, v) in vals.enumerated() {
+                let bh = max(1.5, CGFloat((v - lo) / denom) * h)
+                let x = CGFloat(i) * slot + (slot - barW) / 2
+                p.addRoundedRect(in: CGRect(x: x, y: h - bh, width: barW, height: bh),
+                                 cornerSize: CGSize(width: 1, height: 1),
+                                 style: .continuous)
             }
         }
-        .frame(width: w, height: h, alignment: .bottomLeading)
+        .fill(color.opacity(0.85))
     }
 
     /// Stable vertical scale: floor at 0 (these are non-negative metrics)
     /// and pad a flat series so it doesn't pin to the baseline.
     private func bounds() -> (lo: Double, hi: Double) {
-        let lo = min(values.min() ?? 0, 0)
-        let hi = values.max() ?? 1
+        let vals = samples
+        let lo = min(vals.min() ?? 0, 0)
+        let hi = vals.max() ?? 1
         if hi - lo < 0.001 { return (lo, hi + 1) }
         return (lo, hi)
     }

--- a/Sources/MoInteractive.swift
+++ b/Sources/MoInteractive.swift
@@ -251,7 +251,21 @@ final class PTYTask: PTYPort {
         close(aslave)   // parent doesn't use the slave end
     }
 
-    func send(_ bytes: [UInt8]) { try? master?.write(contentsOf: Data(bytes)) }
+    /// PTY writes go through a dedicated serial queue so a blocked `write()`
+    /// — the `mo` child not draining its stdin — can never park the @MainActor
+    /// caller (issue #73 / Sentry BURROW-D: the 0.06 s selection-replay tick
+    /// runs on the main queue). The serial queue preserves keystroke order;
+    /// the captured handle keeps the fd alive for an in-flight write even if
+    /// `terminate()` clears `master` underneath it. The master fd is otherwise
+    /// only touched by the FileHandle read handler, and read/write on a pty are
+    /// independent directions, so there's no fd race.
+    private let writeQueue = DispatchQueue(label: "dev.caezium.burrow.pty-write")
+
+    func send(_ bytes: [UInt8]) {
+        guard let master else { return }
+        let data = Data(bytes)
+        writeQueue.async { try? master.write(contentsOf: data) }
+    }
     func terminate() {
         master?.readabilityHandler = nil
         if proc.isRunning { proc.terminate() }

--- a/Sources/StatusView.swift
+++ b/Sources/StatusView.swift
@@ -605,28 +605,43 @@ struct ProcRow: View {
         return String(format: "%.1f%%", p.memory)
     }
 
+    /// Constant menu labels, hoisted out of the per-row `Menu` builder. As
+    /// inline `NSLocalizedString`s they were re-materialized as tagged-pointer
+    /// CFStrings on every 2 s feed tick × every realized row (issue #74 /
+    /// Sentry BURROW-E: `_CFStringCreateTaggedPointerString` in `Menu.init`).
+    /// Created once here.
+    private enum L {
+        static let pin = NSLocalizedString("Pin", comment: "")
+        static let unpin = NSLocalizedString("Unpin", comment: "")
+        static let reveal = NSLocalizedString("Reveal in Finder", comment: "")
+        static let copyName = NSLocalizedString("Copy name", comment: "")
+        static let copyPID = NSLocalizedString("Copy PID", comment: "")
+        static let quit = NSLocalizedString("Quit…", comment: "")
+        static let forceKill = NSLocalizedString("Force Kill…", comment: "")
+    }
+
     /// Per-row "…" menu: pin, reveal, copy; Quit / Force Kill for
     /// own-user processes only — root rows stay read-only.
     private var rowMenu: some View {
         Menu {
-            Button(pinned ? NSLocalizedString("Unpin", comment: "") : NSLocalizedString("Pin", comment: "")) { onPin() }
-            Button(NSLocalizedString("Reveal in Finder", comment: "")) {
+            Button(pinned ? L.unpin : L.pin) { onPin() }
+            Button(L.reveal) {
                 if let path = ProcessActions.executablePath(pid: p.pid) {
                     NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
                 }
             }
-            Button(NSLocalizedString("Copy name", comment: "")) {
+            Button(L.copyName) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(p.name, forType: .string)
             }
-            Button(NSLocalizedString("Copy PID", comment: "")) {
+            Button(L.copyPID) {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString("\(p.pid)", forType: .string)
             }
             if ProcessActions.isOwnProcess(pid: p.pid) {
                 Divider()
-                Button(NSLocalizedString("Quit…", comment: ""), role: .destructive) { confirmQuit(force: false) }
-                Button(NSLocalizedString("Force Kill…", comment: ""), role: .destructive) { confirmQuit(force: true) }
+                Button(L.quit, role: .destructive) { confirmQuit(force: false) }
+                Button(L.forceKill, role: .destructive) { confirmQuit(force: true) }
             }
         } label: {
             Image(systemName: "ellipsis")


### PR DESCRIPTION
Triaged all 11 unresolved Sentry issues (10 App Hangs + 1 crash) into root-cause buckets and cross-referenced each against the source. The #57 chart-layout hang (34 users) is already fixed on `main` and unreleased; this PR clears the remaining, distinct main-thread problems it does **not** touch.

| Fix | Issue | Sentry | Users | Culprit |
|---|---|---|---|---|
| Discover `mo` off the main thread at launch | #72 | BURROW-1 | 11 | `AppDelegate` gated startup on a synchronous `findExecutable()` → `which mo` blocking `Process` wait |
| PTY keystroke `write()` on a serial queue | #73 | BURROW-D | 2 | `PTYTask.send` blocked the `@MainActor` 0.06s replay tick on a full stdin pipe |
| Hoist per-row process-menu labels to statics | #74 | BURROW-E | 1 | `ProcRow.rowMenu` re-materialized ~12 CFStrings × rows every 2s tick |
| MiniChart `.bars` as one `Path` + clamp | #75 | BURROW-K (crash) | 1 | same `GeometryReader`+per-point-`ForEach` shape #57 removed from HistoryView, still live in the popover → `EXC_BAD_ACCESS` in AttributeGraph |

All four are behavior-preserving plumbing changes. Build + full suite green (**436 tests, 0 failures**).

**Note:** bucket B (mo decode on the main actor, 6 users) was already fixed on `main` by the #53 feed migration — no code change needed; it ships in any release cut from current `main`.

Caveat: dSYMs are missing on all events, so #74/#75 attribution is by structural/root-frame match, not symbolication. Wiring `SENTRY_AUTH_TOKEN` + dSYM upload would symbolicate future telemetry.

Closes #72
Closes #73
Closes #74
Closes #75