### PR TITLE
release: 0.8.1 — ANR fixes + streaming-default live status

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,48 +1,34 @@
-# Burrow 0.8.0
+# Burrow 0.8.1
 
-A top-to-bottom visual redesign, a wave of new tools, a deeper agent surface,
-and an early Windows preview. Still local-first — no new always-on network.
+A stability release: the live dashboard no longer freezes, live status now
+streams, and there's a one-click Homebrew update button — plus the Windows
+preview catches up on its code review. Still local-first.
 
-## Redesigned
-- A warm, tactile new look — a warm-coffee adaptive palette, film grain over a
-  soft gradient, a **floating icon rail** (replacing the top tabs), borderless
-  cards, and the Geist / Cal Sans type system.
-- **Overview** — Health pulled into an open hero band over a cleaner 3-up
-  vitals grid.
-- **History** — a focal hero chart with a selectable metric strip (tap to swap),
-  plus drag-select on a chart to surface the top processes for that spike.
-- **Menu-bar HUD** — borderless tiles on the same warm ground. Doctor and
-  Restore reskinned to match; edge-fade scrollers throughout.
+## Fixed
+- **No more "App Hanging" freezes.** The Overview dashboard used to re-render
+  its whole grid — every chart tile and the full process table — once a second;
+  now only the small Disk / Network tiles update that often, the rest on the
+  snapshot. Opening **Settings** and the **About** panel no longer blocks the
+  main thread either (login-item status, metrics-folder sizing, and the
+  engine-version lookup all moved off it), and **PostHog telemetry now flushes
+  off the main thread**.
 
-## New & improved tools
-- **Ports** — live connections, bandwidth, reverse-DNS peers, service labels,
-  conflicts, sortable columns, and a detail view.
-- **Get Online / Connectivity** — MDM + gateway checks, active-interface IP,
-  captive-portal and device-side rescue, one-click fixes.
-- **Tune-Up** — a Smart-Care flow (scan → results → run) that auto-scans on entry.
-- **Homebrew** — Services (start / stop / restart), Brewfile snapshots
-  (export / restore), and live `brew upgrade` progress in Updates.
-- **Menu bar** — customizable popup, Stats-depth widgets, a RunCat-style runner,
-  and live metric widgets in the status item.
-- **Disk** gains a "Full in ~N" forecast; **Doctor** gains SMART-health and
-  backup-awareness checks, with backup-overdue / SMART-failing reminders;
-  multi-select bulk reclaim; a git purge-safety badge.
+## Changed
+- **Live status streams by default.** With Mole 1.44+, Burrow streams
+  `mo status --watch` (newline-delimited JSON) instead of polling `mo status
+  --json` — lower latency and less subprocess churn. It falls back to polling
+  on older `mo` or if the stream drops, so the dashboard never stalls.
 
-## For your AI agent
-- A deeper MCP surface: a token-gated `/events` **SSE stream** and `burrow_diff`
-  (e.g. login-item churn), so an agent can watch and compare your machine over
-  time.
+## Added
+- **Update with Homebrew** — for cask installs, the update prompt now has a
+  one-click button that runs `brew upgrade --cask burrow` and relaunches,
+  instead of just printing the command.
 
