### PR TITLE
Migrate Burrow.app off GPL mo → bundle the MIT burrow-engine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,29 @@ jobs:
       # not be able to run new code here. Comment keeps the version legible.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      # Fetch the bundled MIT engine (burrow-engine) at its PINNED submodule
+      # commit so a release embeds OUR engine — the exact one the PR reviewed,
+      # not whatever HEAD happens to be — instead of resolving system `mo`.
+      # burrow-engine is a PRIVATE repo, so set ENGINE_PAT (a PAT with
+      # Contents:Read on caezium/burrow-engine); TAP_PAT can't be reused — it's
+      # fine-grained to the tap. NON-FATAL on purpose: without access the
+      # release still ships, just without the bundled engine, so the app falls
+      # back to system `mo` exactly as before this migration (set ENGINE_PAT,
+      # or make burrow-engine public, to actually bundle it).
+      - name: Fetch bundled engine submodule (non-fatal)
+        env:
+          ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
+        run: |
+          if [ -n "$ENGINE_PAT" ]; then
+            git config --global url."https://x-access-token:${ENGINE_PAT}@github.com/".insteadOf "https://github.com/"
+          fi
+          if git submodule update --init --recursive macos/vendor/burrow-engine; then
+            echo "engine: checked out at pinned commit $(git -C macos/vendor/burrow-engine rev-parse --short HEAD)"
+          else
+            echo "::warning::burrow-engine submodule unavailable — set ENGINE_PAT (private repo) or make it public. Shipping WITHOUT the bundled engine; the app resolves system \`mo\`, as before this migration."
+          fi
+          git config --global --unset-all url."https://x-access-token:${ENGINE_PAT}@github.com/".insteadOf 2>/dev/null || true
+
       # Use the newest Xcode on the runner so xcodebuild can read the project
       # format xcodegen emits (Homebrew's xcodegen targets the latest Xcode).
       - name: Select newest Xcode
@@ -135,6 +158,19 @@ jobs:
               find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) -print0 \
                 | while IFS= read -r -d '' f; do codesign --force --sign - "$f"; done
             fi
+            # The bundled MIT engine ships nested Mach-O helpers (status-go,
+            # analyze-go). Re-sign them with the app's ad-hoc identity too, so
+            # the whole bundle carries one coherent signature — the same
+            # inside-out pass we do for frameworks. (bundle-engine.sh ad-hoc
+            # signs them at build time, but best-effort/`|| true`; this makes it
+            # authoritative and is what the Developer ID path below relies on.)
+            # Filter by Mach-O magic so the shell entrypoint + lib/*.sh skip.
+            if [ -d "$APP/Contents/Resources/engine" ]; then
+              find "$APP/Contents/Resources/engine" -type f -print0 \
+                | while IFS= read -r -d '' f; do
+                    if file -b "$f" | grep -q 'Mach-O'; then codesign --force --sign - "$f"; fi
+                  done
+            fi
             codesign --force --sign - --entitlements macos/Resources/Burrow.entitlements "$APP"
             codesign --verify --strict --verbose=2 "$APP"
             echo "signed=false" >> "$GITHUB_OUTPUT"
@@ -160,6 +196,18 @@ jobs:
             find "$APP/Contents/Frameworks" \( -name "*.framework" -o -name "*.dylib" \) -print0 \
               | while IFS= read -r -d '' f; do
                   codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$f"
+                done
+          fi
+          # The bundled engine's nested Mach-O helpers (status-go, analyze-go)
+          # need Developer ID + hardened runtime + secure timestamp too — every
+          # embedded Mach-O must be signed this way or notarization rejects the
+          # submission. (Mach-O filter skips the shell entrypoint + lib/*.sh.)
+          if [ -d "$APP/Contents/Resources/engine" ]; then
+            find "$APP/Contents/Resources/engine" -type f -print0 \
+              | while IFS= read -r -d '' f; do
+                  if file -b "$f" | grep -q 'Mach-O'; then
+                    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$f"
+                  fi
                 done
           fi
           # Hardened runtime + secure timestamp are required for notarization.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "macos/vendor/burrow-engine"]
+	path = macos/vendor/burrow-engine
+	url = https://github.com/caezium/burrow-engine.git

--- a/macos/Sources/MoleCLI.swift
+++ b/macos/Sources/MoleCLI.swift
@@ -73,13 +73,26 @@ enum MoleCLI {
         return nil
     }
 
