### PR TITLE
fix(perf): kill the App-Hang ANR fan-out + add opt-in `mo status --watch`

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -513,6 +513,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// Standard About panel, with the engine version and the links that
     /// matter (repo, releases, telemetry disclosure) in the credits.
     func showAboutPanel() {
+        // `mo --version` spawns a subprocess — fetch it off-main, then build
+        // and present the panel on main (was a main-thread subprocess block).
+        DispatchQueue.global(qos: .userInitiated).async {
+            let version = MoleCLI.version().map { "v\($0)" } ?? NSLocalizedString("not found", comment: "")
+            DispatchQueue.main.async { self.presentAboutPanel(moleVersion: version) }
+        }
+    }
+
+    private func presentAboutPanel(moleVersion: String) {
         let credits = NSMutableAttributedString()
         let para = NSMutableParagraphStyle()
         para.alignment = .center
@@ -524,8 +533,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                   .foregroundColor: NSColor.secondaryLabelColor, .paragraphStyle: para]
             credits.append(NSAttributedString(string: text + "\n", attributes: attrs))
         }
-        line(String(format: NSLocalizedString("Mole engine %@", comment: ""),
-                    MoleCLI.version().map { "v\($0)" } ?? NSLocalizedString("not found", comment: "")))
+        line(String(format: NSLocalizedString("Mole engine %@", comment: ""), moleVersion))
         line(NSLocalizedString("Source on GitHub", comment: ""), link: "https://github.com/caezium/Burrow")
         line(NSLocalizedString("Releases", comment: ""), link: "https://github.com/caezium/Burrow/releases")
         line(NSLocalizedString("What telemetry is collected", comment: ""),

--- a/macos/Sources/MoEngine.swift
+++ b/macos/Sources/MoEngine.swift
@@ -192,4 +192,19 @@ final class MoEngine {
     func interactive() -> PTYPort {
         makePTY()
     }
+
+    // MARK: Status stream (mo status --watch, V1.44+)
+
+    /// Stream `mo status --watch` as process events — each `.line` is one
+    /// NDJSON status snapshot; `.exited` ends the stream (the caller falls back
+    /// to polling). Runs indefinitely (no timeout); cancelling the consuming
+    /// task terminates the child via the stream's onTermination. Returns nil if
+    /// `mo` can't be resolved. Reuses the streaming port that drives
+    /// clean/optimize, so there's no new spawn plumbing.
+    func statusWatch() -> AsyncStream<ProcessEvent>? {
+        guard let path = locator.locate() else { return nil }
+        let spec = ProcessSpec(executable: path, arguments: ["status", "--watch"],
+                               stdin: nil, elevated: false, timeout: nil)
+        return streamPort.events(spec)
+    }
 }

--- a/macos/Sources/MoleCLI.swift
+++ b/macos/Sources/MoleCLI.swift
@@ -155,6 +155,31 @@ enum MoleCLI {
     /// GUI app with no controlling terminal (#35).
     static let minimumAnalyzeJSONVersion = "1.29.0"
 
+    /// Oldest Mole whose `status --watch` streams NDJSON (V1.44.0, "Signal").
+    /// Below this Burrow polls `mo status --json` instead.
+    static let minimumWatchVersion = "1.44.0"
+
+    /// Whether the installed `mo` supports `status --watch`. Spawns
+    /// `mo --version` — call OFF the main thread.
+    static func supportsWatch() -> Bool {
+        guard let v = version() else { return false }
+        return versionAtLeast(v, minimumWatchVersion)
+    }
+
+    /// True if `version` ≥ `minimum`, compared numerically component-by-
+    /// component (missing components count as 0). Pure → unit-tested.
+    static func versionAtLeast(_ version: String, _ minimum: String) -> Bool {
+        func parts(_ s: String) -> [Int] {
+            s.split(separator: ".").map { Int($0.prefix { $0.isNumber }) ?? 0 }
+        }
+        let v = parts(version), m = parts(minimum)
+        for i in 0..<max(v.count, m.count) {
+            let a = i < v.count ? v[i] : 0, b = i < m.count ? m[i] : 0
+            if a != b { return a > b }
+        }
+        return true
+    }
+
     /// Result of a subprocess invocation. `exitCode == 0` is the success
     /// convention; callers that care about diagnostics should look at
     /// `stderr` when it's non-zero, and `timedOut` distinguishes "the

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -71,6 +71,7 @@ struct SettingsView: View {
     @State private var newPattern = ""
     @State private var removalMode: CacheRemovalMode = Store.cacheRemovalMode
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
+    @State private var useStatusWatch: Bool = Store.useStatusWatch
     @State private var retentionDays: Int = Store.retentionDays
     @State private var autoVacuum: Bool = Store.autoVacuum
     @State private var dbSizeText: String = "—"
@@ -414,6 +415,8 @@ struct SettingsView: View {
                     Store.sampleIntervalSeconds = $0
                 }
                 footnote("Burrow runs `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
+                toggleRow("Stream live status (experimental)", isOn: $useStatusWatch) { Store.useStatusWatch = $0 }
+                footnote("Mole 1.44+ only: streams `mo status --watch` continuously instead of polling — lower latency and less subprocess churn. Falls back to polling on older mo or if the stream drops. Takes effect after a relaunch.")
             }
         }
     }

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -49,7 +49,9 @@ struct SettingsView: View {
     /// means a relaunch is needed before scans can reach protected caches.
     private let fdaAtOpen = Privacy.hasFullDiskAccess()
     @State private var appLanguage: String = Store.appLanguage
-    @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
+    // Loaded off-main in onAppear — `SMAppService.status` is a synchronous
+    // XPC call that hung the main thread when read in this @State initializer.
+    @State private var launchAtLogin: Bool = false
     @State private var hideDockIcon: Bool = Store.hideDockIcon
     @State private var skipIntro: Bool = Store.skipIntro
     @State private var notifyOnCompletion: Bool = Store.notifyOnCompletion
@@ -153,7 +155,7 @@ struct SettingsView: View {
             .frame(width: 460, height: 440)
         }
         .onAppear {
-            refreshStatusLabels(); loadMoleVersion(); loadTouchIDStatus()
+            refreshStatusLabels(); loadMoleVersion(); loadTouchIDStatus(); loadLaunchAtLogin()
             whitelistPatterns = MoleWhitelist.live.patterns()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
@@ -589,6 +591,16 @@ struct SettingsView: View {
         DispatchQueue.global(qos: .userInitiated).async {
             let v = MoleCLI.version()
             DispatchQueue.main.async { moleVersion = v.map { "v\($0)" } ?? "not found" }
+        }
+    }
+
+    /// Read the login-item status off-main — `SMAppService.status` is a
+    /// synchronous XPC call (a mach send-and-wait) that hung the main thread
+    /// when it ran in the view's @State initializer (App-Hang).
+    private func loadLaunchAtLogin() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let on = SMAppService.mainApp.status == .enabled
+            DispatchQueue.main.async { launchAtLogin = on }
         }
     }
 
@@ -1139,26 +1151,32 @@ struct SettingsView: View {
     // MARK: - Status labels
 
     private func refreshStatusLabels() {
-        let support = FileManager.default.urls(for: .applicationSupportDirectory,
-                                               in: .userDomainMask).first!
-            .appendingPathComponent("Burrow", isDirectory: true)
-        var total: Int64 = 0
-        if let enumerator = FileManager.default.enumerator(at: support,
-                                                           includingPropertiesForKeys: [.fileSizeKey]) {
-            for case let url as URL in enumerator {
-                if let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize {
-                    total += Int64(size)
-                }
-            }
-        }
-        self.dbSizeText = Fmt.bytes(total)
-
+        // The maintenance label is cheap (in-memory) — set it synchronously.
         if let last = AppDelegate.shared?.maintenance?.lastRunAt {
             let delta = Int(Date().timeIntervalSince(last))
             self.lastMaintenanceText = String(format: NSLocalizedString("%ds ago · pruned %d rows", comment: ""),
                                               delta, AppDelegate.shared?.maintenance?.lastPruneDeleted ?? 0)
         } else {
             self.lastMaintenanceText = NSLocalizedString("not yet run", comment: "")
+        }
+        // Sizing the support dir walks every file under it (the metrics SQLite
+        // store grows large over time) — off the main thread so opening
+        // Settings can't hang on a deep enumeration (App-Hang).
+        DispatchQueue.global(qos: .utility).async {
+            let support = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                   in: .userDomainMask).first!
+                .appendingPathComponent("Burrow", isDirectory: true)
+            var total: Int64 = 0
+            if let enumerator = FileManager.default.enumerator(at: support,
+                                                               includingPropertiesForKeys: [.fileSizeKey]) {
+                for case let url as URL in enumerator {
+                    if let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize {
+                        total += Int64(size)
+                    }
+                }
+            }
+            let text = Fmt.bytes(total)
+            DispatchQueue.main.async { self.dbSizeText = text }
         }
     }
 }