-## Windows preview (new)
-- An early native **WinUI 3 / .NET 8** app now lives under `windows/` — Status,
-  History, Analyze, Apps, a tray HUD, local telemetry/history, and an MCP stdio
-  bridge. Build from source; unsigned preview.
-
-## Performance & stability
-- Killed several main-thread app-hangs (process table, sort, ICU on the render
-  path, app icons, clean reports, the software list). Onboarding now
-  auto-detects `mo`.
-
-## Under the hood
-- The repo is now a monorepo (`macos/` + `windows/`), with inside-out framework
-  signing for notarization and an automated upstream `mo` release watcher.
+## Windows preview
+- Closed out the port review: **MCP tool parity with macOS**
+  (`burrow_list_apps`, `burrow_purge`, `burrow_installer` — all preview-only
+  over MCP), stdio MCP that survives the HTTP toggle, **brand assets / palette /
+  fonts / app icon aligned to the Mac**, honest docs, and real MCP +
+  deletion-guard test coverage. (Earlier review rounds added Recycle-Bin
+  routing, a drive-root guard, and SHA-256 verification of the bundled engine
+  binary.) Still an unsigned, build-from-source preview.

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -71,7 +71,6 @@ struct SettingsView: View {
     @State private var newPattern = ""
     @State private var removalMode: CacheRemovalMode = Store.cacheRemovalMode
     @State private var sampleIntervalSeconds: Int = Store.sampleIntervalSeconds
-    @State private var useStatusWatch: Bool = Store.useStatusWatch
     @State private var retentionDays: Int = Store.retentionDays
     @State private var autoVacuum: Bool = Store.autoVacuum
     @State private var dbSizeText: String = "—"
@@ -414,9 +413,7 @@ struct SettingsView: View {
                                     (60, "60 sec"), (120, "2 min"), (300, "5 min")]) {
                     Store.sampleIntervalSeconds = $0
                 }
-                footnote("Burrow runs `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
-                toggleRow("Stream live status (experimental)", isOn: $useStatusWatch) { Store.useStatusWatch = $0 }
-                footnote("Mole 1.44+ only: streams `mo status --watch` continuously instead of polling — lower latency and less subprocess churn. Falls back to polling on older mo or if the stream drops. Takes effect after a relaunch.")
+                footnote("With Mole 1.44+ Burrow streams `mo status --watch` for live status; on older mo it falls back to polling `mo status --json` at this cadence. 60 s is plenty for charts; tighter intervals give finer detail at the cost of more subprocess churn.")
             }
         }
     }

--- a/macos/Sources/SnapshotProducer.swift
+++ b/macos/Sources/SnapshotProducer.swift
@@ -153,9 +153,10 @@ final class SnapshotProducer {
         /// Background executor for the blocking mo fetch. Production hops to
         /// a serial utility queue; tests pass `{ $0() }` for synchrony.
         var work: (@escaping () -> Void) -> Void
-        /// Optional NDJSON status stream (`mo status --watch`, V1.44+). Returns
-        /// nil when streaming is disabled / unsupported / mo unresolved → the
-        /// producer polls. Tests omit it, so the poll path is unchanged.
+        /// NDJSON status stream (`mo status --watch`, V1.44+) — the default when
+        /// the installed mo supports it. Returns nil for older mo / unresolved
+        /// mo → the producer polls (also the fallback if a live stream drops).
+        /// Tests omit it, so the poll path is exercised directly.
         var statusWatch: (() -> AsyncStream<ProcessEvent>?)? = nil
 
         static func live(db: DB) -> Deps {
@@ -167,10 +168,12 @@ final class SnapshotProducer {
                         snapshotInterval: { TimeInterval(Store.sampleIntervalSeconds) },
                         work: { queue.async(execute: $0) },
                         statusWatch: {
-                            // The gate spawns `mo --version`, so this runs off-main
-                            // (the producer calls the factory inside `work`).
-                            (Store.useStatusWatch && MoleCLI.supportsWatch())
-                                ? MoEngine.shared.statusWatch() : nil
+                            // Streaming is the default — used whenever the installed
+                            // mo supports `status --watch` (V1.44+); older mo or a
+                            // dropped stream fall back to polling. supportsWatch()
+                            // spawns `mo --version`, so this runs off-main (the
+                            // producer calls the factory inside `work`).
+                            MoleCLI.supportsWatch() ? MoEngine.shared.statusWatch() : nil
                         })
         }
     }

--- a/macos/Sources/Store.swift
+++ b/macos/Sources/Store.swift
@@ -566,14 +566,6 @@ enum Store {
         set { write(newValue, "auto_check_for_updates") }
     }
 
