### PR TITLE
fix(macos): eliminate Diagnostics tab App Hang (ANR) from main-thread shell-outs

### DIFF
--- a/macos/Sources/DoctorView.swift
+++ b/macos/Sources/DoctorView.swift
@@ -50,7 +50,7 @@ struct DoctorView: View {
         }
         .scrollIndicators(.hidden)
         .fadeEdges()
-        .task { reload() }
+        .task { await reload() }
     }
 
     private func row(_ c: Doctor.Check) -> some View {
@@ -94,7 +94,7 @@ struct DoctorView: View {
         }
     }
 
-    private func reload() {
+    private func reload() async {
         let latest = MetricsStore(db: db).latest()?.status
         var free: Int64 = 0, total: Int64 = 0
         if let d = latest?.disks.max(by: { $0.total < $1.total }) {
@@ -106,12 +106,22 @@ struct DoctorView: View {
         let p = (latest?.memory.pressure ?? "").lowercased()
         let pressure: Doctor.MemoryPressure = p.contains("critical") ? .critical
             : (p.contains("warn") ? .warning : .normal)
+        let fullDiskAccess = Privacy.hasFullDiskAccess()
+        let recentErrorCount = MetricsStore.driftCounters.decodeSkippedTotal
+        // `tmutil latestbackup` and `system_profiler SPNVMeDataType` each spawn a
+        // subprocess and block on waitUntilExit() — system_profiler routinely
+        // takes seconds. Running them inline here (`.task` is MainActor-isolated)
+        // froze the main thread long enough to trip Sentry's ≥2000ms App Hang
+        // detector. Probe off the main thread, then publish on the main actor.
+        let probes = await Task.detached(priority: .utility) {
+            (backup: BackupStatus.lastBackupDaysAgo(), smart: DiskHealth.smartVerified())
+        }.value
         checks = Doctor.report(.init(
-            fullDiskAccess: Privacy.hasFullDiskAccess(),
+            fullDiskAccess: fullDiskAccess,
             moInstalled: moInstalled, pressure: pressure,
             diskFreeBytes: free, diskTotalBytes: total,
-            recentErrorCount: MetricsStore.driftCounters.decodeSkippedTotal,
-            lastBackupDaysAgo: BackupStatus.lastBackupDaysAgo(),
-            smartVerified: DiskHealth.smartVerified()))
+            recentErrorCount: recentErrorCount,
+            lastBackupDaysAgo: probes.backup,
+            smartVerified: probes.smart))
     }
 }


### PR DESCRIPTION
## What

`DoctorView`'s `.task` is MainActor-isolated, so it ran `reload()` — and its two blocking subprocess probes — synchronously on the main thread:

- `system_profiler SPNVMeDataType` (`DiskHealth.smartVerified()`) — routinely 1–5s
- `tmutil latestbackup` (`BackupStatus.lastBackupDaysAgo()`)

Both via `Process.waitUntilExit()` with no timeout. Opening the **Diagnostics** tab froze the main thread past Sentry's 2000 ms App Hang threshold. Sentry files a separate issue per distinct hang stack, which is why one bug produced ~15 ANR issues.

This is the only main-thread synchronous shell-out in the app — every other `Process` call is already dispatched to a background queue.

## Fix

Move the two blocking probes into a `Task.detached(priority: .utility)` and publish the result back on the main actor. Cheap local reads (DB snapshot, FDA check) stay on-main.

## Verification

- `xcodebuild -scheme Burrow -configuration Debug` → **BUILD SUCCEEDED** locally.
- Hand-test: open the Diagnostics tab; checks should populate without a beachball.

## Issues

Resolves the "App hanging for at least 2000 ms" cluster (BURROW-3P…BURROW-44):
Closes #109, #110, #111, #112, #113, #114, #115, #116, #117, #118, #119, #120, #121, #122, #123