-    /// The known install locations ONLY — no PATH lookup. ELEVATED runs
-    /// must resolve through this: accepting a user-writable PATH entry
-    /// would hand root to whatever binary shadowed `mo` first.
+    /// The MIT engine bundled inside the app at Contents/Resources/engine/mole. Preferred
+    /// over any system `mo`: users run our engine with zero install and never touch upstream
+    /// (GPL-relicensed) mo. It's part of the signed app bundle, so it's a trusted location.
+    static func bundledExecutable() -> String? {
+        guard let url = Bundle.main.url(forResource: "mole", withExtension: nil,
+                                        subdirectory: "engine") else { return nil }
+        return FileManager.default.isExecutableFile(atPath: url.path) ? url.path : nil
+    }
+
+    /// The known trusted locations ONLY — no PATH lookup. ELEVATED runs must resolve through
+    /// this: accepting a user-writable PATH entry would hand root to whatever binary shadowed
+    /// the engine first. Order: bundled engine → installed `burrow-engine` (the MIT fork) →
+    /// legacy upstream `mo` (back-compat for existing installs).
     static func trustedExecutable() -> String? {
+        if let bundled = bundledExecutable() { return bundled }
         let candidates = [
-            "/opt/homebrew/bin/mo",      // Apple Silicon Homebrew
-            "/usr/local/bin/mo",          // Intel Homebrew / manual install
+            "/opt/homebrew/bin/burrow-engine",  // MIT fork, if installed
+            "/usr/local/bin/burrow-engine",
+            "/opt/homebrew/bin/mo",             // legacy upstream (back-compat)
+            "/usr/local/bin/mo",
             "/usr/bin/mo",
         ]
         for path in candidates where FileManager.default.isExecutableFile(atPath: path) {
@@ -124,11 +137,13 @@ enum MoleCLI {
 
     // MARK: - Install / version
 
-    /// Canonical install command (Homebrew). Shown in the guided install
-    /// flow; we never run it for the user.
-    static let installCommand = "brew install mole"
-    /// Where to send users without Homebrew.
-    static let repoURL = URL(string: "https://github.com/tw93/Mole")!
+    /// The MIT engine normally ships BUNDLED inside the app (zero install). This is only the
+    /// fallback hint shown if the bundled copy is somehow unavailable — reinstalling the app
+    /// restores it.
+    static let installCommand = "brew install --cask caezium/tap/burrow"
+    /// The engine fork (the MIT engine is bundled with the app, pinned at mo's last MIT
+    /// release before upstream relicensed to GPL-3.0).
+    static let repoURL = URL(string: "https://github.com/caezium/burrow-engine")!
 
     /// Current `mo` version, or nil if not installed / unparsable.
     static func version() -> String? {

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -85,6 +85,20 @@ targets:
     dependencies:
       - package: PostHog
       - package: Sentry
+    postCompileScripts:
+      - name: Bundle burrow-engine (MIT)
+        basedOnDependencyAnalysis: false
+        script: |
+          # Stage the MIT engine into the app's Resources so users run our engine with zero
+          # install (never upstream GPL mo). Activates when the engine source is present —
+          # a release/CI vendors it (vendor/burrow-engine) or sets BURROW_ENGINE_SRC; dev
+          # builds without it fall back to a system-installed engine.
+          ENGINE_SRC="${BURROW_ENGINE_SRC:-$SRCROOT/vendor/burrow-engine}"
+          if [ -d "$ENGINE_SRC" ]; then
+            "$SRCROOT/scripts/bundle-engine.sh" "$ENGINE_SRC" "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
+          else
+            echo "warning: burrow-engine not found at $ENGINE_SRC — Burrow falls back to a system engine. Set BURROW_ENGINE_SRC or add the vendor/burrow-engine submodule."
+          fi
 
   BurrowTests:
     type: bundle.unit-test

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -99,10 +99,16 @@ targets:
           # therefore happens POST-build: use scripts/build.sh locally, and the release
           # pipeline's inside-out re-sign (#178) seals it for distribution.
           ENGINE_SRC="${BURROW_ENGINE_SRC:-$SRCROOT/vendor/burrow-engine}"
-          if [ -d "$ENGINE_SRC" ]; then
+          # Require a real engine checkout, not just the directory: a plain
+          # (no-submodule) checkout — e.g. the PR `ci` job — leaves an EMPTY
+          # vendor/burrow-engine dir for the gitlink, so `[ -d ]` alone would be
+          # true and bundle-engine.sh would then fail building from missing
+          # source. Gate on mole + cmd/ so we bundle only a populated checkout
+          # and otherwise fall through to the system engine (build still green).
+          if [ -f "$ENGINE_SRC/mole" ] && [ -d "$ENGINE_SRC/cmd" ]; then
             "$SRCROOT/scripts/bundle-engine.sh" "$ENGINE_SRC" "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
           else
-            echo "warning: burrow-engine not found at $ENGINE_SRC — Burrow falls back to a system engine. Set BURROW_ENGINE_SRC or add the vendor/burrow-engine submodule."
+            echo "warning: burrow-engine source not present at $ENGINE_SRC — Burrow falls back to a system engine. Set BURROW_ENGINE_SRC or init the vendor/burrow-engine submodule."
           fi
 
   BurrowTests:

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -85,7 +85,7 @@ targets:
     dependencies:
       - package: PostHog
       - package: Sentry
-    postCompileScripts:
+    postBuildScripts:
       - name: Bundle burrow-engine (MIT)
         basedOnDependencyAnalysis: false
         script: |
@@ -93,6 +93,11 @@ targets:
           # install (never upstream GPL mo). Activates when the engine source is present —
           # a release/CI vendors it (vendor/burrow-engine) or sets BURROW_ENGINE_SRC; dev
           # builds without it fall back to a system-installed engine.
+          #
+          # NOTE: Xcode's CodeSign phase runs AFTER all build phases, so it re-signs the app
+          # over the freshly-added engine and the resource seal ends up stale. The final seal
+          # therefore happens POST-build: use scripts/build.sh locally, and the release
+          # pipeline's inside-out re-sign (#178) seals it for distribution.
           ENGINE_SRC="${BURROW_ENGINE_SRC:-$SRCROOT/vendor/burrow-engine}"
           if [ -d "$ENGINE_SRC" ]; then
             "$SRCROOT/scripts/bundle-engine.sh" "$ENGINE_SRC" "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"

--- a/macos/scripts/build.sh
+++ b/macos/scripts/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# build.sh — build Burrow.app with the MIT engine bundled AND properly sealed.
+#
+# The engine is staged into Resources by a build phase, but Xcode's CodeSign runs after all
+# phases, leaving the resource seal stale (which breaks Full Disk Access — #177/#178). So the
+# final inside-out seal is done HERE, after xcodebuild.
+#
+# Usage: scripts/build.sh [Debug|Release]
+#   BURROW_ENGINE_SRC   engine checkout to bundle (default: ./vendor/burrow-engine)
+#   BURROW_SIGN_IDENTITY signing identity (default: '-' ad-hoc; release sets a Developer ID)
+set -euo pipefail
+cd "$(dirname "$0")/.."   # macos/
+
+CONFIG="${1:-Debug}"
+ENGINE_SRC="${BURROW_ENGINE_SRC:-$PWD/vendor/burrow-engine}"
+SIGN_ID="${BURROW_SIGN_IDENTITY:--}"
+
+xcodegen generate >/dev/null
+
+BURROW_ENGINE_SRC="$ENGINE_SRC" xcodebuild -project Burrow.xcodeproj -scheme Burrow \
+  -configuration "$CONFIG" CODE_SIGN_IDENTITY="$SIGN_ID" CODE_SIGNING_REQUIRED=NO build
+
+APP="$(xcodebuild -project Burrow.xcodeproj -scheme Burrow -configuration "$CONFIG" \
+  -showBuildSettings 2>/dev/null \
+  | awk -F' = ' '/ TARGET_BUILD_DIR /{d=$2} / WRAPPER_NAME /{w=$2} END{print d"/"w}')"
+
+# Final inside-out seal (engine included). This is the step Xcode can't do for us.
+codesign --force --deep --sign "$SIGN_ID" "$APP"
+codesign --verify --deep "$APP" && echo "✓ built + sealed: $APP"

--- a/macos/scripts/bundle-engine.sh
+++ b/macos/scripts/bundle-engine.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# bundle-engine.sh — stage the burrow-engine RUNTIME into the app's Resources/engine.
+#
+# Bundling the MIT engine inside Burrow.app means users run our engine with zero install and
+# never touch upstream (GPL) mo. Only runtime files travel (entrypoint + lib + the two Go
+# binaries + LICENSE) — no Go source.
+#
+# Usage: bundle-engine.sh <ENGINE_SRC> <RESOURCES_DIR>
+#   ENGINE_SRC     a burrow-engine checkout (has mole, lib/, cmd/, go.mod)
+#   RESOURCES_DIR  the app bundle's Resources dir (engine/ is created inside it)
+set -euo pipefail
+
+ENGINE_SRC="${1:?engine source dir required}"
+RESOURCES="${2:?resources dir required}"
+OUT="$RESOURCES/engine"
+
+# 1. Build the Go binaries (status-go, analyze-go) if Go is available; otherwise require
+#    that prebuilt ones already exist in the source bin/.
+if command -v go >/dev/null 2>&1; then
+  ( cd "$ENGINE_SRC" \
+      && go build -ldflags="-s -w" -o bin/status-go ./cmd/status \
+      && go build -ldflags="-s -w" -o bin/analyze-go ./cmd/analyze )
+fi
+for b in status-go analyze-go; do
+  [ -x "$ENGINE_SRC/bin/$b" ] || { echo "error: $ENGINE_SRC/bin/$b missing (need Go to build)"; exit 1; }
+done
+
+# 2. Copy only the runtime: entrypoint, shell libs, the two binaries, and the MIT LICENSE.
+rm -rf "$OUT"
+mkdir -p "$OUT/bin"
+cp "$ENGINE_SRC/mole" "$OUT/"
+[ -f "$ENGINE_SRC/mo" ] && cp "$ENGINE_SRC/mo" "$OUT/"
+cp -R "$ENGINE_SRC/lib" "$OUT/"
+cp "$ENGINE_SRC"/bin/*.sh "$OUT/bin/" 2>/dev/null || true
+cp "$ENGINE_SRC/bin/status-go" "$ENGINE_SRC/bin/analyze-go" "$OUT/bin/"
+cp "$ENGINE_SRC/LICENSE" "$OUT/LICENSE"
+chmod +x "$OUT/mole" "$OUT/bin/"* 2>/dev/null || true
+[ -f "$OUT/mo" ] && chmod +x "$OUT/mo"
+
+echo "bundled engine -> $OUT ($(du -sh "$OUT" 2>/dev/null | awk '{print $1}'))"

--- a/macos/scripts/bundle-engine.sh
+++ b/macos/scripts/bundle-engine.sh
@@ -38,4 +38,12 @@ cp "$ENGINE_SRC/LICENSE" "$OUT/LICENSE"
 chmod +x "$OUT/mole" "$OUT/bin/"* 2>/dev/null || true
 [ -f "$OUT/mo" ] && chmod +x "$OUT/mo"
 
-echo "bundled engine -> $OUT ($(du -sh "$OUT" 2>/dev/null | awk '{print $1}'))"
+# 3. Code-sign the nested Mach-O binaries so the app's own signature validates (--deep).
+#    Uses the build's resolved identity when run as a build phase, else ad-hoc ('-').
+IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:--}"
+for b in status-go analyze-go; do
+  codesign --force --sign "$IDENTITY" --timestamp=none "$OUT/bin/$b" 2>/dev/null \
+    || codesign --force --sign - --timestamp=none "$OUT/bin/$b" || true
+done
+
+echo "bundled engine -> $OUT ($(du -sh "$OUT" 2>/dev/null | awk '{print $1}'); signed with '${IDENTITY}')"


### PR DESCRIPTION
## Why

Shipping Burrow resolves upstream **mo**, which **relicensed MIT → GPL-3.0 on 2026-06-11** (+ trademark policy). GPL is incompatible with a closed product. This migrates the app onto our **MIT engine fork** (`burrow-engine`, pinned at mo's last MIT commit `9daf936` / V1.42.0), **bundled inside the app** — zero install, never touches GPL upstream.

## What this does

- **`scripts/bundle-engine.sh`** — stages the engine *runtime* (`mole` + `lib/` + `status-go`/`analyze-go` + MIT `LICENSE`; no Go source, ~8.6 MB) into `Resources/engine/`, ad-hoc-signing the nested Go binaries.
- **`scripts/build.sh`** — canonical build: `xcodebuild` **+ a post-build `codesign --force --deep`**. Xcode's CodeSign runs *after* all build phases, so the engine's resource seal is finalized here (a stale seal breaks FDA — #177/#178).
- **`project.yml`** — a `postBuildScripts` phase stages the engine when its source is present (`vendor/burrow-engine` submodule or `$BURROW_ENGINE_SRC`); dev builds without it fall back to a system engine.
- **`MoleCLI.swift`** — resolution is now **bundled engine → installed `burrow-engine` → legacy `mo`**. Install hints repoint off `tw93/Mole`; keeps the `Mole CLI © tw93` credit (graceful, license-forced migration).

## ✅ Verified (real `xcodebuild`)
- **BUILD SUCCEEDED**; the bundled `mole status --json` (and `--watch` NDJSON) runs correctly from inside the `.app`.
- **Signing resolved:** `scripts/build.sh` output passes `codesign --verify --deep --strict`. Nested engine binaries signed; app seal valid.

## ⏳ Remaining
- [ ] Vendor the engine as a `vendor/burrow-engine` submodule for reproducible release/CI builds.
- [ ] Wire the post-build seal into the release pipeline (extend the existing inside-out re-sign to cover the bundled engine).

## Test
```bash
cd macos && BURROW_ENGINE_SRC=~/Desktop/burrow-engine scripts/build.sh Debug
# -> ✓ built + sealed: <path>/Burrow.app   (open it; engine is at Contents/Resources/engine)
```