### PR TITLE
docs: refresh README + site screenshots (0.7 redesign)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,31 @@ an **MCP server** so any AI agent (Claude Code, Cursor, Codex…) can ask
 
 <table>
   <tr>
-    <td><img alt="Status — live CPU, memory, GPU, disk, network, and battery with sparklines" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-status.png"></td>
-    <td><img alt="Analyze — squarified treemap of your whole disk" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-analyze.png"></td>
+    <td><img alt="Status — live CPU, memory, GPU, disk, network, and battery" src="https://github.com/user-attachments/assets/4161784c-b51d-4972-97f8-8ec0ea21e072"></td>
+    <td><img alt="History — long-range charts over a local SQLite metric history" src="https://github.com/user-attachments/assets/300c9c1c-13d9-4b2d-8660-6602c6b07161"></td>
   </tr>
   <tr>
-    <td><img alt="Clean — categorized cache, log, and leftover removal" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-clean.png"></td>
-    <td><img alt="Purge — reclaim space from dev projects (node_modules, build dirs, target/…)" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-purge2.png"></td>
+    <td><img alt="Analyze — squarified treemap of your whole disk" src="https://github.com/user-attachments/assets/9ef6ce5e-9730-470f-9a5a-3bfe9e195f82"></td>
+    <td><img alt="Clean — categorized cache, log, and leftover removal" src="https://github.com/user-attachments/assets/05b3d436-3c13-42ac-b7b3-dc7f331a5eb9"></td>
   </tr>
   <tr>
+    <td><img alt="Clean — running" src="https://github.com/user-attachments/assets/1deb82af-00e3-4ba3-b641-c743a22242c5"></td>
+    <td><img alt="Clean — structured result summary" src="https://github.com/user-attachments/assets/27f9e945-9298-45ce-a842-de7af32d971e"></td>
+  </tr>
+  <tr>
+    <td><img alt="Purge — reclaim space from dev projects (node_modules, build dirs, target/…)" src="https://github.com/user-attachments/assets/fb00ec56-6dd6-4781-8970-642ce2c1c300"></td>
     <td><img alt="Installers — find and remove leftover .dmg/.pkg files in bulk" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-installers.png"></td>
-    <td><img alt="Optimize — one-tap safe maintenance" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-optimize.png"></td>
   </tr>
   <tr>
-    <td><img alt="Software — installed apps with search, sort, and multi-select uninstall" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-apps.png"></td>
-    <td><img alt="History — long-range charts over a local SQLite metric history" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-history.png"></td>
+    <td><img alt="Optimize — one-tap safe maintenance running" src="https://github.com/user-attachments/assets/05fafc36-6c38-4043-904d-f79c6841de04"></td>
+    <td><img alt="Optimize — finished summary" src="https://github.com/user-attachments/assets/de3c2ece-2c54-46bd-96af-5cb42e5895a2"></td>
+  </tr>
+  <tr>
+    <td><img alt="Software — installed apps with search, sort, and multi-select uninstall" src="https://github.com/user-attachments/assets/1a293b2f-baa4-4895-b722-eed0921ff21d"></td>
+    <td><img alt="Software — Homebrew app updates" src="https://github.com/user-attachments/assets/8c3fa0bd-ba08-4dff-af5c-b0213b8adb69"></td>
+  </tr>
+  <tr>
+    <td><img alt="Settings" src="https://github.com/user-attachments/assets/a642c5eb-6959-4b7a-a29a-de9bb9f0edb3"></td>
   </tr>
 </table>
 
@@ -78,7 +89,7 @@ an **MCP server** so any AI agent (Claude Code, Cursor, Codex…) can ask
 </p>
 
 <p align="center">
-  <img width="320" alt="Menu-bar HUD — health, metric tiles, top processes, and live job status" src="https://raw.githubusercontent.com/caezium/Burrow/main/docs/assets/shot-menubar.png">
+  <img width="320" alt="Menu-bar HUD — health, metric tiles, top processes, and live job status" src="https://github.com/user-attachments/assets/105ef0ca-b970-4eec-8604-db21f458b816">
 </p>
 
 ## The tools

--- a/docs/index.html
+++ b/docs/index.html
@@ -356,23 +356,23 @@
     </div>
 
     <div class="card demo">