--- a/macos/Sources/SnapshotProducer.swift
+++ b/macos/Sources/SnapshotProducer.swift
@@ -153,6 +153,10 @@ final class SnapshotProducer {
         /// Background executor for the blocking mo fetch. Production hops to
         /// a serial utility queue; tests pass `{ $0() }` for synchrony.
         var work: (@escaping () -> Void) -> Void
+        /// Optional NDJSON status stream (`mo status --watch`, V1.44+). Returns
+        /// nil when streaming is disabled / unsupported / mo unresolved → the
+        /// producer polls. Tests omit it, so the poll path is unchanged.
+        var statusWatch: (() -> AsyncStream<ProcessEvent>?)? = nil
 
         static func live(db: DB) -> Deps {
             let queue = DispatchQueue(label: "dev.caezium.burrow.producer", qos: .utility)
@@ -161,7 +165,13 @@ final class SnapshotProducer {
                         clock: DispatchClock(),
                         sink: DBSnapshotSink(db: db),
                         snapshotInterval: { TimeInterval(Store.sampleIntervalSeconds) },
-                        work: { queue.async(execute: $0) })
+                        work: { queue.async(execute: $0) },
+                        statusWatch: {
+                            // The gate spawns `mo --version`, so this runs off-main
+                            // (the producer calls the factory inside `work`).
+                            (Store.useStatusWatch && MoleCLI.supportsWatch())
+                                ? MoEngine.shared.statusWatch() : nil
+                        })
         }
     }
 