-    /// Stream live status via `mo status --watch` (V1.44+) instead of polling
-    /// `mo status --json`. Experimental, default off — falls back to polling
-    /// when mo is too old or the stream drops.
-    static var useStatusWatch: Bool {
-        get { d.object(forKey: "use_status_watch") as? Bool ?? false }
-        set { write(newValue, "use_status_watch") }
-    }
-
     /// When the last background self-update check ran — throttles the
     /// periodic check to ~daily.
     static var lastUpdateCheckAt: Date? {

--- a/macos/Sources/Telemetry.swift
+++ b/macos/Sources/Telemetry.swift
@@ -62,23 +62,32 @@ enum Telemetry {
             ?? "https://us.i.posthog.com"
 
         // Crash reporting shares the opt-in flag; safe no-op if no DSN is set.
+        // Stays on the main thread so the crash handler installs at launch.
         CrashReporter.start(enabled: isEnabled)
 
         guard !apiKey.isEmpty else { return }  // unconfigured / dev build → no analytics
 
-        let config = PostHogConfig(projectToken: apiKey, host: host)
-        config.captureApplicationLifecycleEvents = false  // we emit our own lifecycle events
-        config.captureScreenViews = false                 // AppKit; no autocapture
-        config.optOut = !isEnabled                         // hard-mute the network when opted out
-        // Burrow uses no feature flags; preloading them would add an extra
-        // network call at every launch that TELEMETRY.md doesn't list.
-        config.preloadFeatureFlags = false
-        PostHogSDK.shared.setup(config)
-        configured = true
+        // PostHog schedules its periodic-flush Timer on whatever run loop `setup`
+        // runs on. Doing setup on the main thread put that timer on the MAIN run
+        // loop, so every flush ran on main and could hang the UI for >2 s
+        // (App-Hang BURROW-4S: __NSFireTimer → PostHogQueue.flush → take). Set up
+        // off-main so the queue and its timer never touch the main thread; events
+        // still flush by batch size and on quit (Telemetry.flush()).
+        DispatchQueue.global(qos: .utility).async {
+            let config = PostHogConfig(projectToken: apiKey, host: host)
+            config.captureApplicationLifecycleEvents = false  // we emit our own lifecycle events
+            config.captureScreenViews = false                 // AppKit; no autocapture
+            config.optOut = !isEnabled                         // hard-mute the network when opted out
+            // Burrow uses no feature flags; preloading them would add an extra
+            // network call at every launch that TELEMETRY.md doesn't list.
+            config.preloadFeatureFlags = false
+            PostHogSDK.shared.setup(config)
+            configured = true
 
-        guard isEnabled else { return }
-        registerSuperProperties()
-        capture("app_opened", ["cold_start": true])
+            guard isEnabled else { return }
+            registerSuperProperties()
+            capture("app_opened", ["cold_start": true])
+        }
     }
 
     /// Best-effort flush on quit so the final session's events aren't lost.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -50,8 +50,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.8.0"
-        CFBundleVersion: "11"
+        CFBundleShortVersionString: "0.8.1"
+        CFBundleVersion: "12"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Friendly, one-time prompts for the standard folders Mole scans
         # (purge/installer touch these). Full Disk Access still covers the


### PR DESCRIPTION
The macOS half of **0.8.1** (Windows closeout is #164, same milestone).

- **ANR fixes** (#139): StatusView no longer re-renders the whole dashboard at 1 Hz; `SMAppService.status`, the Settings metrics-dir walk, and the About `mo --version` lookup moved off-main.
- **PostHog off-main**: the telemetry flush Timer no longer runs on the main run loop (App-Hang BURROW-4S).
- **Streaming live status by default**: `mo status --watch` (mo 1.44+) replaces polling, poll fallback retained; the opt-in toggle is gone.
- Version → 0.8.1 (build 12); `RELEASES.md` carries the 0.8.1 notes.

Tagging `v0.8.1` once this + #164 land triggers the build / publish / cask bump.