### PR TITLE
ci(sentry-issues): stop auto-filing App-Hang (ANR) issues

### DIFF
--- a/.github/workflows/sentry-issues.yml
+++ b/.github/workflows/sentry-issues.yml
@@ -133,6 +133,23 @@ jobs:
                 continue
               fi
 
+              # Skip App-Hang (ANR) issues. One 2 s main-thread stall fans out
+              # into many Sentry issues — the hang sampler's top frame differs
+              # each time (swift_release, StackLayout.explicitAlignment, langid_…),
+              # all the same underlying event — so filing one GitHub issue per
+              # short-id floods the tracker for a single hang. They're also low
+              # signal here: the memory-starved majority (Burrow runs on RAM-
+              # pressured Macs) is already dropped client-side in
+              # CrashReporter.isMemoryStarvedAppHang, and a genuine hang is better
+              # triaged in Sentry, where its fan-out is grouped. Match on
+              # issueType/title so it's robust to exact wording.
+              issueType=$(jq -r '.issueType // empty' <<<"$issue")
+              titleProbe=$(jq -r '.title // .metadata.value // empty' <<<"$issue")
+              if printf '%s %s' "$issueType" "$titleProbe" | grep -qiE 'app[ _-]?hang|hanging'; then
+                echo "Skipping App-Hang issue ${shortId} (ANR fan-out — not auto-filed)."
+                continue
+              fi
+
               if [ "$filed" -ge "$MAX_PER_RUN" ]; then
                 echo "::warning::Hit MAX_PER_RUN=${MAX_PER_RUN}; remaining new issues will be filed next run."
                 break 2


### PR DESCRIPTION
## What

Skip **App-Hang (ANR)** issues in the `sentry-issues` poller so they no longer auto-file GitHub issues.

## Why

The open-issue tracker filled up with ~15 `[Sentry] BURROW-… : App Hanging` issues (#198–#215). They're all **one underlying event fanning out**:

- A single ≥2 s main-thread hang is sampled by Sentry's ANR tracker, and the **top frame differs every sample** — `swift_release`, `StackLayout.explicitAlignment`, `langid_consume_string`, `ViewGraph.init`, `NSAttributedString.MetricsCache.metrics`, … — so Sentry groups it into many separate issues.
- BURROW-N / -1 / -G / -34 / -2 literally share the **same `trace_id`** from the **same user/device** (one MacBookPro18,2 in Bangkok, 0.8.2). One hang → 6+ Sentry issues → 6+ GitHub issues.

They're also **low-signal for the tracker**:
- Every reported hang was on a **memory-starved** machine (<150 MB free). Burrow is a system monitor — it runs precisely when the Mac is under memory pressure, and the OS thrashing the render/display commit is not a Burrow defect. That majority is **already dropped client-side** by `CrashReporter.isMemoryStarvedAppHang` (commit `dbc9cee`, shipping in **v0.8.3**).
- A genuine hang is far easier to triage in Sentry — where its fan-out is grouped — than as a swarm of near-duplicate GitHub issues.

## Change

After the lookback/dedup gates, skip any issue whose `issueType`/title matches `app[ _-]?hang|hanging`. Real crashes and errors (e.g. `EXC_BAD_ACCESS` — BURROW-K) still file exactly as before.

## Follow-up (manual, not in this PR)
- The 15 already-filed `[Sentry]` GitHub issues are being closed.
- The 99 open AppHang Sentry issues are being **ignored** (untilEscalating) — resolving would bounce on the next stale-0.8.2 event; they fade as users move to the 0.8.3 client filter.