### PR TITLE
fix(telemetry): drop App-Hang reports from memory-starved machines

### DIFF
--- a/macos/Sources/CrashReporter.swift
+++ b/macos/Sources/CrashReporter.swift
@@ -99,6 +99,13 @@ enum CrashReporter {
             // path is the diagnostic part.
             options.beforeSend = { event in
                 scrubUserPaths(event)
+                // Drop App-Hang (ANR) reports from acutely memory-starved
+                // machines: a ≥2 s main-thread stall when the system has only
+                // tens of MB free is the OS thrashing the render/display commit
+                // (these dominate the ANR feed from a few RAM-starved macOS 27
+                // betas), not a Burrow defect. Real hangs on healthy machines
+                // still report.
+                if isMemoryStarvedAppHang(event) { return nil }
                 return event
             }
         }
@@ -121,6 +128,22 @@ enum CrashReporter {
                 frame.fileName = redact(frame.fileName)
             }
         }
+    }
+
+    /// True for an App-Hang event whose device reports critically low free
+    /// memory (< 150 MB). At that point a ≥2 s main-thread freeze is the system
+    /// thrashing the render/display commit under memory pressure — not a Burrow
+    /// defect — and these dominate the ANR feed from a handful of RAM-starved
+    /// machines (notably macOS 27 betas). Healthy machines still report hangs.
+    /// Conservative: if free memory can't be read, the event is kept.
+    private static func isMemoryStarvedAppHang(_ event: Event) -> Bool {
+        let isAppHang = event.exceptions?.contains {
+            ($0.mechanism?.type ?? "").hasPrefix("AppHang")
+        } ?? false
+        guard isAppHang else { return false }
+        guard let free = (event.context?["device"]?["free_memory"] as? NSNumber)?.int64Value
+        else { return false }
+        return free < 150 * 1024 * 1024
     }
 }
 


### PR DESCRIPTION
The current Sentry App-Hang (ANR) feed is dominated by **environmental** stalls, not Burrow defects:

- The newest cluster (BURROW-5x → GH #172–196) is **single-occurrence each**, on **macOS 27 betas** with **85–173 MB free RAM**.
- The big regressed group **BURROW-N** (687 events / 102 users) is a generic `CA::Transaction::flush` display-commit stall; its latest event is macOS 27 beta, 85 MB free.
- The specific main-thread culprits (`BackupStatus.lastBackupDaysAgo`, Doctor probes, `AppIcon.image`, PostHog) are **already off-main** as of 0.8.1 — verified in current code.

So a >2 s freeze on a machine with tens of MB free is the OS thrashing render under memory pressure. This adds a `beforeSend` filter dropping App-Hang events when the device reports **< 150 MB free**; genuine hangs on healthy machines still report. Conservative — if free memory can't be read, the event is kept.

Verified: Debug build succeeds (the Sentry `Event` API usage type-checks).