### PR TITLE
ci(release): sign embedded frameworks inside-out before notarizing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,17 @@ jobs:
           # Put our keychain first in the search list so codesign finds the identity.
           security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
           rm -f "$RUNNER_TEMP/cert.p12"
+          # Sign nested code inside-out FIRST. Notarization requires every
+          # embedded Mach-O (the Sentry + PostHog frameworks, any bundled
+          # dylibs) to carry Developer ID + hardened runtime + secure
+          # timestamp; signing only the outer bundle leaves them ad-hoc /
+          # linker-signed and the submission is rejected.
+          if [ -d "$APP/Contents/Frameworks" ]; then
+            find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) -print0 \
+              | while IFS= read -r -d '' f; do
+                  codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$f"
+                done
+          fi
           # Hardened runtime + secure timestamp are required for notarization.
           codesign --force --options runtime --timestamp \
             --entitlements Resources/Burrow.entitlements \


### PR DESCRIPTION
## What

The Developer ID code-sign step in `release.yml` signed only the outer `Burrow.app` bundle, not the embedded **Sentry** and **PostHog** frameworks.

Notarization requires *every* nested Mach-O to be signed with Developer ID + hardened runtime + a secure timestamp. As written, the first signed+notarized release would have been **rejected** by Apple (the frameworks were left ad-hoc/linker-signed).

## Fix

Sign frameworks/dylibs inside-out **first**, then the outer bundle — the standard, robust order (no `--deep`).

## Impact

- **No change to current releases** — the whole sign step is still skipped until the `MACOS_CERT_*` secrets are configured.
- This only matters once Developer ID signing is turned on; it makes the **first** notarization pass instead of bounce.
- Does **not** affect telemetry, runtime behaviour, or the ad-hoc `release.sh` path.