### PR TITLE
fix(menubar): colour audit — real memory pressure (#202), temp ramp, honest picker + ANR-safe file pickers

### DIFF
--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -25,6 +25,7 @@
 
 import AppKit
 import SwiftUI
+import Darwin   // sysctlbyname — native memory-pressure level
 
 // MARK: - Model
 
@@ -268,8 +269,30 @@ struct MenuBarMetricValues {
     /// Sparkline series (oldest→newest), already downsampled by the controller.
     var histories: [MenuBarMetric: [Double]] = [:]
     var batteryCharging = false
+    /// Current macOS memory-pressure level (`kern.memorystatus_vm_pressure_level`):
+    /// 1 = normal, 2 = warning, 4 = critical. Drives the "By pressure" colour.
+    var memoryPressureLevel: Int = MemoryPressure.normal
 
     func has(_ m: MenuBarMetric) -> Bool { primary[m] != nil }
+}
+
+/// The current macOS memory-pressure level, read natively from
+/// `kern.memorystatus_vm_pressure_level` — the same signal Activity Monitor's
+/// Memory Pressure graph and `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` report. It's
+/// a discrete level, NOT a percentage.
+enum MemoryPressure {
+    static let normal = 1, warning = 2, critical = 4
+
+    /// Point read of the current level — one cheap sysctl. Called on the
+    /// value-build pass, never on the draw path. Falls back to `normal` if the
+    /// sysctl is unavailable.
+    static func level() -> Int {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        guard sysctlbyname("kern.memorystatus_vm_pressure_level", &value, &size, nil, 0) == 0,
+              value > 0 else { return normal }
+        return Int(value)
+    }
 }
 
 // MARK: - Renderer
@@ -321,6 +344,17 @@ enum MenuBarRenderer {
         }
     }
 
