### PR TITLE
fix(notify): ask for notification permission up front, not mid-notification

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -148,10 +148,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         maintenance.start()
 
         // Completion notices + opt-in smart reminders. The delegate must
-        // be set before any notification is delivered or clicked;
-        // authorization is requested lazily by the first actual post
-        // (BurrowNotifier), never here at launch. (Main-actor hop: the
-        // notifier is @MainActor, this delegate callback isn't.)
+        // be set before any notification is delivered or clicked.
+        // startReminders() also requests notification permission up front
+        // (when a notifying feature is on) so the grant is settled at launch,
+        // not mid-notification. (Main-actor hop: the notifier is @MainActor,
+        // this delegate callback isn't.)
         Task { @MainActor in
             UNUserNotificationCenter.current().delegate = BurrowNotifier.shared
             BurrowNotifier.shared.startReminders()
@@ -279,6 +280,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let view = OnboardingView(onFinish: { [weak self] in
             Store.onboardingCompleted = true
             Telemetry.capture("onboarding_completed")
+            // Settle notification permission now the user has finished setup —
+            // up front, before any completion notice or reminder needs it.
+            // (Hop to the main actor: the notifier is @MainActor, this
+            // SwiftUI callback isn't isolated.)
+            Task { @MainActor in BurrowNotifier.shared.requestAuthorizationForEnabledFeatures() }
             self?.onboardingWC?.close()
             self?.onboardingWC = nil
             self?.openMainWindow(initial: .home)

--- a/macos/Sources/Notifications.swift
+++ b/macos/Sources/Notifications.swift
@@ -18,9 +18,11 @@
 //      per week (reviewers pan chatty cleaners — throttling is the
 //      feature), and never while the app is frontmost.
 //
-//  UNUserNotificationCenter authorization is requested lazily by the
-//  first actual post — launching Burrow never prompts. The whole class
-//  is inert under XCTest (TEST_HOST shell).
+//  UNUserNotificationCenter authorization is requested UP FRONT when a
+//  notifying feature is enabled — at launch (startReminders) and when a
+//  notifying operation starts — so the grant is settled before the first
+//  notice fires, instead of ambushing the user mid-notification. The post
+//  path still requests lazily as a fallback. Inert under XCTest (TEST_HOST).
 //
 
 import AppKit
@@ -185,6 +187,11 @@ final class BurrowNotifier: NSObject {
     /// today, not in an hour.
     func startReminders() {
         guard !inert, reminderTimer == nil else { return }
+        // Ask for notification permission up front — at launch, once onboarding
+        // is done (first run asks at the end of onboarding instead) — rather
+        // than lazily when the first notice tries to fire (which ambushed the
+        // user mid-clean, or when a reminder triggered).
+        if Store.onboardingCompleted { requestAuthorizationForEnabledFeatures() }
         let timer = Timer(timeInterval: 3_600, repeats: true) { _ in
             Task { @MainActor in
                 BurrowNotifier.shared.checkReminders()
@@ -344,12 +351,23 @@ final class BurrowNotifier: NSObject {
         post(content, id: id)
     }
 
-    /// Ask for notification permission up front — called when a notifying
-    /// operation STARTS, so the grant is settled before the run finishes
-    /// (requesting only at completion races a closed window). Logged so a
-    /// denial, or an unsigned-build registration failure, is visible in
+    /// Proactively settle notification permission — at launch and at the end of
+    /// onboarding — but only when a feature that posts notifications is actually
+    /// on, so a user who turned them all off is never prompted. No-op once the
+    /// permission is already decided.
+    func requestAuthorizationForEnabledFeatures() {
+        guard Store.notifyOnCompletion || Store.watchStartupItems
+            || Store.smartRemindersEnabled || Store.thresholdAlertsEnabled else { return }
+        requestAuthorizationIfNeeded()
+    }
+
+    /// Request notification permission if it's still undetermined — called up
+    /// front: at launch when a notifying feature is on, and when a notifying
+    /// operation STARTS, so the grant is settled before the first notice fires
+    /// rather than mid-notification. A no-op once the user has answered. Logged
+    /// so a denial, or an unsigned-build registration failure, is visible in
     /// Console (`log stream --predicate 'eventMessage CONTAINS "Burrow.notify"'`).
-    func prepareAuthorization() {
+    func requestAuthorizationIfNeeded() {
         guard !inert else { return }
         let center = UNUserNotificationCenter.current()
         center.getNotificationSettings { settings in

--- a/macos/Sources/OperationCenter.swift
+++ b/macos/Sources/OperationCenter.swift
@@ -47,7 +47,7 @@ final class OperationCenter: ObservableObject {
         // Settle notification permission now, while the op runs, so the
         // completion notice can fire the moment it ends (even if the window
         // has been closed by then).
-        if notifiesOnEnd { BurrowNotifier.shared.prepareAuthorization() }
+        if notifiesOnEnd { BurrowNotifier.shared.requestAuthorizationIfNeeded() }
     }
 
     func detail(_ id: UUID, _ text: String) {


### PR DESCRIPTION
**Problem:** macOS only prompted for notification permission *lazily* — when the first completion notice or smart reminder actually tried to fire. So the permission dialog ambushed the user mid-clean, or whenever a background reminder first triggered.

**Fix:** request it proactively, while still only asking when it makes sense:
- **First run:** at the end of onboarding (`OnboardingView.onFinish`) — the natural "you're set up" moment, after the window is up.
- **Later runs (incl. post-update):** at launch in `startReminders()`, gated on `Store.onboardingCompleted`.
- Both go through `requestAuthorizationForEnabledFeatures()`, which only asks when a notifying feature is actually on (`notifyOnCompletion` / `watchStartupItems` / `smartReminders` / `thresholdAlerts`) and is a no-op once permission is decided — so it asks **at most once**, and never for someone who turned notifications off.
- The op-start (`requestAuthorizationIfNeeded`, renamed from `prepareAuthorization`) and post-time requests remain as a fallback.

Build: `xcodebuild … build` → **BUILD SUCCEEDED**.

Note: hard to fully exercise in an ad-hoc dev build (separate TCC identity), but on a fresh permission state it now prompts at launch / after onboarding instead of on the first notice.