### PR TITLE
prune: remove dead macOS symbols + relocate test clock

### DIFF
--- a/macos/Sources/Explain.swift
+++ b/macos/Sources/Explain.swift
@@ -198,8 +198,6 @@ enum ExplainPrompt {
         }
     }
 
-    static func isChinese() -> Bool { chineseVariant() != nil }
-
     static func make(_ ctx: ExplainContext) -> (system: String, user: String) {
         let language: String
         switch chineseVariant() {

--- a/macos/Sources/Feeds.swift
+++ b/macos/Sources/Feeds.swift
@@ -58,29 +58,6 @@ final class TimerFeedClock: FeedClock {
     }
 }
 
-/// Test clock: ticks fire only when `advance()` is called.
-@MainActor
-final class ManualFeedClock: FeedClock {
-    private var tickers: [ManualTicker] = []
-    init() {}
-    func makeTicker() -> FeedTicker {
-        let t = ManualTicker()
-        tickers.append(t)
-        return t
-    }
-    /// Fire every running ticker once.
-    func advance() {
-        for t in tickers { t.fire() }
-    }
-
-    private final class ManualTicker: FeedTicker {
-        private var handler: (() -> Void)?
-        func start(every interval: TimeInterval, _ tick: @escaping () -> Void) { handler = tick }
-        func stop() { handler = nil }
-        func fire() { handler?() }
-    }
-}
-
 // MARK: - Feed
 
 /// A shared, self-refreshing published value. Obtain via `FeedHub.feed` —

--- a/macos/Sources/MoleCLI.swift
+++ b/macos/Sources/MoleCLI.swift
@@ -155,26 +155,6 @@ enum MoleCLI {
     /// GUI app with no controlling terminal (#35).
     static let minimumAnalyzeJSONVersion = "1.29.0"
 
-    /// Modal alert shown at launch when `mo` isn't installed. We block on
-    /// it because there's nothing useful Burrow can do without Mole, and a
-    /// background app silently failing is the worst possible UX for this
-    /// dependency model.
-    static func showMissingAlert() {
-        let alert = NSAlert()
-        alert.messageText = NSLocalizedString("Mole CLI not found", comment: "")
-        alert.informativeText = NSLocalizedString("""
-            Burrow uses the Mole CLI (`mo`) for system metrics and cleanup. \
-            Install it with:
-
-                brew install mole
-
-            Then relaunch Burrow.
-            """, comment: "")
-        alert.alertStyle = .critical
-        alert.addButton(withTitle: NSLocalizedString("Quit", comment: ""))
-        _ = alert.runModalQuiet()
-    }
-
     /// Result of a subprocess invocation. `exitCode == 0` is the success
     /// convention; callers that care about diagnostics should look at
     /// `stderr` when it's non-zero, and `timedOut` distinguishes "the

--- a/macos/Sources/Privacy.swift
+++ b/macos/Sources/Privacy.swift
@@ -50,12 +50,6 @@ enum Privacy {
         return false
     }
 
-    /// Live check combining the access probe with the persisted dismissal.
-    static func shouldOfferFullDiskAccessNow() -> Bool {
-        shouldOfferFullDiskAccess(hasAccess: hasFullDiskAccess(),
-                                  dismissed: Store.fullDiskAccessNoticeDismissed)
-    }
-
     /// Deep-link to System Settings ▸ Privacy & Security ▸ Full Disk Access.
     static let fullDiskAccessSettingsURL = URL(
         string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles")!

--- a/macos/Tests/FeedsTests.swift
+++ b/macos/Tests/FeedsTests.swift
@@ -13,6 +13,30 @@
 import XCTest
 @testable import Burrow
 
+/// Test clock: ticks fire only when `advance()` is called. Lives in the test
+/// target — it's a test double, not production code.
+@MainActor
+final class ManualFeedClock: FeedClock {
+    private var tickers: [ManualTicker] = []
+    init() {}
+    func makeTicker() -> FeedTicker {
+        let t = ManualTicker()
+        tickers.append(t)
+        return t
+    }
+    /// Fire every running ticker once.
+    func advance() {
+        for t in tickers { t.fire() }
+    }
+
+    private final class ManualTicker: FeedTicker {
+        private var handler: (() -> Void)?
+        func start(every interval: TimeInterval, _ tick: @escaping () -> Void) { handler = tick }
+        func stop() { handler = nil }
+        func fire() { handler?() }
+    }
+}
+
 @MainActor
 final class FeedsTests: XCTestCase {
     private var clock: ManualFeedClock!


### PR DESCRIPTION
Evidence-based dead-code pass (ripgrep ref-counting, dynamic dispatch ruled out).

**Removed:** `Explain.isChinese()`, `Privacy.shouldOfferFullDiskAccessNow()` (unused wrappers; the tested seams stay), `MoleCLI.showMissingAlert()` (orphaned by the engine-fold #48/#71; `runModalQuiet()` keeps 15 other callers), and `ManualFeedClock` (a test double moved from `Sources/` into the test target).

**Kept deliberately (NOT dead):** `Telemetry.bytesBucket/countBucket/secondsBucket` — documented in TELEMETRY.md + SECURITY.md as the privacy-bucketing primitives for planned size/count/duration events; removing them would make those docs untrue.

No behavior change — CI runs the suite (sandbox can't run xcodebuild here).