### PR TITLE
site: film grain on the landing page (match the app redesign)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -79,9 +79,14 @@
     -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility; overflow-x: hidden;
     background-color: var(--bg);
     background-image:
+      url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='180'%20height='180'%3E%3Cfilter%20id='g'%3E%3CfeTurbulence%20type='fractalNoise'%20baseFrequency='0.82'%20numOctaves='2'%20stitchTiles='stitch'/%3E%3CfeColorMatrix%20type='saturate'%20values='0'/%3E%3C/filter%3E%3Crect%20width='100%25'%20height='100%25'%20filter='url(%23g)'%20opacity='0.06'/%3E%3C/svg%3E"),
       radial-gradient(1200px 600px at 82% -10%, rgba(217,160,102,0.10), transparent 60%),
       radial-gradient(1000px 520px at -10% 108%, rgba(217,160,102,0.08), transparent 60%);
-    background-repeat: no-repeat; background-attachment: fixed;
+    /* Film grain (top layer) over the warm glow — the den's tactile ground,
+       mirroring Burrow's in-app GrainOverlay so the site reads like the app. */
+    background-repeat: repeat, no-repeat, no-repeat;
+    background-size: 180px 180px, auto, auto;
+    background-attachment: fixed;
   }
   a { color: inherit; text-decoration: none; }
   a.u { text-decoration: underline; text-decoration-color: rgba(217,160,102,0.5); text-underline-offset: 3px; }


### PR DESCRIPTION
Brings one signature element of the app's visual redesign to the landing page: the **film grain**.

**What.** Layers Burrow's in-app `GrainOverlay` (faint monochrome `feTurbulence` noise) as the top background layer over the page's existing warm radial-gradient, so the site reads with the same tactile ground as the redesigned app. Subtle (0.06 opacity), tiled, fixed; space-escaped data-URI for cross-browser support. **No other styling touched** — palette, fonts (Geist/Cal Sans), layout, and the mole.fit disclaimer are all unchanged.

**Verified.** Data-URI validated in Chromium and the grain confirmed rendering (injected into the live page — subtle texture over the dark ground, content unaffected). The on-disk render wasn't previewable here (the local preview pointed at a different checkout), so worth a glance on deploy — the 0.06 opacity is easy to tune.

**Deliberately not in this PR — screenshot refresh.** The page's `assets/shot-*.png` still show the pre-redesign UI. Refreshing them to the new Overview/History/HUD is the higher-impact follow-up, but it needs **curated/clean captures** — my session screenshots show real machine data (installed apps, processes, disk), which shouldn't go on a public page. Happy to set up a clean demo state and reshoot all the panes as a separate PR.
