### PR TITLE
docs: FDA re-grant troubleshooting + correct ad-hoc signing status

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,21 +271,23 @@ handles this honestly:
 
 ### Granted Full Disk Access but Burrow still doesn't see it?
 
-After a Burrow update, macOS can hold on to a stale permission record, so a
-grant you already enabled stops being recognised — and toggling it off and back
-on in System Settings doesn't always clear it. Reset it once:
+Burrow's macOS builds are currently *ad-hoc signed*, which gives the app no
+stable code identity — so macOS can treat an updated build as a new app and stop
+honouring a Full Disk Access grant you'd already enabled. To clear the stale
+grant (macOS 26 and earlier):
 
 ```sh
+killall Burrow                                          # menu-bar agent — quit it fully
 tccutil reset SystemPolicyAllFiles dev.caezium.Burrow
 ```
 
-Then quit Burrow (⌘Q), re-add it under **System Settings → Privacy & Security →
+Then **reboot**, re-add Burrow under **System Settings → Privacy & Security →
 Full Disk Access**, and reopen.
 
-Why it happens: Burrow's macOS builds are currently *ad-hoc signed*, so the
-app's identity changes between releases and macOS treats an updated build as a
-new app for permission purposes. A stable Developer ID signature — the permanent
-fix — is planned.
+On **macOS 27**, TCC appears to require a stable signed identity, so an ad-hoc
+build may be unable to hold Full Disk Access at all and the reset won't help.
+The durable fix for every case is a stable **Developer ID** signature — planned;
+tracked in [#181](https://github.com/caezium/Burrow/issues/181).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,24 @@ handles this honestly:
 - Burrow only ever reads sizes; it never opens that data itself, and the real
   cleanup always goes through macOS's own admin dialog.
 
+### Granted Full Disk Access but Burrow still doesn't see it?
+
+After a Burrow update, macOS can hold on to a stale permission record, so a
+grant you already enabled stops being recognised — and toggling it off and back
+on in System Settings doesn't always clear it. Reset it once:
+
+```sh
+tccutil reset SystemPolicyAllFiles dev.caezium.Burrow
+```
+
+Then quit Burrow (⌘Q), re-add it under **System Settings → Privacy & Security →
+Full Disk Access**, and reopen.
+
+Why it happens: Burrow's macOS builds are currently *ad-hoc signed*, so the
+app's identity changes between releases and macOS treats an updated build as a
+new app for permission purposes. A stable Developer ID signature — the permanent
+fix — is planned.
+
 ## Requirements
 
 ### macOS
@@ -362,9 +380,13 @@ Burrow drives the audited `mo` CLI. The honest privacy picture:
   disables REST endpoints but keeps the local `/mcp` bridge route available for
   stdio MCP clients. The macOS Updates tab runs `brew outdated`, the same check
   `brew` does for itself.
-- **Unsigned preview builds:** macOS release zips and Windows preview artifacts
-  are unsigned in the current repo state. Windows direct-download users should
-  expect SmartScreen or stricter Application Control policy prompts.
+- **Signing status:** macOS release zips are **ad-hoc signed** — a strictly
+  valid signature, but a per-build identity, so Full Disk Access must be
+  re-granted after each update (see [Permissions & Full Disk
+  Access](#permissions--full-disk-access)). Windows preview artifacts are
+  unsigned, so direct-download users should expect SmartScreen or stricter
+  Application Control policy prompts. A stable Developer ID signature (the
+  permanent fix) is planned.
 - The full honest write-up, including macOS admin trade-offs and the "Scan with
   admin" option, is in **[SECURITY.md](SECURITY.md)**.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,30 @@
 # Security & trust
 
 Burrow is a GUI that drives the [`mo` (Mole)](https://github.com/tw93/Mole)
-CLI. It is pre-1.0 and **not yet code-signed** — this page is the honest
+CLI. It is pre-1.0 and **not yet signed with a Developer ID** — this page is the honest
 account of what it does, what touches the network, and how it handles
 admin rights, so you can decide before you run it. The actual
 cleaning/scanning is done by `mo` (MIT, © tw93); audit that too.
 
 ## Code signing
 
-Burrow is currently **unsigned and un-notarized**. Code signing is a real
-security mechanism (a cryptographic identity macOS can rely on), not a
-formality — a signed/notarized build is on the roadmap. Until then:
+macOS release builds are **ad-hoc signed**: the signature is cryptographically
+valid (`codesign --verify --strict` passes), but it carries no Developer ID, so
+the build is **not notarized** and its identity changes on every build.
+Practically:
 
-- Install via the Homebrew cask (it strips the quarantine flag for you), or
-- after copying the app, run `xattr -cr /Applications/Burrow.app`.
+- Gatekeeper still shows the "unidentified developer" prompt on first launch.
+  Install via the Homebrew cask (it strips the quarantine flag for you), or run
+  `xattr -cr /Applications/Burrow.app` after copying the app.
+- Because the identity is per-build, a permission you grant (e.g. Full Disk
+  Access) has to be re-granted after each update.
 
-If you're not comfortable running an unsigned app that can ask for admin
-rights, **wait for the signed release** or build it yourself from source.
+A stable **Developer ID** signature — which fixes both points — is the planned
+next step. Code signing is a real security mechanism (a cryptographic identity
+macOS can rely on), not a formality.
+
+If you're not comfortable running a non-notarized app that can ask for admin
+rights, build it yourself from source.
 
 ## Privileged (admin) operations — no background helper
 


### PR DESCRIPTION
Follow-up to #181 (FDA still unrecognised on 0.8.2 — the cross-update ad-hoc limitation).

**README** — adds a *"Granted Full Disk Access but Burrow still doesn't see it?"* note with the reliable reset:
```
tccutil reset SystemPolicyAllFiles dev.caezium.Burrow
```
…then quit + re-grant + reopen. Explains it's the per-build ad-hoc identity, with a Developer ID signature as the permanent fix.

**Honesty fix** — README + SECURITY.md said the macOS build is *"unsigned and un-notarized."* As of 0.8.2 it's **ad-hoc signed** (strictly valid, just no Developer ID / not notarized). Corrected both.