-      <div class="stage"><img id="demoImg" src="assets/shot-analyze.png" alt="Burrow — Analyze treemap"></div>
+      <div class="stage"><img id="demoImg" src="https://github.com/user-attachments/assets/9ef6ce5e-9730-470f-9a5a-3bfe9e195f82" alt="Burrow — Analyze treemap"></div>
       <div class="demo-foot">
         <div class="demo-now">
           <div class="name" id="demoName">Analyze</div>
           <div class="tag" id="demoTag">Map every chamber below.</div>
         </div>
         <div class="demo-tabs" role="tablist">
-          <button class="pill" role="tab" data-img="assets/shot-clean.png"      data-name="Clean"      data-tag="Fresh air through old tunnels.">Clean</button>
-          <button class="pill" role="tab" data-img="assets/shot-purge2.png"     data-name="Purge"      data-tag="Clear the diggings dev work leaves behind.">Purge</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/05b3d436-3c13-42ac-b7b3-dc7f331a5eb9" data-name="Clean"      data-tag="Fresh air through old tunnels.">Clean</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/fb00ec56-6dd6-4781-8970-642ce2c1c300" data-name="Purge"      data-tag="Clear the diggings dev work leaves behind.">Purge</button>
           <button class="pill" role="tab" data-img="assets/shot-installers.png" data-name="Installers" data-tag="Sweep out the crates you unpacked.">Installers</button>
-          <button class="pill" role="tab" data-img="assets/shot-optimize.png"   data-name="Optimize"   data-tag="Small turns, a smoother run.">Optimize</button>
-          <button class="pill" role="tab" data-img="assets/shot-apps.png"       data-name="Software"   data-tag="Shed what you've outgrown.">Software</button>
-          <button class="pill" role="tab" data-img="assets/shot-analyze.png"    data-name="Analyze"    data-tag="Map every chamber below." aria-selected="true">Analyze</button>
-          <button class="pill" role="tab" data-img="assets/shot-status.png"     data-name="Status"     data-tag="Every pulse of the den.">Status</button>
-          <button class="pill" role="tab" data-img="assets/shot-history.png"    data-name="History"    data-tag="A long memory of the den.">History</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/05fafc36-6c38-4043-904d-f79c6841de04" data-name="Optimize"   data-tag="Small turns, a smoother run.">Optimize</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/1a293b2f-baa4-4895-b722-eed0921ff21d" data-name="Software"   data-tag="Shed what you've outgrown.">Software</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/9ef6ce5e-9730-470f-9a5a-3bfe9e195f82" data-name="Analyze"    data-tag="Map every chamber below." aria-selected="true">Analyze</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/4161784c-b51d-4972-97f8-8ec0ea21e072" data-name="Status"     data-tag="Every pulse of the den.">Status</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/300c9c1c-13d9-4b2d-8660-6602c6b07161" data-name="History"    data-tag="A long memory of the den.">History</button>
           <button class="pill" role="tab" data-img="assets/shot-ai.png"         data-name="Agent"      data-tag="Ask your Mac, from Claude." data-contain="1">Agent</button>
-          <button class="pill" role="tab" data-img="assets/shot-menubar.png"    data-name="Menu&nbsp;bar" data-tag="The whole den, from the menu bar." data-contain="1">Menu&nbsp;bar</button>
+          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/105ef0ca-b970-4eec-8604-db21f458b816" data-name="Menu&nbsp;bar" data-tag="The whole den, from the menu bar." data-contain="1">Menu&nbsp;bar</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Swaps the pre-redesign screenshots for current-UI captures in both the README and the landing site.

**README** — new 13-shot table + menu-bar HUD: Status, History, Analyze, Clean (menu / running / results), Purge, Optimize (running / finished), Software (apps + updates), Settings. Uses GitHub-hosted captures (no repo-asset bloat).

**Site (`docs/index.html`)** — the demo gallery repoints to the same new captures and **drops the Installers tab** (folded into Clean in 0.7). The **Agent** tab keeps the existing capture for now.

Docs-only; no code change.

**Follow-up worth doing:** there's no fresh **agent/MCP** screenshot in this set — that's the differentiator shot, so a new capture of an agent acting over MCP would be the highest-value add to both surfaces. I dropped the old README "Explain with AI" and "Activity" blocks rather than show stale UI.