+    /// "By pressure" colour — the discrete macOS memory-pressure level (not a
+    /// percentage): normal → green, warning → orange, critical → red, matching
+    /// Activity Monitor's Memory Pressure graph.
+    private static func pressureColor(_ level: Int) -> NSColor {
+        switch level {
+        case MemoryPressure.critical: return NSColor(Brand.red)
+        case MemoryPressure.warning:  return NSColor(Brand.orange)
+        default:                      return NSColor(Brand.green)
+        }
+    }
+
     /// Battery is inverse: low charge is the alarming end.
     private static func batteryColor(_ pct: Double, charging: Bool) -> NSColor {
         if charging { return NSColor(Brand.green) }
@@ -336,7 +370,13 @@ enum MenuBarRenderer {
         switch item.color {
         case .mono:    return .labelColor
         case .accent:  return NSColor(Brand.blue)
-        case .pressure, .utilization:
+        case .pressure:
+            // "By pressure" = the real macOS memory-pressure level, not a load
+            // percentage. Only memory carries a pressure signal; other metrics
+            // fall back to value-driven colouring.
+            if item.metric == .memory { return pressureColor(values.memoryPressureLevel) }
+            fallthrough
+        case .utilization:
             if item.metric == .battery { return batteryColor(value, charging: values.batteryCharging) }
             if item.metric.isPercentage { return utilization(value) }
             return NSColor(Brand.blue)

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -88,6 +88,14 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// Colour modes offered for this metric. "By pressure" reads macOS memory
+    /// pressure, so it's only meaningful for `.memory` — don't offer it
+    /// elsewhere (it would silently fall back to "By utilization").
+    var colorModes: [MenuBarColorMode] {
+        self == .memory ? MenuBarColorMode.allCases
+                        : MenuBarColorMode.allCases.filter { $0 != .pressure }
+    }
+
     /// Two-channel metrics (down/up, read/write) — eligible for the speed style.
     var isDual: Bool { self == .network || self == .diskIO }
 
@@ -365,6 +373,19 @@ enum MenuBarRenderer {
         }
     }
 
+    /// Temperature ramp (°C), so a temp widget actually warns when hot instead
+    /// of sitting flat blue. Tuned for Mac CPU/GPU package temps (idle ~40,
+    /// sustained load ~80, throttle ~100): cool → green, warm → gold, hot →
+    /// orange, very hot → red.
+    private static func temperatureColor(_ celsius: Double) -> NSColor {
+        switch celsius {
+        case 95...:   return NSColor(Brand.red)
+        case 85..<95: return NSColor(Brand.orange)
+        case 70..<85: return NSColor(Brand.gold)
+        default:      return NSColor(Brand.green)
+        }
+    }
+
     static func color(for item: MenuBarItem, value: Double, values: MenuBarMetricValues) -> NSColor {
         if let fixed = item.color.fixedColor { return fixed }   // named colours
         switch item.color {
@@ -378,6 +399,7 @@ enum MenuBarRenderer {
             fallthrough
         case .utilization:
             if item.metric == .battery { return batteryColor(value, charging: values.batteryCharging) }
+            if item.metric == .temperature { return temperatureColor(value) }
             if item.metric.isPercentage { return utilization(value) }
             return NSColor(Brand.blue)
         default:       return .labelColor   // unreachable: named modes handled above

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -960,7 +960,7 @@ struct SettingsView: View {
                 }
             }
             optionPicker("Color", value: item.color.title) {
-                ForEach(MenuBarColorMode.allCases) { c in
+                ForEach(item.metric.colorModes) { c in
                     Button(c.title) { updateMenuBarItem(idx) { $0.color = c } }
                 }
             }

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -697,7 +697,7 @@ struct SettingsView: View {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "Brewfile"
         panel.canCreateDirectories = true
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard CrashReporter.withoutAppHangTracking({ panel.runModal() }) == .OK, let url = panel.url else { return }
         brewBusy = true
         brewSnapshotStatus = NSLocalizedString("Exporting…", comment: "")
         Task {
@@ -719,7 +719,7 @@ struct SettingsView: View {
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard CrashReporter.withoutAppHangTracking({ panel.runModal() }) == .OK, let url = panel.url else { return }
         brewBusy = true
         brewSnapshotStatus = NSLocalizedString("Restoring — installing from your Brewfile can take a while…", comment: "")
         Task {

--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -198,6 +198,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         v.histories[.cpu]    = menuBarHistory[.cpu]
         v.histories[.memory] = menuBarHistory[.memory]
         v.histories[.gpu]    = menuBarHistory[.gpu]
+        // Real memory-pressure level for the "By pressure" colour mode — a
+        // cheap native sysctl read here on the value-build pass, not the draw
+        // path (see MemoryPressure in MenuBarWidgets).
+        v.memoryPressureLevel = MemoryPressure.level()
         return v
     }
 


### PR DESCRIPTION
Fixes #202, and the menu-bar colour audit it prompted, plus an ANR false-positive found during the Sentry pass.

### 1. "By pressure" reads real memory pressure (#202)
`color(for:)` handled `.pressure` and `.utilization` in the same branch, so "By pressure" coloured by load **%** and never read macOS pressure. Now reads `kern.memorystatus_vm_pressure_level` (Activity Monitor's signal) on the value-build pass — not the draw path — and colours memory by the discrete level: normal → 🟢, warning → 🟠, critical → 🔴. (It's a level, **not** a percentage — the root of the reporter's confusion.)

### 2. Temperature colour ramp
Temperature is non-percentage, so under any value-driven mode it returned **flat blue** — a temp widget never warned when hot. Added a °C ramp (`<70` green, `70–85` gold, `85–95` orange, `95+` red).

### 3. Honest "By pressure" picker
"By pressure" is memory-only, so the colour picker now offers it **only for the memory metric** instead of every metric (where it silently fell back).

### 4. ANR-safe file pickers
`NSSavePanel`/`NSOpenPanel.runModal()` in the Brewfile export/import block the main thread while the user picks a file — taking >2 s there trips Sentry's App-Hang detector (BURROW-60). Wrapped both in `CrashReporter.withoutAppHangTracking`, matching the existing `runModalQuiet` pattern.

> Build verified by CI (local build skipped — runner `/tmp` at 99%).