### PR TITLE
fix(site): live site images blank — revert gallery to local assets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -356,23 +356,23 @@
     </div>
 
     <div class="card demo">
-      <div class="stage"><img id="demoImg" src="https://github.com/user-attachments/assets/9ef6ce5e-9730-470f-9a5a-3bfe9e195f82" alt="Burrow — Analyze treemap"></div>
+      <div class="stage"><img id="demoImg" src="assets/shot-analyze.png" alt="Burrow — Analyze treemap"></div>
       <div class="demo-foot">
         <div class="demo-now">
           <div class="name" id="demoName">Analyze</div>
           <div class="tag" id="demoTag">Map every chamber below.</div>
         </div>
         <div class="demo-tabs" role="tablist">
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/05b3d436-3c13-42ac-b7b3-dc7f331a5eb9" data-name="Clean"      data-tag="Fresh air through old tunnels.">Clean</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/fb00ec56-6dd6-4781-8970-642ce2c1c300" data-name="Purge"      data-tag="Clear the diggings dev work leaves behind.">Purge</button>
+          <button class="pill" role="tab" data-img="assets/shot-clean.png"      data-name="Clean"      data-tag="Fresh air through old tunnels.">Clean</button>
+          <button class="pill" role="tab" data-img="assets/shot-purge2.png"     data-name="Purge"      data-tag="Clear the diggings dev work leaves behind.">Purge</button>
           <button class="pill" role="tab" data-img="assets/shot-installers.png" data-name="Installers" data-tag="Sweep out the crates you unpacked.">Installers</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/05fafc36-6c38-4043-904d-f79c6841de04" data-name="Optimize"   data-tag="Small turns, a smoother run.">Optimize</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/1a293b2f-baa4-4895-b722-eed0921ff21d" data-name="Software"   data-tag="Shed what you've outgrown.">Software</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/9ef6ce5e-9730-470f-9a5a-3bfe9e195f82" data-name="Analyze"    data-tag="Map every chamber below." aria-selected="true">Analyze</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/4161784c-b51d-4972-97f8-8ec0ea21e072" data-name="Status"     data-tag="Every pulse of the den.">Status</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/300c9c1c-13d9-4b2d-8660-6602c6b07161" data-name="History"    data-tag="A long memory of the den.">History</button>
+          <button class="pill" role="tab" data-img="assets/shot-optimize.png"   data-name="Optimize"   data-tag="Small turns, a smoother run.">Optimize</button>
+          <button class="pill" role="tab" data-img="assets/shot-apps.png"       data-name="Software"   data-tag="Shed what you've outgrown.">Software</button>
+          <button class="pill" role="tab" data-img="assets/shot-analyze.png"    data-name="Analyze"    data-tag="Map every chamber below." aria-selected="true">Analyze</button>
+          <button class="pill" role="tab" data-img="assets/shot-status.png"     data-name="Status"     data-tag="Every pulse of the den.">Status</button>
+          <button class="pill" role="tab" data-img="assets/shot-history.png"    data-name="History"    data-tag="A long memory of the den.">History</button>
           <button class="pill" role="tab" data-img="assets/shot-ai.png"         data-name="Agent"      data-tag="Ask your Mac, from Claude." data-contain="1">Agent</button>
-          <button class="pill" role="tab" data-img="https://github.com/user-attachments/assets/105ef0ca-b970-4eec-8604-db21f458b816" data-name="Menu&nbsp;bar" data-tag="The whole den, from the menu bar." data-contain="1">Menu&nbsp;bar</button>
+          <button class="pill" role="tab" data-img="assets/shot-menubar.png"    data-name="Menu&nbsp;bar" data-tag="The whole den, from the menu bar." data-contain="1">Menu&nbsp;bar</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Regression from #85.** The landing-site demo gallery was pointed at `github.com/user-attachments/...` URLs. Those only render inside GitHub (the README is fine); on the externally-served site they 404, so every gallery image showed blank.

This reverts the gallery to the committed `docs/assets/shot-*.png` (which still exist and work). The README is untouched (its GitHub-hosted captures render correctly on github.com).

**Merge this promptly** to restore the live site. The *new* screenshots will land on the site separately, once the real PNG files are added to `docs/assets/` (they can't be hotlinked from user-attachments).