### PR TITLE
fix(menubar): cap HUD height to the popover's own display (#223 follow-up)

### DIFF
--- a/macos/Sources/HUDController.swift
+++ b/macos/Sources/HUDController.swift
@@ -29,7 +29,16 @@ final class HUDController: NSViewController {
     required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
 
     private var maxHeight: CGFloat {
-        max(360, (NSScreen.main?.visibleFrame.height ?? 800) - 28)
+        // Cap to the display the popover is ACTUALLY on, not `NSScreen.main`
+        // (the key-window screen — for a menu-bar app clicking a status item
+        // on a secondary display there's often no key window, so `.main`
+        // returns the primary). On a shorter secondary display that would size
+        // the HUD taller than the screen and run it off the bottom edge — the
+        // exact overflow this cap exists to prevent. `view.window` is the
+        // popover's own window once shown; fall back to `.main` on the first
+        // layout pass before it's attached (a later pass corrects it).
+        let screen = view.window?.screen ?? NSScreen.main
+        return max(360, (screen?.visibleFrame.height ?? 800) - 28)
     }
 
     override func loadView() {


### PR DESCRIPTION
Follow-up to #225. That PR merged with only the popover-placement commit; this sizing commit was pushed to the branch moments later and didn't make it into the merge, so it's still missing from `main`.

## What this fixes
`HUDController` capped the popover height to `NSScreen.main.visibleFrame`, but `NSScreen.main` is the **key-window** screen, not the display showing the popover. For a menu-bar app clicking a status item on a secondary display there's usually no key window, so `.main` returns the primary.

**Failure scenario:** menu bar on a shorter secondary display (e.g. a 1080p monitor below a taller main display). The height is capped against the tall primary, so the HUD is sized taller than the secondary screen and runs off the bottom edge — the exact overflow this cap exists to prevent.

## Fix
Cap against `view.window?.screen` (the popover's actual display), falling back to `NSScreen.main` only on the first layout pass before the popover window is attached (a later `viewDidLayout`/`frameDidChange` pass corrects it).

One-line change in `macos/Sources/HUDController.swift`. Not build-verified (screen swap in an already-compiling path).