### PR TITLE
feat: 0.8.3 menu-bar & metrics improvements

### DIFF
--- a/macos/Sources/MenuBarRunner.swift
+++ b/macos/Sources/MenuBarRunner.swift
@@ -59,6 +59,8 @@ enum RunnerCatalog {
         .init(id: "pulse",  title: NSLocalizedString("Pulse", comment: "")),
         .init(id: "orbit",  title: NSLocalizedString("Orbit", comment: "")),
         .init(id: "stride", title: NSLocalizedString("Stride", comment: "")),
+        .init(id: "wave",   title: NSLocalizedString("Wave", comment: "")),
+        .init(id: "bars",   title: NSLocalizedString("Bars", comment: "")),
     ]
 
     /// Frames for a built-in runner at the given height (square frames).
@@ -94,6 +96,26 @@ enum RunnerCatalog {
                 }
                 let body = NSBezierPath(ovalIn: NSRect(x: mid.x - 3, y: rect.midY + rect.height * 0.10, width: 6, height: 6))
                 c.setFill(); body.fill()
+            case "wave":
+                let wave = NSBezierPath()
+                let steps = 24
+                for k in 0...steps {
+                    let x = rect.minX + rect.width * CGFloat(k) / CGFloat(steps)
+                    let y = mid.y + sin((CGFloat(k) / CGFloat(steps) * 2 + phase) * 2 * .pi) * rect.height * 0.22
+                    if k == 0 { wave.move(to: NSPoint(x: x, y: y)) } else { wave.line(to: NSPoint(x: x, y: y)) }
+                }
+                wave.lineWidth = 1.5; wave.lineCapStyle = .round; c.setStroke(); wave.stroke()
+            case "bars":
+                let n = 4
+                let bw = rect.width * 0.12
+                let span = rect.width * 0.5
+                let startX = rect.midX - span / 2
+                for k in 0..<n {
+                    let h = rect.height * (0.22 + 0.5 * abs(sin((phase + CGFloat(k) / CGFloat(n)) * 2 * .pi)))
+                    let x = startX + span * CGFloat(k) / CGFloat(n - 1)
+                    let bar = NSBezierPath(roundedRect: NSRect(x: x - bw / 2, y: mid.y - h / 2, width: bw, height: h), xRadius: 1, yRadius: 1)
+                    c.setFill(); bar.fill()
+                }
             default: // "pulse" — concentric expanding rings
                 for k in 0..<3 {
                     let t = (phase + CGFloat(k) / 3).truncatingRemainder(dividingBy: 1)

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -31,7 +31,7 @@ import Darwin   // sysctlbyname — native memory-pressure level
 
 /// A metric that can be surfaced in the menu bar.
 enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
-    case cpu, memory, gpu, diskUsage, network, diskIO, fan, temperature, battery
+    case cpu, memory, gpu, diskUsage, network, diskIO, fan, temperature, battery, power
 
     var id: String { rawValue }
 
@@ -47,6 +47,7 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
         case .fan:         return "FAN"
         case .temperature: return "TEMP"
         case .battery:     return "BAT"
+        case .power:       return "PWR"
         }
     }
 
@@ -62,6 +63,7 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
         case .fan:         return NSLocalizedString("Fan speed", comment: "")
         case .temperature: return NSLocalizedString("Temperature", comment: "")
         case .battery:     return NSLocalizedString("Battery", comment: "")
+        case .power:       return NSLocalizedString("Power draw", comment: "")
         }
     }
 
@@ -77,6 +79,7 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
         case .fan:         return "fanblades"
         case .temperature: return "thermometer.medium"
         case .battery:     return "battery.100"
+        case .power:       return "bolt.fill"
         }
     }
 
@@ -84,7 +87,7 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
     var isPercentage: Bool {
         switch self {
         case .cpu, .memory, .gpu, .diskUsage, .battery: return true
-        case .network, .diskIO, .fan, .temperature:     return false
+        case .network, .diskIO, .fan, .temperature, .power: return false
         }
     }
 
@@ -107,6 +110,7 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
         case .network, .diskIO:       return [.value, .labeled, .speed, .sparkline]
         case .fan, .temperature:      return [.value, .labeled]
         case .battery:                return [.value, .labeled, .bar, .battery]
+        case .power:                  return [.value, .labeled, .sparkline]
         }
     }
 
@@ -428,6 +432,8 @@ enum MenuBarRenderer {
             return v > 0 ? "\(Int(v.rounded()))" : "—"
         case .temperature:
             return "\(Int(v.rounded()))°"
+        case .power:
+            return "\(Int(v.rounded()))W"
         case .network, .diskIO:
             return rate(v + (values.secondary[m] ?? 0))
         }

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -305,6 +305,17 @@ enum MemoryPressure {
               value > 0 else { return normal }
         return Int(value)
     }
+
+    /// Brand tint for mo's pressure STRING (normal/warning/critical) — the same
+    /// signal as the menu-bar "By pressure" mode, so the Status + popover memory
+    /// tiles read by actual pressure (calm even at high usedPercent) instead of
+    /// a fixed colour. normal → green, warning → orange, critical → red.
+    static func tint(_ pressureString: String) -> Color {
+        let p = pressureString.lowercased()
+        if p.contains("crit") { return Brand.red }
+        if p.contains("warn") { return Brand.orange }
+        return Brand.green
+    }
 }
 
 // MARK: - Renderer

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -99,6 +99,11 @@ enum MenuBarMetric: String, Codable, CaseIterable, Identifiable {
                         : MenuBarColorMode.allCases.filter { $0 != .pressure }
     }
 
+    /// Default colour mode for a fresh widget of this metric. Memory defaults to
+    /// "By pressure" (raw % is misleading on macOS — it counts cache); the rest
+    /// use the value-driven utilization ramp.
+    var defaultColor: MenuBarColorMode { self == .memory ? .pressure : .utilization }
+
     /// Two-channel metrics (down/up, read/write) — eligible for the speed style.
     var isDual: Bool { self == .network || self == .diskIO }
 
@@ -264,7 +269,7 @@ struct MenuBarItem: Codable, Equatable, Identifiable {
     /// user switches the menu bar to `.metrics` (default is the icon).
     static let defaults: [MenuBarItem] = [
         MenuBarItem(metric: .cpu, style: .value),
-        MenuBarItem(metric: .memory, style: .value),
+        MenuBarItem(metric: .memory, style: .value, color: .pressure),
     ]
 }
 

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -293,29 +293,35 @@ struct MenuBarMetricValues {
     func has(_ m: MenuBarMetric) -> Bool { primary[m] != nil }
 }
 
