### PR TITLE
feat(updater): one-click "Update with Homebrew" button

### DIFF
--- a/macos/Sources/RootView.swift
+++ b/macos/Sources/RootView.swift
@@ -82,7 +82,10 @@ struct RootView: View {
                 VStack(spacing: 0) {
                     if let release = appUpdate.available {
                         UpdateBanner(release: release,
-                                     onDownload: { NSWorkspace.shared.open(release.url) },
+                                     onDownload: {
+                                         if UpdateCheck.installedViaHomebrew() { UpdateCheck.homebrewUpgrade() }
+                                         else { NSWorkspace.shared.open(release.url) }
+                                     },
                                      onDismiss: { appUpdate.dismiss() })
                             .padding(.horizontal, 18).padding(.top, 12).padding(.bottom, 4)
                             .transition(reduceMotion ? .opacity : .move(edge: .top).combined(with: .opacity))
@@ -202,13 +205,16 @@ private struct UpdateBanner: View {
                 Text(String(format: NSLocalizedString("Burrow %@ is available", comment: ""), release.version))
                     .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
                 Text(UpdateCheck.installedViaHomebrew()
-                     ? NSLocalizedString("Update with `brew upgrade --cask burrow`, or open the release page.", comment: "")
+                     ? NSLocalizedString("One-click update + relaunch via Homebrew.", comment: "")
                      : NSLocalizedString("Download it from the release page.", comment: ""))
                     .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
             }
             Spacer()
             Button(action: onDownload) {
-                Text("Download").font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                Text(UpdateCheck.installedViaHomebrew()
+                     ? NSLocalizedString("Update", comment: "")
+                     : NSLocalizedString("Download", comment: ""))
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
                     .padding(.horizontal, 14).padding(.vertical, 6)
                     .background(Capsule().fill(.white))
             }.buttonStyle(.plain)

--- a/macos/Sources/UpdateCheck.swift
+++ b/macos/Sources/UpdateCheck.swift
@@ -154,10 +154,11 @@ enum UpdateCheck {
                     return
                 }
                 if isNewer(release.version, than: currentVersion) {
-                    let body = installedViaHomebrew()
-                        ? String(format: NSLocalizedString("Burrow %@ is available (you have %@). Update with `brew upgrade --cask burrow`, or open the release page.", comment: ""), release.version, currentVersion)
+                    let brew = installedViaHomebrew()
+                    let body = brew
+                        ? String(format: NSLocalizedString("Burrow %@ is available (you have %@). Update and relaunch with Homebrew, or open the release page.", comment: ""), release.version, currentVersion)
                         : String(format: NSLocalizedString("Burrow %@ is available (you have %@). Download it from the release page.", comment: ""), release.version, currentVersion)
-                    presentResult(title: NSLocalizedString("Update available", comment: ""), body: body, link: release.url)
+                    presentResult(title: NSLocalizedString("Update available", comment: ""), body: body, link: release.url, brewUpgrade: brew)
                 } else {
                     presentResult(title: NSLocalizedString("You're up to date", comment: ""),
                                   body: String(format: NSLocalizedString("Burrow %@ is the latest release.", comment: ""), currentVersion),
@@ -167,19 +168,56 @@ enum UpdateCheck {
         }.resume()
     }
 
-    private static func presentResult(title: String, body: String, link: URL?) {
+    private static func presentResult(title: String, body: String, link: URL?, brewUpgrade: Bool = false) {
         let alert = NSAlert()
         alert.messageText = title
         alert.informativeText = body
-        if link != nil {
-            alert.addButton(withTitle: NSLocalizedString("Open Release Page", comment: ""))
-            alert.addButton(withTitle: NSLocalizedString("Close", comment: ""))
-        } else {
-            alert.addButton(withTitle: NSLocalizedString("Close", comment: ""))
-        }
+        // Button order defines the response order: Update (default) · Release page · Close.
+        if brewUpgrade { alert.addButton(withTitle: NSLocalizedString("Update with Homebrew", comment: "")) }
+        if link != nil { alert.addButton(withTitle: NSLocalizedString("Open Release Page", comment: "")) }
+        alert.addButton(withTitle: NSLocalizedString("Close", comment: ""))
         NSApp.activate(ignoringOtherApps: true)
-        if alert.runModalQuiet() == .alertFirstButtonReturn, let link {
+        let resp = alert.runModalQuiet()
+        if brewUpgrade {
+            if resp == .alertFirstButtonReturn { homebrewUpgrade() }
+            else if resp == .alertSecondButtonReturn, let link { NSWorkspace.shared.open(link) }
+        } else if resp == .alertFirstButtonReturn, let link {
             NSWorkspace.shared.open(link)
         }
+    }
+
+    /// User-initiated one-click update for Homebrew installs: run
+    /// `brew upgrade --cask burrow` in Terminal, then relaunch. Still entirely
+    /// user-driven — nothing installs without this click. Uses a `.command`
+    /// file (no Automation/AppleScript permission needed): it waits for this
+    /// app to quit so the bundle can be swapped cleanly, upgrades, then reopens
+    /// Burrow. Terminal runs in the user's login shell, so `brew` is on PATH.
+    static func homebrewUpgrade() {
+        let script = """
+        #!/bin/bash
+        echo "Updating Burrow via Homebrew — it'll reopen when this finishes."
+        echo
+        for _ in $(seq 1 60); do pgrep -x Burrow >/dev/null 2>&1 || break; sleep 0.5; done
+        brew upgrade --cask burrow
+        code=$?
+        echo
+        if [ $code -eq 0 ]; then
+          echo "Updated. Relaunching Burrow…"
+          open -a Burrow
+        else
+          echo "Update failed (exit $code). Grab it from \(releasesPageURL.absoluteString)"
+        fi
+        """
+        let path = (NSTemporaryDirectory() as NSString).appendingPathComponent("burrow-update.command")
+        do {
+            try script.write(toFile: path, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        } catch {
+            NSWorkspace.shared.open(releasesPageURL)
+            return
+        }
+        NSWorkspace.shared.open(URL(fileURLWithPath: path))
+        // Quit so the .command can replace the bundle and relaunch the new build.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { NSApp.terminate(nil) }
     }
 }


### PR DESCRIPTION
## What

The update dialog and in-app banner already detected Homebrew installs and showed a copy-pasteable `brew upgrade --cask burrow` command — but there was no button to actually run it. This adds a real **"Update with Homebrew"** button to both surfaces.

When the cask receipt is present (`installedViaHomebrew()`), clicking it:
1. Writes a `.command` script to a temp dir and opens it in Terminal.
2. The script waits for Burrow to quit (so the bundle can be swapped cleanly), runs `brew upgrade --cask burrow`, then relaunches Burrow.
3. Burrow quits itself ~0.6s after handing off, so the new build comes back up.

### Why a `.command` in Terminal (vs. running brew in-process)
- **No Automation/AppleScript permission prompt** — opening a file isn't controlling another app.
- **`brew` resolves on PATH** — Terminal runs the user's login shell.
- **Robust to self-replacement** — the upgrade outlives Burrow quitting, and the user sees transparent progress (fits the local-first / no-magic ethos).

Still **entirely user-initiated** — nothing installs without the click. Non-Homebrew installs are unchanged (Download / Open Release Page).

## Surfaces
- `UpdateCheck.checkNow()` NSAlert → adds **Update with Homebrew** (default button), keeps Open Release Page + Close.
- In-app `UpdateBanner` (RootView) → button reads **Update** and runs the same path; subtext updated.

## Scope notes
- **Auto-check is not regressed.** `Store.autoCheckForUpdates` defaults to `true` (launch + ~daily check), and the Settings toggle binds to it correctly. A copy showing it *off* had it explicitly toggled off — flipping it on restores the banner.
- This is the **interim** path. Full silent self-update (Sparkle + appcast) still depends on signed/notarized distribution (Developer ID cert) — out of scope here.

## Test
- `xcodegen generate && xcodebuild -scheme Burrow -configuration Debug build` → **BUILD SUCCEEDED**.