### PR TITLE
fix(fda): access banner reappears when Full Disk Access is off

### DIFF
--- a/Sources/RootView.swift
+++ b/Sources/RootView.swift
@@ -37,7 +37,12 @@ struct RootView: View {
     /// gates). Probed at mount and on every app activation, so granting
     /// access in System Settings dismisses the banner by itself.
     @State private var fdaGranted = Privacy.hasFullDiskAccess()
-    @State private var fdaBannerDismissed = Store.fullDiskAccessNoticeDismissed
+    /// Session-only: the FDA banner reappears each launch while access is off,
+    /// and dismissing it only hides it for the current run. (It used to read a
+    /// PERSISTED flag — `fda_notice_dismissed`, shared with the pre-redesign
+    /// notice — so one historical dismiss suppressed it forever even while FDA
+    /// stayed off, which is why upgraders never saw it.)
+    @State private var fdaBannerDismissed = false
     /// Where Esc in the Settings pane returns to.
     @State private var lastNonSettingsPane: Pane = .home
     /// Burrow's own self-update state — drives the top banner.
@@ -103,7 +108,8 @@ struct RootView: View {
         .overlay(alignment: .bottom) {
             if !fdaGranted, !fdaBannerDismissed {
                 AccessBanner(onDismiss: {
-                    Store.fullDiskAccessNoticeDismissed = true
+                    // Session-only — don't persist, so a future launch with FDA
+                    // still off shows it again (a gentle once-per-launch nudge).
                     withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
                         fdaBannerDismissed = true
                     }


### PR DESCRIPTION
The bottom "Full Disk Access is off" banner never showed for upgraders: it read the persisted `fda_notice_dismissed` flag (shared with the pre-redesign notice), so one historical dismiss suppressed it permanently even while FDA stayed off. Verified on a machine where Burrow's TCC grant is `auth_value 0` (FDA off) yet the banner was hidden because the flag was `1`.

Fix: the banner's dismiss is now **session-only** — it shows whenever FDA is off, hides for the current launch when ×'d, and returns next launch if access is still missing. No persisted suppression. The vestigial `fullDiskAccessNoticeDismissed` key (its only real consumer) is no longer read by the banner; `Privacy.shouldOfferFullDiskAccessNow` has no callers.

Build + Debug tests green.