### PR TITLE
release(macos): ad-hoc re-sign frameworks when unsigned — fixes FDA (#177)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,24 @@ jobs:
         run: |
           APP="${{ steps.build.outputs.app }}"
           if [ -z "$CERT_P12" ] || [ -z "$SIGN_IDENTITY" ]; then
-            echo "::warning::No signing cert (MACOS_CERT_P12 / MACOS_SIGN_IDENTITY) set — shipping UNSIGNED."
+            # No Developer ID cert: re-sign AD-HOC rather than ship whatever
+            # xcodebuild left behind. Its SPM frameworks carry a CodeResources
+            # manifest that doesn't match the embedded bundle, so
+            # `codesign --verify --strict` fails ("code has no resources but
+            # signature indicates they must be present" on Sentry.framework) —
+            # macOS then can't validate the app's identity, so a Full Disk
+            # Access grant is never honoured (#177). An inside-out ad-hoc
+            # re-sign regenerates each framework's CodeResources and gives the
+            # app one coherent, strictly-valid identity, so TCC can validate it
+            # and FDA holds within a version. (A stable identity ACROSS updates
+            # still needs a Developer ID — set the MACOS_CERT_* secrets.)
+            echo "::warning::No Developer ID cert — re-signing AD-HOC (valid, but a per-build identity: FDA must be re-granted after each update until a cert is configured)."
+            if [ -d "$APP/Contents/Frameworks" ]; then
+              find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) -print0 \
+                | while IFS= read -r -d '' f; do codesign --force --sign - "$f"; done
+            fi
+            codesign --force --sign - --entitlements macos/Resources/Burrow.entitlements "$APP"
+            codesign --verify --strict --verbose=2 "$APP"
             echo "signed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
Fixes #177 (Full Disk Access undetected after enabling it).

## Root cause (the reporter nailed it)
`codesign --verify --strict` fails on the 0.8.1 release:
> Burrow.app: code has no resources but signature indicates they must be present — In subcomponent: …/Frameworks/Sentry.framework

xcodebuild (with signing disabled) ships the SPM frameworks with a CodeResources manifest that doesn't match the embedded bundle. macOS can't validate the app's code identity, so TCC **never honours the Full Disk Access grant** — `Privacy.hasFullDiskAccess()` is a correct functional read-test, it just never gets to read because the grant isn't applied.

## Fix
When no Developer ID cert is configured, the release now re-signs **ad-hoc, inside-out** (each framework/dylib, then the bundle with entitlements) so the signature is strictly valid and TCC can validate the app.

**Verified locally** on a Debug build with the same frameworks:
```
# before
Burrow.app: code has no resources but signature indicates they must be present
# after the inside-out ad-hoc re-sign
codesign --verify --strict  → all components --validated (passes)
```

This makes FDA hold **within a version**. A stable identity **across updates** (so FDA persists through an upgrade, plus Gatekeeper trust) still needs a **Developer ID** — the signed + notarized path already exists in this workflow; it just needs the `MACOS_CERT_P12` / `MACOS_CERT_PASSWORD` / `MACOS_SIGN_IDENTITY` (+ `AC_API_*`) secrets.

## Rollout
Ships in the next release. Existing 0.8.1 users will need that build and a one-time re-grant of FDA.