-/// Memory pressure, expressed as a percentage and colour. macOS's own pressure
-/// signal (`kern.memorystatus_vm_pressure_level`) is a jumpy 3-level enum with
-/// no number, and mo's snapshot string is empty on Apple Silicon — so we report
-/// the VM compressor's share of RAM, which is stable and rises under pressure.
+/// Memory pressure as a percentage + colour, matching Activity Monitor / iStat
+/// Menus: the share of physical RAM that is "hard" — wired (unpageable) plus
+/// compressed — over total. The kernel's own `kern.memorystatus_vm_pressure_level`
+/// is only a jumpy 3-level enum with no number, and mo's snapshot pressure string
+/// is empty on Apple Silicon, so neither gives an accurate figure on its own.
 enum MemoryPressure {
-    /// Memory pressure as a percentage — the share of physical RAM the VM
-    /// compressor is holding, which rises as macOS compresses pages under
-    /// pressure. (mo's snapshot pressure string is empty on Apple Silicon, and
-    /// `kern.memorystatus_vm_pressure_level` is jumpy with no number, so this is
-    /// the stable signal shown everywhere.)
+    /// `(wired + compressed) / total` via `host_statistics64` — the same number
+    /// iStat Menus reports as "Pressure" (e.g. ~53%).
     static func percent() -> Int {
-        var compressed: UInt64 = 0; var cSize = MemoryLayout<UInt64>.size
+        var size = mach_msg_type_number_t(MemoryLayout<vm_statistics64_data_t>.stride / MemoryLayout<integer_t>.stride)
+        var stats = vm_statistics64_data_t()
+        let kr = withUnsafeMutablePointer(to: &stats) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(size)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &size)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return 0 }
+        let hard = (Double(stats.wire_count) + Double(stats.compressor_page_count)) * Double(vm_page_size)
         var total: UInt64 = 0; var tSize = MemoryLayout<UInt64>.size
-        guard sysctlbyname("vm.compressor_bytes_used", &compressed, &cSize, nil, 0) == 0,
-              sysctlbyname("hw.memsize", &total, &tSize, nil, 0) == 0, total > 0 else { return 0 }
-        return min(100, Int((Double(compressed) / Double(total) * 100).rounded()))
+        guard sysctlbyname("hw.memsize", &total, &tSize, nil, 0) == 0, total > 0 else { return 0 }
+        return min(100, max(0, Int((hard / Double(total) * 100).rounded())))
     }
 
-    /// green ≤ 39 · orange 40–69 · red ≥ 70.
+    /// Tuned so normal operation (wired + light compression, ~40–55%) stays
+    /// green: green ≤ 59 · orange 60–79 · red ≥ 80.
     static func tint(percent: Int) -> Color {
         switch percent {
-        case 70...: return Brand.red
-        case 40...: return Brand.orange
+        case 80...: return Brand.red
+        case 60...: return Brand.orange
         default:    return Brand.green
         }
     }

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -321,6 +321,17 @@ enum MemoryPressure {
         if p.contains("warn") { return Brand.orange }
         return Brand.green
     }
+
+    /// Map the engine's pressure STRING to a level int (for the menu-bar "By
+    /// pressure" colour), so the menu bar agrees with the dashboard/popover
+    /// tiles. Empty string ⇒ fall back to the native sysctl.
+    static func levelForString(_ s: String) -> Int {
+        let p = s.lowercased()
+        if p.contains("crit") { return critical }
+        if p.contains("warn") { return warning }
+        if p.isEmpty { return level() }
+        return normal
+    }
 }
 
 // MARK: - Renderer

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -325,14 +325,6 @@ enum MemoryPressure {
         default:       return Brand.green
         }
     }
