### PR TITLE
release: 0.8.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,25 @@
+# Burrow 0.8.2
+
+A fix release: a Full Disk Access grant now actually takes effect, and Burrow
+asks for notification permission up front instead of mid-alert. Still
+local-first.
+
+## Fixed
+- **Full Disk Access is honored again.** The shipped app's embedded framework
+  signatures were malformed (`codesign --verify --strict` failed on
+  `Sentry.framework`), so macOS couldn't validate Burrow's identity and silently
+  ignored a Full Disk Access grant — turning it on in System Settings appeared to
+  do nothing. The release now re-signs the app and every nested framework
+  inside-out so the signature is valid and the grant takes effect. After
+  updating, toggle Full Disk Access off and back on once. (Burrow is still
+  ad-hoc-signed, so a re-grant is needed after each update until it ships with a
+  Developer ID signature.) (#177)
+
+## Changed
+- **Notification permission is requested up front.** Burrow now asks once — when
+  you finish onboarding or first enable a notifying feature — instead of
+  springing the system prompt the moment a notification tries to fire.
+
 # Burrow 0.8.1
 
 A stability release: the live dashboard no longer freezes, live status now

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -50,8 +50,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.8.1"
-        CFBundleVersion: "12"
+        CFBundleShortVersionString: "0.8.2"
+        CFBundleVersion: "13"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Friendly, one-time prompts for the standard folders Mole scans
         # (purge/installer touch these). Full Disk Access still covers the


### PR DESCRIPTION
Cuts **0.8.2** — bundles the two fixes already on main since 0.8.1:

- **Full Disk Access signing fix** (#178 → #177): the release now re-signs the app + nested frameworks inside-out so the signature is strictly valid and TCC honors the FDA grant.
- **Up-front notification permission** (#176): asks at onboarding / first notifying-feature enable, not mid-alert.

Bumps `CFBundleShortVersionString` 0.8.1 → 0.8.2 (build 12 → 13) and adds the 0.8.2 section to `RELEASES.md`. Merge → tag `v0.8.2` to trigger the release (which will now ad-hoc re-sign).

macOS-only; the Windows preview has no changes this cycle and stays at 0.8.1.