@@ -173,8 +183,14 @@ final class SnapshotProducer {
     private let lock = NSLock()
     private var running = false
     private var foreground = false
+    private var streaming = false            // `mo status --watch` active (guarded by lock)
     private var snapTimer: ClockCancellable?
     private var liveTimer: ClockCancellable?
+    private var streamTask: Task<Void, Never>?
+    /// Last time a streamed snapshot was persisted — throttles DB writes to the
+    /// configured interval so a fast `--watch` stream doesn't write
+    /// 1 s-resolution rows into the long-range history (guarded by lock).
+    private var lastStreamPersist = Date.distantPast
 
     private let foregroundInterval: TimeInterval = 5
     private let liveInterval: TimeInterval = 1
@@ -199,18 +215,61 @@ final class SnapshotProducer {
         let now = deps.clock.now
         if let n = deps.hardware.netBytes() { _ = liveNet.mbps(n.rx, n.tx, at: now) }
         if let d = deps.hardware.diskBytes() { _ = liveDisk.mbps(d.read, d.write, at: now) }
-        // Immediate sample so the popup has data right away.
-        deps.work { self.sampleNow() }
-        armSnapshotTimer()
         armLiveTimer()
+        // Off-main: seed one snapshot immediately, then either start the
+        // `mo status --watch` stream or arm the poll timer. The gate spawns
+        // `mo --version`, so the decision must run off the main thread.
+        deps.work { self.beginSnapshots() }
+    }
+
+    /// Seed one snapshot, then choose snapshot delivery: stream when
+    /// `deps.statusWatch` vends one (V1.44+, opt-in), else poll. Runs on
+    /// `deps.work` (off-main).
+    private func beginSnapshots() {
+        sampleNow()
+        if let factory = deps.statusWatch, let stream = factory() {
+            startStreaming(stream)
+        } else {
+            armSnapshotTimer()
+        }
+    }
+
+    /// Consume `mo status --watch` NDJSON: publish every line, persist throttled
+    /// to the configured interval. On stream end (mo exited / errored) fall back
+    /// to polling, so a dropped stream never leaves the dashboard frozen.
+    private func startStreaming(_ stream: AsyncStream<ProcessEvent>) {
+        lock.lock()
+        guard running else { lock.unlock(); return }
+        streaming = true
+        lock.unlock()
+        streamTask = Task { [weak self] in
+            for await event in stream {
+                guard let self else { return }
+                guard case .line(let json) = event else { continue }
+                let now = self.deps.clock.now
+                self.lock.lock()
+                let due = now.timeIntervalSince(self.lastStreamPersist) >= self.deps.snapshotInterval() - 0.5
+                if due { self.lastStreamPersist = now }
+                self.lock.unlock()
+                self.ingest(raw: json, persist: due)
+            }
+            guard let self else { return }
+            self.lock.lock()
+            self.streaming = false
+            let resume = self.running
+            self.lock.unlock()
+            if resume { self.armSnapshotTimer() }
+        }
     }
 
     func stop() {
         lock.lock()
         running = false
+        streaming = false
         snapTimer?.cancel(); snapTimer = nil
         liveTimer?.cancel(); liveTimer = nil
         lock.unlock()
+        streamTask?.cancel(); streamTask = nil   // cancellation terminates the mo child
     }
 
     /// Switch between background and live (foreground) cadence. Turning it
@@ -221,10 +280,12 @@ final class SnapshotProducer {
         guard foreground != on else { lock.unlock(); return }
         foreground = on
         let isRunning = running
+        let isStreaming = streaming
         lock.unlock()
         guard isRunning else { return }
-        if on { deps.work { self.sampleNow() } }
-        armSnapshotTimer()
+        // While streaming, the watch supplies snapshots — no poll to re-pace.
+        if on && !isStreaming { deps.work { self.sampleNow() } }
+        armSnapshotTimer()   // no-op while streaming (guarded)
     }
 
     // MARK: Cadence
@@ -232,7 +293,7 @@ final class SnapshotProducer {
     private func armSnapshotTimer() {
         lock.lock()
         defer { lock.unlock() }
-        guard running else { return }
+        guard running, !streaming else { return }   // the watch stream owns snapshots
         snapTimer?.cancel()
         let slow = deps.snapshotInterval()
         let interval = foreground ? min(foregroundInterval, slow) : slow
@@ -283,7 +344,13 @@ final class SnapshotProducer {
             NSLog("Burrow.SnapshotProducer: mo status failed: \(error.localizedDescription)")
             return
         }
+        ingest(raw: raw, persist: true)
+    }
 
+    /// Patch holes from native counters → parse-validate (a malformed snapshot
+    /// never pollutes the DB) → optionally persist → publish. Shared by the poll
+    /// (`persist: true` every tick) and the `--watch` stream (persist throttled).
+    private func ingest(raw: String, persist: Bool) {
         let now = deps.clock.now
         let fans = deps.hardware.fans()
         let temps = deps.hardware.temps()
@@ -324,14 +391,16 @@ final class SnapshotProducer {
             return
         }
 
-        // Mole's `collected_at` (not Date()): if the tick lags, the chart
-        // x-axis stays accurate to the sample window.
-        let ts = Int(snapshot.collectedAt.timeIntervalSince1970)
-        do {
-            try deps.sink.persist(ts: ts, json: json)
-        } catch {
-            NSLog("Burrow.SnapshotProducer: persist failed: \(error.localizedDescription)")
-            return
+        if persist {
+            // Mole's `collected_at` (not Date()): if the tick lags, the chart
+            // x-axis stays accurate to the sample window.
+            let ts = Int(snapshot.collectedAt.timeIntervalSince1970)
+            do {
+                try deps.sink.persist(ts: ts, json: json)
+            } catch {
+                NSLog("Burrow.SnapshotProducer: persist failed: \(error.localizedDescription)")
+                return
+            }
         }
 
         let at = deps.clock.now

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -18,11 +18,17 @@ import AppKit
 /// The Overview section of Home: live metric cards + the process table.
 struct StatusView: View {
     @StateObject private var model: StatusModel
-    @ObservedObject private var io: LiveFeed
+    /// The 1 Hz live feed. Deliberately NOT `@ObservedObject` here: only the
+    /// small Disk / Net cards observe it (`LiveDiskCard` / `LiveNetCard`), so a
+    /// per-second rate/ring tick re-renders just those two tiles instead of the
+    /// whole dashboard — every chart tile AND the 100-row process table — every
+    /// second. That StatusView-wide 1 Hz invalidation was the App-Hang fan-out
+    /// (BURROW-4x: layout/AttributeGraph churn, per-row Menus rebuilt at 1 Hz).
+    private let live: LiveFeed
 
     init(db: DB, live: LiveFeed, feeds: FeedHub) {
         _model = StateObject(wrappedValue: StatusModel(db: db, live: live, feeds: feeds))
-        self.io = live
+        self.live = live
     }
 
     private let row1H: CGFloat = 162
@@ -40,8 +46,9 @@ struct StatusView: View {
                         gpuTile(s).frame(minHeight: row1H)
                     }
                     HStack(spacing: 16) {
-                        DiskCard(s: s, liveRead: io.readMBs, liveWrite: io.writeMBs, minHeight: row2H, db: model.db)
-                        netTile(s).frame(minHeight: row2H)
+                        LiveDiskCard(s: s, io: live, minHeight: row2H, db: model.db)
+                        LiveNetCard(s: s, io: live, fallbackRx: model.netRxHist, fallbackTx: model.netTxHist)
+                            .frame(minHeight: row2H)
                         fanTile(s).frame(minHeight: row2H)
                     }
                     // Battery card carries the ring gauges (Mac + connected
@@ -171,7 +178,31 @@ struct StatusView: View {
         }
     }
 
-    private func netTile(_ s: MoleStatus) -> ValueTile {
+}
+
+/// Disk tile that observes the 1 Hz `LiveFeed` HERE (not in StatusView), so a
+/// per-second throughput tick re-renders only this tile.
+struct LiveDiskCard: View {
+    let s: MoleStatus
+    @ObservedObject var io: LiveFeed
+    var minHeight: CGFloat? = nil
+    var db: DB? = nil
+    var body: some View {
+        DiskCard(s: s, liveRead: io.readMBs, liveWrite: io.writeMBs, minHeight: minHeight, db: db)
+    }
+}
+
+/// Network tile that observes the 1 Hz `LiveFeed` HERE, for the same reason —
+/// the per-second rate/ring updates stay scoped to this tile rather than
+/// invalidating the whole dashboard.
+struct LiveNetCard: View {
+    let s: MoleStatus
+    @ObservedObject var io: LiveFeed
+    /// Sparkline fallback for the first tick, before the 1 s ring has samples.
+    var fallbackRx: [Double] = []
+    var fallbackTx: [Double] = []
+
+    var body: some View {
         let snapNet = s.network.first(where: { !$0.ip.isEmpty }) ?? s.network.first
         // Prefer the native 1 s monitor (catches bursts the mo poll misses); the
         // mo snapshot is the fallback before the monitor has any samples.
@@ -185,8 +216,8 @@ struct StatusView: View {
         // Two lines, one scale: download (green, ↓) and upload (blue, ↑) —
         // matching the ↓/↑ figures in the footnote. Tile window = the recent
         // 2 min of the 1 s ring; longer windows live in the History tab.
-        let rxHist = useLive ? io.netRxHistory(lastSeconds: 120) : model.netRxHist
-        let txHist = useLive ? io.netTxHistory(lastSeconds: 120) : model.netTxHist
+        let rxHist = useLive ? io.netRxHistory(lastSeconds: 120) : fallbackRx
+        let txHist = useLive ? io.netTxHistory(lastSeconds: 120) : fallbackTx
         return ValueTile(
             eyebrow: "Network", glyph: "network", accent: Brand.green,
             value: value, unit: unit, chip: chip,

--- a/macos/Sources/Store.swift
+++ b/macos/Sources/Store.swift
@@ -566,6 +566,14 @@ enum Store {
         set { write(newValue, "auto_check_for_updates") }
     }
 
+    /// Stream live status via `mo status --watch` (V1.44+) instead of polling
+    /// `mo status --json`. Experimental, default off — falls back to polling
+    /// when mo is too old or the stream drops.
+    static var useStatusWatch: Bool {
+        get { d.object(forKey: "use_status_watch") as? Bool ?? false }
+        set { write(newValue, "use_status_watch") }
+    }
+
     /// When the last background self-update check ran — throttles the
     /// periodic check to ~daily.
     static var lastUpdateCheckAt: Date? {


### PR DESCRIPTION
Addresses the open Sentry ANRs and adds `mo status --watch`. The GPL note for engine-bundling is already posted on #54.

## 1 · ANR fixes — the "App Hanging ≥2000ms" fan-out (Sentry BURROW-45…4C / #128–#136)

Eight Sentry issues, one class of bug: **main-thread work**. Four root causes:

- **StatusView observed the 1 Hz `LiveFeed` directly**, so every per-second rate/ring tick re-laid-out the *whole* dashboard — all chart tiles **and** the 100-row process table (per-row Menus included). That's the layout/AttributeGraph/ForEach-of-buttons churn (BURROW-48/49/4A/4C). Live observation now lives in two small `LiveDiskCard` / `LiveNetCard` tiles; the rest of the dashboard re-renders only on the ~5 s snapshot.
- **`SettingsView` read `SMAppService.mainApp.status`** (a synchronous XPC call — the `mach_send_and_wait_for_reply` stack, BURROW-46) **in a `@State` initializer** → moved off-main.
- **`SettingsView.refreshStatusLabels`** did a synchronous `FileManager` deep-walk of the (large, growing) metrics dir on the main thread in `.onAppear` → moved off-main.
- **The About panel spawned `mo --version`** on the main thread → fetched off-main, then presented.

The idle-runloop (BURROW-47) and generic-metadata-warmup (BURROW-45) samples are benign/inherent and not chased.

## 2 · `mo status --watch` (Mole 1.44+) — opt-in

Streams status as NDJSON instead of polling `mo status --json`:
- `MoEngine.statusWatch()` runs it over the existing streaming port (one snapshot per line); cancelling terminates the child.
- `SnapshotProducer` publishes every line, **persists throttled** to the configured interval (no 1 s-resolution rows in long-range history), and **falls back to polling** on stream end/error.
- **Gated:** `Store.useStatusWatch` (Settings ▸ Maintenance ▸ Sampling, **default OFF, experimental**) AND mo ≥ 1.44. The poll path is the default and is untouched when the toggle is off — the streaming code is dormant.

## Test

`xcodegen && xcodebuild -scheme Burrow -configuration Debug build` → **BUILD SUCCEEDED**. The unit suite runs in CI (sandbox can't run `xcodebuild test`).

**Needs a hand-test:** the ANR fix should be eyeballed on the live dashboard (tiles still tick, table doesn't stutter), and the `--watch` path needs enabling on a mo-1.44 machine to confirm streaming + the poll fallback before it'd ever become default.

## After merge — issue triage
- Close the 8 ANR issues (#128–#130, #132–#136); the dedup marker means a recurrence re-files cleanly.
- Upstream `mo` (#105/#106/#107/#137): no breaking changes to parsed output; close as triaged. `--watch` (#137) is now wired; the GPL note (#106 → #54) is filed.