-
-    static func label(level: Int) -> String {
-        switch level {
-        case critical: return NSLocalizedString("critical", comment: "")
-        case warning:  return NSLocalizedString("warning", comment: "")
-        default:       return NSLocalizedString("normal", comment: "")
-        }
-    }
 }
 
 // MARK: - Renderer

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -315,22 +315,23 @@ enum MemoryPressure {
     /// signal as the menu-bar "By pressure" mode, so the Status + popover memory
     /// tiles read by actual pressure (calm even at high usedPercent) instead of
     /// a fixed colour. normal → green, warning → orange, critical → red.
-    static func tint(_ pressureString: String) -> Color {
-        let p = pressureString.lowercased()
-        if p.contains("crit") { return Brand.red }
-        if p.contains("warn") { return Brand.orange }
-        return Brand.green
+    /// Brand tint for a pressure LEVEL — normal → green, warning → orange,
+    /// critical → red. The engine's snapshot pressure string is empty on Apple
+    /// Silicon, so the native `level()` sysctl is the real signal used everywhere.
+    static func tint(level: Int) -> Color {
+        switch level {
+        case critical: return Brand.red
+        case warning:  return Brand.orange
+        default:       return Brand.green
+        }
     }
 
-    /// Map the engine's pressure STRING to a level int (for the menu-bar "By
-    /// pressure" colour), so the menu bar agrees with the dashboard/popover
-    /// tiles. Empty string ⇒ fall back to the native sysctl.
-    static func levelForString(_ s: String) -> Int {
-        let p = s.lowercased()
-        if p.contains("crit") { return critical }
-        if p.contains("warn") { return warning }
-        if p.isEmpty { return level() }
-        return normal
+    static func label(level: Int) -> String {
+        switch level {
+        case critical: return NSLocalizedString("critical", comment: "")
+        case warning:  return NSLocalizedString("warning", comment: "")
+        default:       return NSLocalizedString("normal", comment: "")
+        }
     }
 }
 

--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -288,41 +288,35 @@ struct MenuBarMetricValues {
     var batteryCharging = false
     /// Current macOS memory-pressure level (`kern.memorystatus_vm_pressure_level`):
     /// 1 = normal, 2 = warning, 4 = critical. Drives the "By pressure" colour.
-    var memoryPressureLevel: Int = MemoryPressure.normal
+    var memoryPressurePercent: Int = 0
 
     func has(_ m: MenuBarMetric) -> Bool { primary[m] != nil }
 }
 
-/// The current macOS memory-pressure level, read natively from
-/// `kern.memorystatus_vm_pressure_level` — the same signal Activity Monitor's
-/// Memory Pressure graph and `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` report. It's
-/// a discrete level, NOT a percentage.
+/// Memory pressure, expressed as a percentage and colour. macOS's own pressure
+/// signal (`kern.memorystatus_vm_pressure_level`) is a jumpy 3-level enum with
+/// no number, and mo's snapshot string is empty on Apple Silicon — so we report
+/// the VM compressor's share of RAM, which is stable and rises under pressure.
 enum MemoryPressure {
-    static let normal = 1, warning = 2, critical = 4
-
-    /// Point read of the current level — one cheap sysctl. Called on the
-    /// value-build pass, never on the draw path. Falls back to `normal` if the
-    /// sysctl is unavailable.
-    static func level() -> Int {
-        var value: Int32 = 0
-        var size = MemoryLayout<Int32>.size
-        guard sysctlbyname("kern.memorystatus_vm_pressure_level", &value, &size, nil, 0) == 0,
-              value > 0 else { return normal }
-        return Int(value)
+    /// Memory pressure as a percentage — the share of physical RAM the VM
+    /// compressor is holding, which rises as macOS compresses pages under
+    /// pressure. (mo's snapshot pressure string is empty on Apple Silicon, and
+    /// `kern.memorystatus_vm_pressure_level` is jumpy with no number, so this is
+    /// the stable signal shown everywhere.)
+    static func percent() -> Int {
+        var compressed: UInt64 = 0; var cSize = MemoryLayout<UInt64>.size
+        var total: UInt64 = 0; var tSize = MemoryLayout<UInt64>.size
+        guard sysctlbyname("vm.compressor_bytes_used", &compressed, &cSize, nil, 0) == 0,
+              sysctlbyname("hw.memsize", &total, &tSize, nil, 0) == 0, total > 0 else { return 0 }
+        return min(100, Int((Double(compressed) / Double(total) * 100).rounded()))
     }
 
-    /// Brand tint for mo's pressure STRING (normal/warning/critical) — the same
-    /// signal as the menu-bar "By pressure" mode, so the Status + popover memory
-    /// tiles read by actual pressure (calm even at high usedPercent) instead of
-    /// a fixed colour. normal → green, warning → orange, critical → red.
-    /// Brand tint for a pressure LEVEL — normal → green, warning → orange,
-    /// critical → red. The engine's snapshot pressure string is empty on Apple
-    /// Silicon, so the native `level()` sysctl is the real signal used everywhere.
-    static func tint(level: Int) -> Color {
-        switch level {
-        case critical: return Brand.red
-        case warning:  return Brand.orange
-        default:       return Brand.green
+    /// green ≤ 39 · orange 40–69 · red ≥ 70.
+    static func tint(percent: Int) -> Color {
+        switch percent {
+        case 70...: return Brand.red
+        case 40...: return Brand.orange
+        default:    return Brand.green
         }
     }
 }
@@ -379,12 +373,8 @@ enum MenuBarRenderer {
     /// "By pressure" colour — the discrete macOS memory-pressure level (not a
     /// percentage): normal → green, warning → orange, critical → red, matching
     /// Activity Monitor's Memory Pressure graph.
-    private static func pressureColor(_ level: Int) -> NSColor {
-        switch level {
-        case MemoryPressure.critical: return NSColor(Brand.red)
-        case MemoryPressure.warning:  return NSColor(Brand.orange)
-        default:                      return NSColor(Brand.green)
-        }
+    private static func pressureColor(_ percent: Int) -> NSColor {
+        NSColor(MemoryPressure.tint(percent: percent))
     }
 
     /// Battery is inverse: low charge is the alarming end.
@@ -419,7 +409,7 @@ enum MenuBarRenderer {
             // "By pressure" = the real macOS memory-pressure level, not a load
             // percentage. Only memory carries a pressure signal; other metrics
             // fall back to value-driven colouring.
-            if item.metric == .memory { return pressureColor(values.memoryPressureLevel) }
+            if item.metric == .memory { return pressureColor(values.memoryPressurePercent) }
             fallthrough
         case .utilization:
             if item.metric == .battery { return batteryColor(value, charging: values.batteryCharging) }

--- a/macos/Sources/MoleStatus.swift
+++ b/macos/Sources/MoleStatus.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-struct MoleStatus: Codable {
+struct MoleStatus: Codable, Equatable {
     let collectedAt: Date
     let host: String
     let platform: String
@@ -119,7 +119,7 @@ struct MoleStatus: Codable {
     }()
 }
 
-struct Hardware: Codable {
+struct Hardware: Codable, Equatable {
     let model: String
     let cpuModel: String
     let totalRam: String
@@ -135,7 +135,7 @@ struct Hardware: Codable {
     }
 }
 
-struct CPUStatus: Codable {
+struct CPUStatus: Codable, Equatable {
     let usage: Double
     let perCore: [Double]?
     let load1: Double
@@ -157,7 +157,7 @@ struct CPUStatus: Codable {
     }
 }
 
-struct MemoryStatus: Codable {
+struct MemoryStatus: Codable, Equatable {
     let used: UInt64
     let total: UInt64
     /// `available` is documented in Mole's source but omitted from the
@@ -178,7 +178,7 @@ struct MemoryStatus: Codable {
     }
 }
 
-struct DiskIOStatus: Codable {
+struct DiskIOStatus: Codable, Equatable {
     let readRate: Double   // MB/s
     let writeRate: Double  // MB/s
 
@@ -188,7 +188,7 @@ struct DiskIOStatus: Codable {
     }
 }
 
-struct DiskStatus: Codable {
+struct DiskStatus: Codable, Equatable {
     let mount: String
     let used: UInt64
     let total: UInt64
@@ -202,7 +202,7 @@ struct DiskStatus: Codable {
     }
 }
 
-struct NetworkStatus: Codable {
+struct NetworkStatus: Codable, Equatable {
     let name: String
     let rxRateMbs: Double
     let txRateMbs: Double
@@ -216,7 +216,7 @@ struct NetworkStatus: Codable {
     }
 }
 
-struct BatteryStatus: Codable {
+struct BatteryStatus: Codable, Equatable {
     let percent: Double
     let status: String
     let timeLeft: String
@@ -233,7 +233,7 @@ struct BatteryStatus: Codable {
     }
 }
 
-struct ThermalStatus: Codable {
+struct ThermalStatus: Codable, Equatable {
     let cpuTemp: Double
     let gpuTemp: Double
     /// Battery temperature (°C). On Apple Silicon, `cpu_temp`/`gpu_temp` are
@@ -289,7 +289,7 @@ struct ProcessInfo: Codable, Equatable {
     }
 }
 
-struct GPUStatus: Codable {
+struct GPUStatus: Codable, Equatable {
     let name: String
     /// `-1` when the platform can't report GPU utilisation (common on
     /// Apple Silicon); treat negative as "unavailable".
@@ -308,13 +308,13 @@ struct GPUStatus: Codable {
     }
 }
 
-struct ProxyStatus: Codable {
+struct ProxyStatus: Codable, Equatable {
     let enabled: Bool
     let type: String
     let host: String
 }
 
-struct BluetoothDevice: Codable {
+struct BluetoothDevice: Codable, Equatable {
     let name: String
     let connected: Bool
     /// Mole reports battery as a string ("85%" or empty). Parse the percent

--- a/macos/Sources/MoleStatus.swift
+++ b/macos/Sources/MoleStatus.swift
@@ -164,13 +164,15 @@ struct MemoryStatus: Codable, Equatable {
     /// actual JSON output (Go `omitempty` on a derived field). Treat it
     /// as opportunistic — fall back to `total - used` when missing.
     let available: UInt64?
+    /// Memory backing cached files — reclaimable, so not really "in use".
+    let cached: UInt64?
     let usedPercent: Double
     let swapUsed: UInt64
     let swapTotal: UInt64
     let pressure: String
 
     private enum CodingKeys: String, CodingKey {
-        case used, total, available
+        case used, total, available, cached
         case usedPercent = "used_percent"
         case swapUsed = "swap_used"
         case swapTotal = "swap_total"

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -260,7 +260,7 @@ struct PopupView: View {
                           footnote: (s.gpu?.first?.name ?? "GPU").replacingOccurrences(of: "Apple ", with: ""))
             }
             if tiles.contains(.memory) {
-                ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: Brand.amber,
+                ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(s.memory.pressure),
                           value: String(format: "%.0f", s.memory.usedPercent), unit: "%",
                           chip: memChip(s),
                           values: model.memHist, chartStyle: .area,

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -673,6 +673,14 @@ final class HUDModel: ObservableObject {
     func subscribeSnapshot() async {
         for await v in feeds.liveSnapshot(live).subscribeValues() {
             snap = v.snap
+            // Live 1 s sparklines for the cpu/mem/gpu tiles — appended each tick
+            // so the popover charts actually move (the 15 s pump now only feeds
+            // net/fan + top-drain). Capped to the largest history window.
+            if let s = v.snap {
+                appendHist(&cpuHist, s.cpu.usage)
+                appendHist(&memHist, s.memory.usedPercent)
+                if let g = s.gpu?.first, g.usage >= 0 { appendHist(&gpuHist, g.usage) }
+            }
             if let when = v.sampledAt {
                 freshness = String(format: NSLocalizedString("%ds ago", comment: ""), Int(Date().timeIntervalSince(when)))
             } else {
@@ -684,9 +692,14 @@ final class HUDModel: ObservableObject {
     /// Sparklines + top drain, off the 15 s `metrics.sparklines.30m` pump.
     func subscribeSparklines() async {
         for await v in feeds.metricSparklines(db: db).subscribeValues() {
-            cpuHist = v.cpu; memHist = v.mem; netHist = v.net; gpuHist = v.gpu; fanHist = v.fan
+            netHist = v.net; fanHist = v.fan
             topDrain = v.topDrain
         }
+    }
+
+    private func appendHist(_ ring: inout [Double], _ value: Double) {
+        ring.append(value)
+        if ring.count > 120 { ring.removeFirst(ring.count - 120) }
     }
 
     /// Clean Watch lifetime totals, off the daily `history.cleanwatch`

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -697,7 +697,9 @@ final class HUDModel: ObservableObject {
 
     private func appendHist(_ ring: inout [Double], _ value: Double) {
         ring.append(value)
-        if ring.count > 120 { ring.removeFirst(ring.count - 120) }
+        // ~1 min of 1 s samples — enough recent trend to read at a glance
+        // without cramming the small popover chart.
+        if ring.count > 60 { ring.removeFirst(ring.count - 60) }
     }
 
     /// Clean Watch lifetime totals, off the daily `history.cleanwatch`

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -14,6 +14,24 @@
 import SwiftUI
 import AppKit
 
+/// Re-renders `content` only when `key` changes — lets a heavy, snapshot-driven
+/// block (the metric grid) skip rebuilding when an unrelated @Published on the
+/// popover ticks (ops, Stay-Awake, clean-watch, privacy). Pair with `.equatable()`.
+private struct EquatableGate<Key: Equatable, Content: View>: View, Equatable {
+    let key: Key
+    @ViewBuilder var content: () -> Content
+    var body: some View { content() }
+    static func == (lhs: EquatableGate, rhs: EquatableGate) -> Bool { lhs.key == rhs.key }
+}
+
+/// Everything the popover metric grid depends on; unchanged ⇒ the grid (6 tiles
+/// + charts) is not rebuilt. Relies on `MoleStatus: Equatable`.
+private struct MetricGridKey: Equatable {
+    let snap: MoleStatus
+    let cpu, gpu, mem, net, fan: [Double]
+    let tiles: Set<MenuBarMetric>
+}
+
 struct PopupView: View {
     @StateObject private var model: HUDModel
     @ObservedObject private var ops = OperationCenter.shared
@@ -42,7 +60,14 @@ struct PopupView: View {
             }
             if sections.contains(.activity), ops.hasActivity { activitySection }
             if let s = model.snap {
-                if sections.contains(.metrics) { metricGrid(s) }
+                if sections.contains(.metrics) {
+                    EquatableGate(key: MetricGridKey(snap: s, cpu: model.cpuHist, gpu: model.gpuHist,
+                                                     mem: model.memHist, net: model.netHist,
+                                                     fan: model.fanHist, tiles: Store.popupTiles)) {
+                        metricGrid(s)
+                    }
+                    .equatable()
+                }
                 if sections.contains(.battery) { batteryCard(s) }
                 if sections.contains(.processes) { topProcesses(s) }
             } else {

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -289,8 +289,8 @@ struct PopupView: View {
                           value: String(format: "%.0f", s.memory.usedPercent), unit: "%",
                           chip: memChip(s),
                           values: model.memHist, chartStyle: .area,
-                          footnote: String(format: "%.1f/%.0f GB · swap %.1f GB",
-                                           Fmt.gib(s.memory.used), Fmt.gib(s.memory.total), Fmt.gib(s.memory.swapUsed)))
+                          footnote: String(format: "%.1f/%.0f GB used",
+                                           Fmt.gib(s.memory.used), Fmt.gib(s.memory.total)))
             }
             if tiles.contains(.diskUsage) { diskTile(s) }
             if tiles.contains(.network) {
@@ -363,8 +363,9 @@ struct PopupView: View {
     }
 
     private func memChip(_ s: MoleStatus) -> (String, Color)? {
-        let lvl = MemoryPressure.level()
-        return (MemoryPressure.label(level: lvl), MemoryPressure.tint(level: lvl))
+        guard s.memory.swapUsed > 0 else { return nil }   // concrete pressure info, only when swapping
+        return (String(format: NSLocalizedString("swap %.1fG", comment: ""), Fmt.gib(s.memory.swapUsed)),
+                MemoryPressure.tint(level: MemoryPressure.level()))
     }
 
     private func netValue(_ s: MoleStatus) -> (String, String) {

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -285,12 +285,12 @@ struct PopupView: View {
                           footnote: (s.gpu?.first?.name ?? "GPU").replacingOccurrences(of: "Apple ", with: ""))
             }
             if tiles.contains(.memory) {
-                ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(level: MemoryPressure.level()),
+                ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(percent: MemoryPressure.percent()),
                           value: String(format: "%.0f", s.memory.usedPercent), unit: "%",
                           chip: memChip(s),
                           values: model.memHist, chartStyle: .area,
-                          footnote: String(format: "%.1f/%.0f GB used",
-                                           Fmt.gib(s.memory.used), Fmt.gib(s.memory.total)))
+                          footnote: String(format: "%.1f/%.0f GB · swap %.1f GB",
+                                           Fmt.gib(s.memory.used), Fmt.gib(s.memory.total), Fmt.gib(s.memory.swapUsed)))
             }
             if tiles.contains(.diskUsage) { diskTile(s) }
             if tiles.contains(.network) {
@@ -363,9 +363,8 @@ struct PopupView: View {
     }
 
     private func memChip(_ s: MoleStatus) -> (String, Color)? {
-        guard s.memory.swapUsed > 0 else { return nil }   // concrete pressure info, only when swapping
-        return (String(format: NSLocalizedString("swap %.1fG", comment: ""), Fmt.gib(s.memory.swapUsed)),
-                MemoryPressure.tint(level: MemoryPressure.level()))
+        let p = MemoryPressure.percent()
+        return (String(format: NSLocalizedString("%d%% pressure", comment: ""), p), MemoryPressure.tint(percent: p))
     }
 
     private func netValue(_ s: MoleStatus) -> (String, String) {

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -285,7 +285,7 @@ struct PopupView: View {
                           footnote: (s.gpu?.first?.name ?? "GPU").replacingOccurrences(of: "Apple ", with: ""))
             }
             if tiles.contains(.memory) {
-                ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(s.memory.pressure),
+                ValueTile(variant: .hud, eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(level: MemoryPressure.level()),
                           value: String(format: "%.0f", s.memory.usedPercent), unit: "%",
                           chip: memChip(s),
                           values: model.memHist, chartStyle: .area,
@@ -363,10 +363,8 @@ struct PopupView: View {
     }
 
     private func memChip(_ s: MoleStatus) -> (String, Color)? {
-        let label = s.memory.pressure.isEmpty ? "" : s.memory.pressure.lowercased()
-        guard !label.isEmpty else { return nil }
-        let color: Color = label == "normal" ? Brand.textSecondary : (label == "warning" ? Brand.orange : Brand.red)
-        return (label, color)
+        let lvl = MemoryPressure.level()
+        return (MemoryPressure.label(level: lvl), MemoryPressure.tint(level: lvl))
     }
 
     private func netValue(_ s: MoleStatus) -> (String, String) {

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -364,7 +364,7 @@ struct PopupView: View {
 
     private func memChip(_ s: MoleStatus) -> (String, Color)? {
         let p = MemoryPressure.percent()
-        return (String(format: NSLocalizedString("%d%% pressure", comment: ""), p), MemoryPressure.tint(percent: p))
+        return (String(format: NSLocalizedString("%d%%", comment: ""), p), MemoryPressure.tint(percent: p))
     }
 
     private func netValue(_ s: MoleStatus) -> (String, String) {

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -967,7 +967,7 @@ struct SettingsView: View {
         }
         v.primary[.network] = live.rxMBs; v.secondary[.network] = live.txMBs
         v.primary[.diskIO]  = live.readMBs; v.secondary[.diskIO]  = live.writeMBs
-        v.memoryPressureLevel = MemoryPressure.level()
+        v.memoryPressureLevel = MemoryPressure.levelForString(live.lastSnapshot?.memory.pressure ?? "")
         return v
     }
 

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -928,19 +928,47 @@ struct SettingsView: View {
         .padding(.vertical, 4)
     }
 
-    /// Live preview of the configured row, rendered with representative values
-    /// so the layout is visible while editing (not live data).
+    /// Live preview of the configured row, rendered with the real sampler values
+    /// (refreshed ~1 s) so it matches what's actually in the menu bar.
     private var menuBarPreview: some View {
-        HStack {
-            Spacer()
-            if let img = MenuBarRenderer.image(items: menuBarItems, values: Self.menuBarPreviewValues) {
-                Image(nsImage: img)
-                    .padding(.horizontal, 10).padding(.vertical, 5)
-                    .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Brand.cardFill))
+        TimelineView(.periodic(from: .now, by: 1)) { _ in
+            HStack {
+                Spacer()
+                if let img = MenuBarRenderer.image(items: menuBarItems, values: liveMenuBarValues) {
+                    Image(nsImage: img)
+                        .padding(.horizontal, 10).padding(.vertical, 5)
+                        .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Brand.cardFill))
+                }
+                Spacer()
             }
-            Spacer()
         }
         .padding(.bottom, 4)
+    }
+
+    /// The real values the menu-bar row would draw, from the running sampler;
+    /// falls back to representative numbers before the first sample.
+    private var liveMenuBarValues: MenuBarMetricValues {
+        guard let live = AppDelegate.shared?.producer?.live else { return Self.menuBarPreviewValues }
+        var v = MenuBarMetricValues()
+        if let s = live.lastSnapshot {
+            v.primary[.cpu] = s.cpu.usage
+            v.primary[.memory] = s.memory.usedPercent
+            if let g = s.gpu?.first, g.usage >= 0 { v.primary[.gpu] = g.usage }
+            if let d = s.disks.first { v.primary[.diskUsage] = d.usedPercent }
+            if let t = s.thermal {
+                if t.fanSpeed > 0 || (t.fanCount ?? 0) > 0 { v.primary[.fan] = Double(t.fanSpeed) }
+                if let temp = t.bestTemp { v.primary[.temperature] = temp }
+                if t.systemPower > 0 { v.primary[.power] = t.systemPower }
+            }
+            if let b = s.batteries?.first {
+                v.primary[.battery] = b.percent
+                v.batteryCharging = b.status.lowercased().contains("charg")
+            }
+        }
+        v.primary[.network] = live.rxMBs; v.secondary[.network] = live.txMBs
+        v.primary[.diskIO]  = live.readMBs; v.secondary[.diskIO]  = live.writeMBs
+        v.memoryPressureLevel = MemoryPressure.level()
+        return v
     }
 
     /// Representative values for the Settings preview only.
@@ -959,12 +987,14 @@ struct SettingsView: View {
     private struct MenuBarPreset { let name: String; let items: [MenuBarItem] }
     private static let menuBarPresets: [MenuBarPreset] = [
         .init(name: NSLocalizedString("CPU · RAM", comment: ""),
-              items: [MenuBarItem(metric: .cpu, style: .value), MenuBarItem(metric: .memory, style: .value)]),
+              items: [MenuBarItem(metric: .cpu, style: .value),
+                      MenuBarItem(metric: .memory, style: .value, color: .pressure)]),
         .init(name: NSLocalizedString("CPU · RAM · Net · Disk", comment: ""),
-              items: [MenuBarItem(metric: .cpu, style: .value), MenuBarItem(metric: .memory, style: .value),
+              items: [MenuBarItem(metric: .cpu, style: .value),
+                      MenuBarItem(metric: .memory, style: .value, color: .pressure),
                       MenuBarItem(metric: .network, style: .speed), MenuBarItem(metric: .diskUsage, style: .bar)]),
         .init(name: NSLocalizedString("Everything", comment: ""),
-              items: MenuBarMetric.allCases.map { MenuBarItem(metric: $0, style: $0.styles.first ?? .value) }),
+              items: MenuBarMetric.allCases.map { MenuBarItem(metric: $0, style: $0.styles.first ?? .value, color: $0.defaultColor) }),
     ]
 
     private func applyMenuBarPreset(_ items: [MenuBarItem]) {
@@ -1072,7 +1102,7 @@ struct SettingsView: View {
     }
 
     private func addMenuBarMetric(_ m: MenuBarMetric) {
-        menuBarItems.append(MenuBarItem(metric: m, style: m.styles.first ?? .value))
+        menuBarItems.append(MenuBarItem(metric: m, style: m.styles.first ?? .value, color: m.defaultColor))
         commitMenuBarItems()
     }
 

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -967,7 +967,7 @@ struct SettingsView: View {
         }
         v.primary[.network] = live.rxMBs; v.secondary[.network] = live.txMBs
         v.primary[.diskIO]  = live.readMBs; v.secondary[.diskIO]  = live.writeMBs
-        v.memoryPressureLevel = MemoryPressure.level()
+        v.memoryPressurePercent = MemoryPressure.percent()
         return v
     }
 

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -885,6 +885,7 @@ struct SettingsView: View {
     @ViewBuilder
     private var menuBarMetricsEditor: some View {
         VStack(spacing: 4) {
+            if !menuBarItems.isEmpty { menuBarPreview }
             if menuBarItems.isEmpty {
                 Text(NSLocalizedString("No metrics yet — add one below.", comment: ""))
                     .font(Brand.sans(11)).foregroundStyle(Brand.textTertiary)
@@ -901,7 +902,7 @@ struct SettingsView: View {
                 .background(RoundedRectangle(cornerRadius: 8)
                     .fill(expandedMenuBarItem == item.id ? Brand.cardFill : Color.clear))
             }
-            HStack {
+            HStack(spacing: 12) {
                 Menu {
                     ForEach(MenuBarMetric.allCases) { m in
                         Button { addMenuBarMetric(m) } label: { Label(m.title, systemImage: m.glyph) }
@@ -911,11 +912,65 @@ struct SettingsView: View {
                         .font(Brand.sans(12)).foregroundStyle(Brand.green)
                 }
                 .menuStyle(.borderlessButton).fixedSize()
+                Menu {
+                    ForEach(Self.menuBarPresets, id: \.name) { preset in
+                        Button(preset.name) { applyMenuBarPreset(preset.items) }
+                    }
+                } label: {
+                    Label(NSLocalizedString("Presets", comment: ""), systemImage: "square.grid.2x2")
+                        .font(Brand.sans(12)).foregroundStyle(Brand.textSecondary)
+                }
+                .menuStyle(.borderlessButton).fixedSize()
                 Spacer()
             }
             .padding(.top, 2)
         }
         .padding(.vertical, 4)
+    }
+
+    /// Live preview of the configured row, rendered with representative values
+    /// so the layout is visible while editing (not live data).
+    private var menuBarPreview: some View {
+        HStack {
+            Spacer()
+            if let img = MenuBarRenderer.image(items: menuBarItems, values: Self.menuBarPreviewValues) {
+                Image(nsImage: img)
+                    .padding(.horizontal, 10).padding(.vertical, 5)
+                    .background(RoundedRectangle(cornerRadius: 6, style: .continuous).fill(Brand.cardFill))
+            }
+            Spacer()
+        }
+        .padding(.bottom, 4)
+    }
+
+    /// Representative values for the Settings preview only.
+    private static let menuBarPreviewValues: MenuBarMetricValues = {
+        var v = MenuBarMetricValues()
+        v.primary = [.cpu: 42, .memory: 68, .gpu: 31, .diskUsage: 55, .network: 8.4,
+                     .diskIO: 3.1, .fan: 2200, .temperature: 74, .battery: 86, .power: 14]
+        v.secondary = [.network: 1.2, .diskIO: 0.6]
+        v.histories = [.cpu: [30, 44, 38, 52, 42], .memory: [60, 63, 66, 68],
+                       .gpu: [18, 26, 31], .network: [4, 7, 8.4, 6, 8.4],
+                       .diskIO: [1, 2.4, 3.1], .power: [10, 12, 14, 13, 14]]
+        return v
+    }()
+
+    /// One-click starting layouts for the metric row.
+    private struct MenuBarPreset { let name: String; let items: [MenuBarItem] }
+    private static let menuBarPresets: [MenuBarPreset] = [
+        .init(name: NSLocalizedString("CPU · RAM", comment: ""),
+              items: [MenuBarItem(metric: .cpu, style: .value), MenuBarItem(metric: .memory, style: .value)]),
+        .init(name: NSLocalizedString("CPU · RAM · Net · Disk", comment: ""),
+              items: [MenuBarItem(metric: .cpu, style: .value), MenuBarItem(metric: .memory, style: .value),
+                      MenuBarItem(metric: .network, style: .speed), MenuBarItem(metric: .diskUsage, style: .bar)]),
+        .init(name: NSLocalizedString("Everything", comment: ""),
+              items: MenuBarMetric.allCases.map { MenuBarItem(metric: $0, style: $0.styles.first ?? .value) }),
+    ]
+
+    private func applyMenuBarPreset(_ items: [MenuBarItem]) {
+        menuBarItems = items
+        expandedMenuBarItem = nil
+        commitMenuBarItems()
     }
 
     private func menuBarMetricRow(index idx: Int, item: MenuBarItem) -> some View {

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -967,7 +967,7 @@ struct SettingsView: View {
         }
         v.primary[.network] = live.rxMBs; v.secondary[.network] = live.txMBs
         v.primary[.diskIO]  = live.readMBs; v.secondary[.diskIO]  = live.writeMBs
-        v.memoryPressureLevel = MemoryPressure.levelForString(live.lastSnapshot?.memory.pressure ?? "")
+        v.memoryPressureLevel = MemoryPressure.level()
         return v
     }
 

--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -201,10 +201,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         v.histories[.memory] = menuBarHistory[.memory]
         v.histories[.gpu]    = menuBarHistory[.gpu]
         v.histories[.power]  = menuBarHistory[.power]
-        // Real memory-pressure level for the "By pressure" colour mode — a
-        // cheap native sysctl read here on the value-build pass, not the draw
-        // path (see MemoryPressure in MenuBarWidgets).
-        v.memoryPressureLevel = MemoryPressure.level()
+        // Memory-pressure level for the "By pressure" colour mode — from the
+        // engine's reported pressure, the same signal the dashboard/popover
+        // memory tiles use, so they all agree (falls back to the native sysctl).
+        v.memoryPressureLevel = MemoryPressure.levelForString(live.lastSnapshot?.memory.pressure ?? "")
         return v
     }
 

--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -142,6 +142,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         appendHistory(.cpu, s.cpu.usage)
         appendHistory(.memory, s.memory.usedPercent)
         if let g = s.gpu?.first, g.usage >= 0 { appendHistory(.gpu, g.usage) }
+        if let p = s.thermal?.systemPower, p > 0 { appendHistory(.power, p) }
         renderMetrics()
     }
 
@@ -184,6 +185,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
             if let t = s.thermal {
                 if t.fanSpeed > 0 || (t.fanCount ?? 0) > 0 { v.primary[.fan] = Double(t.fanSpeed) }
                 if let temp = t.bestTemp { v.primary[.temperature] = temp }
+                if t.systemPower > 0 { v.primary[.power] = t.systemPower }
             }
             if let b = s.batteries?.first {
                 v.primary[.battery] = b.percent
@@ -198,6 +200,7 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         v.histories[.cpu]    = menuBarHistory[.cpu]
         v.histories[.memory] = menuBarHistory[.memory]
         v.histories[.gpu]    = menuBarHistory[.gpu]
+        v.histories[.power]  = menuBarHistory[.power]
         // Real memory-pressure level for the "By pressure" colour mode — a
         // cheap native sysctl read here on the value-build pass, not the draw
         // path (see MemoryPressure in MenuBarWidgets).

--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -201,10 +201,9 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         v.histories[.memory] = menuBarHistory[.memory]
         v.histories[.gpu]    = menuBarHistory[.gpu]
         v.histories[.power]  = menuBarHistory[.power]
-        // Native macOS memory-pressure level for the "By pressure" colour — the
-        // engine's snapshot pressure string is empty on Apple Silicon, so the
-        // sysctl is the real signal (and the tiles read the same `level()`).
-        v.memoryPressureLevel = MemoryPressure.level()
+        // Memory-pressure percentage (compressor share) for the "By pressure"
+        // colour — the same signal the dashboard/popover memory tiles read.
+        v.memoryPressurePercent = MemoryPressure.percent()
         return v
     }
 

--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -201,10 +201,10 @@ final class StatusBarController: NSObject, NSMenuDelegate {
         v.histories[.memory] = menuBarHistory[.memory]
         v.histories[.gpu]    = menuBarHistory[.gpu]
         v.histories[.power]  = menuBarHistory[.power]
-        // Memory-pressure level for the "By pressure" colour mode — from the
-        // engine's reported pressure, the same signal the dashboard/popover
-        // memory tiles use, so they all agree (falls back to the native sysctl).
-        v.memoryPressureLevel = MemoryPressure.levelForString(live.lastSnapshot?.memory.pressure ?? "")
+        // Native macOS memory-pressure level for the "By pressure" colour — the
+        // engine's snapshot pressure string is empty on Apple Silicon, so the
+        // sysctl is the real signal (and the tiles read the same `level()`).
+        v.memoryPressureLevel = MemoryPressure.level()
         return v
     }
 

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -112,7 +112,7 @@ struct StatusView: View {
         let used = Fmt.gib(m.used)
         let total = Fmt.gib(m.total)
         return ValueTile(
-            eyebrow: "Memory", glyph: "memorychip", accent: Brand.amber,
+            eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(m.pressure),
             value: String(format: "%.0f", m.usedPercent), unit: "%",
             chip: (label, color), values: model.memHist, chartStyle: .area,
             footnote: String(format: NSLocalizedString("%.1f / %.1f GB · swap %.1f GB", comment: ""),

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -147,7 +147,7 @@ struct StatusView: View {
         return ValueTile(
             eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(percent: lvl),
             value: String(format: "%.0f", m.usedPercent), unit: "%",
-            chip: (String(format: NSLocalizedString("%d%% pressure", comment: ""), lvl), MemoryPressure.tint(percent: lvl)),
+            chip: (String(format: NSLocalizedString("%d%%", comment: ""), lvl), MemoryPressure.tint(percent: lvl)),
             values: model.memHist, chartStyle: .area,
             footnote: String(format: NSLocalizedString("%.1f / %.1f GB · swap %.1f GB", comment: ""), used, total, Fmt.gib(m.swapUsed)))
     }

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -110,12 +110,17 @@ struct StatusView: View {
         let lvl = MemoryPressure.level()
         let used = Fmt.gib(m.used)
         let total = Fmt.gib(m.total)
+        // Concrete pressure info — swap in use — coloured by the pressure level,
+        // shown only when actually swapping (no chip at rest).
+        let chip: (String, Color)? = m.swapUsed > 0
+            ? (String(format: NSLocalizedString("swap %.1fG", comment: ""), Fmt.gib(m.swapUsed)),
+               MemoryPressure.tint(level: lvl))
+            : nil
         return ValueTile(
             eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(level: lvl),
             value: String(format: "%.0f", m.usedPercent), unit: "%",
-            chip: (MemoryPressure.label(level: lvl), MemoryPressure.tint(level: lvl)), values: model.memHist, chartStyle: .area,
-            footnote: String(format: NSLocalizedString("%.1f / %.1f GB · swap %.1f GB", comment: ""),
-                             used, total, Fmt.gib(m.swapUsed)))
+            chip: chip, values: model.memHist, chartStyle: .area,
+            footnote: String(format: NSLocalizedString("%.1f / %.1f GB used", comment: ""), used, total))
     }
 
     private func gpuTile(_ s: MoleStatus) -> ValueTile {

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -51,6 +51,7 @@ struct StatusView: View {
                             .frame(minHeight: row2H)
                         fanTile(s).frame(minHeight: row2H)
                     }
+                    memoryDetail(s)
                     // Battery card carries the ring gauges (Mac + connected
                     // Bluetooth devices) — the old standalone BT strip folded in.
                     BatteryCard(s: s, minHeight: row2H)
@@ -87,6 +88,39 @@ struct StatusView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Memory detail (the full breakdown the small tile can't show)
+
+    private func memoryDetail(_ s: MoleStatus) -> some View {
+        let m = s.memory
+        let lvl = MemoryPressure.level()
+        let free = m.available ?? (m.total > m.used ? m.total - m.used : 0)
+        return HStack(alignment: .center, spacing: 22) {
+            HStack(spacing: 6) {
+                Image(systemName: "memorychip").font(.system(size: 12)).foregroundStyle(MemoryPressure.tint(level: lvl))
+                Text(NSLocalizedString("Memory", comment: "")).font(Brand.mono(10, .semibold)).foregroundStyle(Brand.textSecondary)
+            }
+            memStat(NSLocalizedString("Used", comment: ""), String(format: "%.1f GB", Fmt.gib(m.used)), MemoryPressure.tint(level: lvl))
+            memStat(NSLocalizedString("Free", comment: ""), String(format: "%.1f GB", Fmt.gib(free)), Brand.textPrimary)
+            if let c = m.cached, c > 0 {
+                memStat(NSLocalizedString("Cached", comment: ""), String(format: "%.1f GB", Fmt.gib(c)), Brand.textPrimary)
+            }
+            memStat(NSLocalizedString("Swap", comment: ""),
+                    String(format: "%.1f / %.0f GB", Fmt.gib(m.swapUsed), Fmt.gib(m.swapTotal)),
+                    m.swapUsed > 0 ? MemoryPressure.tint(level: lvl) : Brand.textPrimary)
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 12, style: .continuous).fill(Brand.cardFill))
+    }
+
+    private func memStat(_ label: String, _ value: String, _ valueColor: Color) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label).font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+            Text(value).font(Brand.mono(13, .semibold)).foregroundStyle(valueColor)
+        }
     }
 
     // MARK: - Tiles built from the snapshot

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -94,21 +94,21 @@ struct StatusView: View {
 
     private func memoryDetail(_ s: MoleStatus) -> some View {
         let m = s.memory
-        let lvl = MemoryPressure.level()
+        let lvl = MemoryPressure.percent()
         let free = m.available ?? (m.total > m.used ? m.total - m.used : 0)
         return HStack(alignment: .center, spacing: 22) {
             HStack(spacing: 6) {
-                Image(systemName: "memorychip").font(.system(size: 12)).foregroundStyle(MemoryPressure.tint(level: lvl))
+                Image(systemName: "memorychip").font(.system(size: 12)).foregroundStyle(MemoryPressure.tint(percent: lvl))
                 Text(NSLocalizedString("Memory", comment: "")).font(Brand.mono(10, .semibold)).foregroundStyle(Brand.textSecondary)
             }
-            memStat(NSLocalizedString("Used", comment: ""), String(format: "%.1f GB", Fmt.gib(m.used)), MemoryPressure.tint(level: lvl))
+            memStat(NSLocalizedString("Used", comment: ""), String(format: "%.1f GB", Fmt.gib(m.used)), MemoryPressure.tint(percent: lvl))
             memStat(NSLocalizedString("Free", comment: ""), String(format: "%.1f GB", Fmt.gib(free)), Brand.textPrimary)
             if let c = m.cached, c > 0 {
                 memStat(NSLocalizedString("Cached", comment: ""), String(format: "%.1f GB", Fmt.gib(c)), Brand.textPrimary)
             }
             memStat(NSLocalizedString("Swap", comment: ""),
                     String(format: "%.1f / %.0f GB", Fmt.gib(m.swapUsed), Fmt.gib(m.swapTotal)),
-                    m.swapUsed > 0 ? MemoryPressure.tint(level: lvl) : Brand.textPrimary)
+                    m.swapUsed > 0 ? MemoryPressure.tint(percent: lvl) : Brand.textPrimary)
             Spacer(minLength: 0)
         }
         .padding(14)
@@ -141,20 +141,15 @@ struct StatusView: View {
 
     private func memTile(_ s: MoleStatus) -> ValueTile {
         let m = s.memory
-        let lvl = MemoryPressure.level()
+        let lvl = MemoryPressure.percent()
         let used = Fmt.gib(m.used)
         let total = Fmt.gib(m.total)
-        // Concrete pressure info — swap in use — coloured by the pressure level,
-        // shown only when actually swapping (no chip at rest).
-        let chip: (String, Color)? = m.swapUsed > 0
-            ? (String(format: NSLocalizedString("swap %.1fG", comment: ""), Fmt.gib(m.swapUsed)),
-               MemoryPressure.tint(level: lvl))
-            : nil
         return ValueTile(
-            eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(level: lvl),
+            eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(percent: lvl),
             value: String(format: "%.0f", m.usedPercent), unit: "%",
-            chip: chip, values: model.memHist, chartStyle: .area,
-            footnote: String(format: NSLocalizedString("%.1f / %.1f GB used", comment: ""), used, total))
+            chip: (String(format: NSLocalizedString("%d%% pressure", comment: ""), lvl), MemoryPressure.tint(percent: lvl)),
+            values: model.memHist, chartStyle: .area,
+            footnote: String(format: NSLocalizedString("%.1f / %.1f GB · swap %.1f GB", comment: ""), used, total, Fmt.gib(m.swapUsed)))
     }
 
     private func gpuTile(_ s: MoleStatus) -> ValueTile {

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -107,14 +107,13 @@ struct StatusView: View {
 
     private func memTile(_ s: MoleStatus) -> ValueTile {
         let m = s.memory
-        let label = m.pressure.isEmpty ? "normal" : m.pressure.lowercased()
-        let color: Color = label == "normal" ? Brand.textSecondary : (label == "warning" ? Brand.orange : Brand.red)
+        let lvl = MemoryPressure.level()
         let used = Fmt.gib(m.used)
         let total = Fmt.gib(m.total)
         return ValueTile(
-            eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(m.pressure),
+            eyebrow: "Memory", glyph: "memorychip", accent: MemoryPressure.tint(level: lvl),
             value: String(format: "%.0f", m.usedPercent), unit: "%",
-            chip: (label, color), values: model.memHist, chartStyle: .area,
+            chip: (MemoryPressure.label(level: lvl), MemoryPressure.tint(level: lvl)), values: model.memHist, chartStyle: .area,
             footnote: String(format: NSLocalizedString("%.1f / %.1f GB · swap %.1f GB", comment: ""),
                              used, total, Fmt.gib(m.swapUsed)))
     }


### PR DESCRIPTION
The 0.8.3 metric/menu-bar improvements. **Stacked on #203** (base `fix/menubar-memory-pressure`) — retarget to `main` once #203 merges. CI green (compile + tests); the **visual/behavioural bits need a hand-test** since I can't run the app on this clone.

1. **Power-draw widget** — new `power` menu-bar metric from `thermal.systemPower` (value/label/sparkline, `12W`).
2. **Pressure-aware memory colour** — Status dashboard + popover memory tiles tint the accent by real macOS pressure (`MemoryPressure.tint`: normal → green, warning → orange, critical → red) instead of fixed amber, so memory reads calm at high usage when pressure is normal.
3. **Setup UX** — live **preview** of the row + one-click **presets** (CPU·RAM / CPU·RAM·Net·Disk / Everything) in Settings.
4. **Runner** — two more built-in animations, **Wave** + **Bars**.
5. **Popover perf** — `MoleStatus` is now `Equatable`; the metric grid is wrapped in an `EquatableGate` keyed on (snapshot + sparkline histories + tiles), so it no longer rebuilds on unrelated popover ticks (ops, Stay-Awake, clean-watch, privacy). Behaviour-preserving — the key captures every input the grid reads.

### Please hand-test
- Memory tile colour (dashboard + popover) at normal vs. high pressure
- Settings live preview renders legibly on the dark panel; presets apply
- Wave/Bars runners animate cleanly
- **Popover tiles still update live** every second (the perf gate didn't make them stale)

### Deferred (would rather land with your hand-test)
- Drag-to-reorder (up/down buttons stay), animated runner preview, and extending the perf gate to the battery card / top-processes block.