### PR TITLE
fix: purge pre-selected-list bug (#231) + analyze runaway spawning (#232)

### DIFF
--- a/macos/Sources/AnalyzeView.swift
+++ b/macos/Sources/AnalyzeView.swift
@@ -329,6 +329,16 @@ struct PulsingDot: View {
     }
 }
 
+/// A one-shot cooperative cancellation flag, set on the main actor when a scan
+/// is superseded and read from the background walk. Lock-guarded because the
+/// write and reads cross threads. #232
+final class ScanCancel: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+    var isCancelled: Bool { lock.lock(); defer { lock.unlock() }; return cancelled }
+    func cancel() { lock.lock(); cancelled = true; lock.unlock() }
+}
+
 @MainActor
 final class AnalyzeModel: ObservableObject {
     struct Progress: Equatable {
@@ -440,11 +450,19 @@ final class AnalyzeModel: ObservableObject {
     /// breadcrumbs have since moved to. (Same pattern as HistoryView's
     /// `loadGen`.)
     private var scanGen = 0
+    /// Cancels the in-flight background walk when a new navigation supersedes it.
+    /// The `scanGen` token above only gates whether a finishing walk's result is
+    /// APPLIED; this token makes a superseded walk stop SPAWNING `mo analyze`
+    /// processes right away, so rapid navigation / refresh can't stack overlapping
+    /// scans that each fire a fanout of engine processes. #232
+    private var scanToken: ScanCancel?
 
     private func scan(_ path: String, name: String, push: Bool, force: Bool = false) {
         if push { crumbs.append((name, path)) }
         scanGen += 1
         let gen = scanGen
+        // Any navigation supersedes the previous walk — stop it spawning at once.
+        scanToken?.cancel()
         // Cache hit → show instantly; don't re-run `mo analyze` for a
         // folder we already walked (back/drill is the common navigation).
         if !force, let cached = cache[path] {
@@ -454,10 +472,12 @@ final class AnalyzeModel: ObservableObject {
         loading = true
         progress = nil
         error = nil
+        let token = ScanCancel()
+        scanToken = token
         OperationCenter.shared.begin(opId, label: String(format: NSLocalizedString("Analyzing %@", comment: ""), name))
         DispatchQueue.global(qos: .userInitiated).async {
             do {
-                let r = try Self.scanWithProgress(path) { current, done, total in
+                let r = try Self.scanWithProgress(path, isCancelled: { token.isCancelled }) { current, done, total in
                     Task { @MainActor in
                         guard gen == self.scanGen else { return }
                         self.progress = Progress(path: current, done: done, total: total)
@@ -501,6 +521,7 @@ final class AnalyzeModel: ObservableObject {
     /// aggregate call rather than spawning hundreds of processes.
     nonisolated static func scanWithProgress(
         _ path: String,
+        isCancelled: @escaping () -> Bool = { false },
         onProgress: @escaping (String, Int, Int) -> Void,
         cacheChild: @escaping (String, DiskScanResult) -> Void
     ) throws -> DiskScanResult {
@@ -525,15 +546,20 @@ final class AnalyzeModel: ObservableObject {
         var totalSize: Int64 = 0
         var done = 0
 
-        let inFlight = DispatchSemaphore(value: 6)   // bound concurrent `mo analyze`
+        // 3, not 6: each child spawns a full-subtree `mo analyze` walk, so a wider
+        // fanout pegs several cores at once (six were visible in #232). Three keeps
+        // wall-clock near the aggregate scan without saturating the machine.
+        let inFlight = DispatchSemaphore(value: 3)   // bound concurrent `mo analyze`
         let group = DispatchGroup()
         let workQ = DispatchQueue.global(qos: .userInitiated)
 
         for name in childNames {
+            if isCancelled() { break }               // superseded → stop queuing more walks
             inFlight.wait()
             group.enter()
             workQ.async {
                 defer { inFlight.signal(); group.leave() }
+                if isCancelled() { return }          // don't spawn `mo analyze` for a dead scan
                 let childPath = (path as NSString).appendingPathComponent(name)
                 var entry: DiskScanEntry?
                 var isDir: ObjCBool = false
@@ -562,6 +588,9 @@ final class AnalyzeModel: ObservableObject {
             }
         }
         group.wait()
+        // A superseded walk returns a PARTIAL tree; throwing keeps the caller's
+        // catch (which is scanGen-guarded) from caching it as if it were complete.
+        if isCancelled() { throw CancellationError() }
 
         entries.sort { $0.size > $1.size }
         return DiskScanResult(path: path, totalSize: totalSize,

--- a/macos/Sources/MoInteractive.swift
+++ b/macos/Sources/MoInteractive.swift
@@ -70,18 +70,27 @@ enum MoTUI {
         Set(screen.items.enumerated().filter { $0.element.selected }.map { $0.offset })
     }
 
-    /// Keystrokes to take a FRESH list (cursor at item 0, everything ○) to
-    /// exactly `wanted` checked. Walks every item top-to-bottom once,
-    /// pressing Space only on wanted ones — deterministic, no cursor math.
-    /// `confirm` appends Enter. Does NOT confirm an empty selection.
-    static func keystrokesToSelect(_ wanted: Set<Int>, count: Int, confirm: Bool) -> [UInt8] {
+    /// Keystrokes to drive the list from its CURRENT checked state to exactly
+    /// `wanted` checked. Walks every item top-to-bottom once (cursor starts at
+    /// row 0), pressing Space only on rows whose current state differs from
+    /// what's wanted — deterministic, no cursor math. `current` is the set of
+    /// rows already checked (●); pass [] for a fresh all-unchecked list.
+    ///
+    /// Toggling the *difference* (not blindly Space-ing `wanted`) is what makes
+    /// this work for `mo purge`, whose list renders with most rows PRE-SELECTED
+    /// by default — the old "everything starts ○" assumption left those defaults
+    /// checked, so the on-screen selection never matched what the user picked and
+    /// the safety guard aborted every purge ("Couldn't confirm the selection
+    /// safely"). `installer` starts all-○, so `current: []` reproduces the old
+    /// behavior there. `confirm` appends Enter. Does NOT confirm an empty selection.
+    static func keystrokesToSelect(_ wanted: Set<Int>, count: Int, currentlySelected current: Set<Int> = [], confirm: Bool) -> [UInt8] {
         let down: [UInt8] = [0x1b, 0x5b, 0x42]   // ESC [ B
         let space: UInt8 = 0x20
         let enter: UInt8 = 0x0d
         var out: [UInt8] = []
         guard count > 0 else { return out }
         for i in 0..<count {
-            if wanted.contains(i) { out.append(space) }
+            if wanted.contains(i) != current.contains(i) { out.append(space) }  // toggle only where state must change
             if i < count - 1 { out.append(contentsOf: down) }
         }
         if confirm && !wanted.isEmpty { out.append(enter) }

--- a/macos/Sources/SelectionSession.swift
+++ b/macos/Sources/SelectionSession.swift
@@ -127,7 +127,11 @@ enum SelectionSession {
         s.wantedSigs = Set(wanted.compactMap { s.items.indices.contains($0) ? sig(s.items[$0]) : nil })
         s.wantedNames = Set(wanted.compactMap { s.items.indices.contains($0) ? s.items[$0].name : nil })
         s.expectedCount = s.items.count
-        let keys = MoTUI.keystrokesToSelect(wanted, count: s.items.count, confirm: false)
+        // Mole may render rows PRE-SELECTED (purge defaults most artifacts to ●).
+        // Plan against the list's current checked state so we toggle the delta,
+        // not just Space the wanted rows on top of the defaults.
+        let current = Set(s.items.enumerated().filter { $0.element.selected }.map { $0.offset })
+        let keys = MoTUI.keystrokesToSelect(wanted, count: s.items.count, currentlySelected: current, confirm: false)
         if s.items.count > s.viewportCount {
             // Selection spans more rows than Mole renders at once (the user pulled
             // in everything via "Show all"). One frame can't show them all, so we

--- a/macos/Tests/MoInteractiveTests.swift
+++ b/macos/Tests/MoInteractiveTests.swift
@@ -75,6 +75,24 @@ final class MoInteractiveTests: XCTestCase {
         XCTAssertEqual(MoTUI.keystrokesToSelect([0, 1, 2], count: 3, confirm: true), expected)
     }
 
+    func testKeystrokes_togglesDeltaAgainstPreselectedList() {
+        // `mo purge` renders rows PRE-SELECTED. Here rows {0, 2} start checked
+        // (●) and the user wants only row {1}. The plan must UNcheck 0, CHECK 1,
+        // and UNcheck 2 — a Space on every row — not just Space the wanted row
+        // (which would leave 0 and 2 checked → the "12/2 toggled" abort). #231
+        let down: [UInt8] = [0x1b, 0x5b, 0x42]
+        let space: [UInt8] = [0x20]
+        let expected = space + down + space + down + space
+        XCTAssertEqual(MoTUI.keystrokesToSelect([1], count: 3, currentlySelected: [0, 2], confirm: false), expected)
+    }
+
+    func testKeystrokes_noOpWhenCurrentAlreadyMatchesWanted() {
+        // Already exactly what's wanted → no Space presses, just the walk's Downs.
+        let down: [UInt8] = [0x1b, 0x5b, 0x42]
+        XCTAssertEqual(MoTUI.keystrokesToSelect([1, 2], count: 3, currentlySelected: [1, 2], confirm: false),
+                       down + down)
+    }
+
     // A real `mo purge` frame: rows are "<project path>  <size> | <category> | <age>",
     // the header carries "[1/53]" (53 total, but Mole renders far fewer).
     private let purgeFrame = """


### PR DESCRIPTION
Fixes #231 and #232 — two independent bugs found during an audit of the process/cleanup subsystems. Both verified against the shipping v0.9.1 code and the real bundled engine (`burrow-engine 1.42.0`). Builds clean (Debug, macOS).

## #231 — Purge fails systematically ("Couldn't confirm the selection safely")
**Root cause:** `mo purge` renders its selection list with most rows **pre-selected (●)** — captured live from the engine: `Select Categories to Clean [1/43], 1.20GB, 37 selected`. But `MoTUI.keystrokesToSelect` assumed a fresh **all-unchecked** list and only pressed Space on the wanted rows, never clearing the defaults. So the on-screen selection never equalled what the user picked, and the safety guard in `SelectionSession.tickViewport` correctly aborted every purge (`(onScreen=12 / wanted=2)` = 12 checked, 2 wanted).

**Fix:** plan against the list's **current** checked state (already parsed into `s.items[i].selected`) and toggle only the rows whose state must change — the symmetric difference. `installer` starts all-○, so `current: []` reproduces its old behavior. Regression tests added for the pre-selected case.

Files: `MoInteractive.swift`, `SelectionSession.swift`, `MoInteractiveTests.swift`.

## #232 — Runaway `analyze-go` spawning
**Root cause:** two compounding issues in `AnalyzeView.swift`:
- `DispatchSemaphore(value: 6)` fired 6 **full-subtree** `mo analyze` walks at once — enough to peg the machine on a single scan (6× `analyze-go` in the report).
- `scan()` never cancelled the in-flight background walk on re-navigation. The `scanGen` token only gates whether a result is *applied*, not whether the walk keeps *spawning* — so Refresh / drill / tab-switch stacked overlapping fanouts.

**Fix:** a cooperative `ScanCancel` token — a new scan cancels the previous walk, which stops queuing/spawning immediately and throws away its partial tree (so it can't poison the cache). Concurrency bound lowered 6 → 3.

Files: `AnalyzeView.swift`.

> Note: not a zombie/orphan leak — processes are reaped correctly (`waitUntilExit`); this was a spawn **rate/count** problem.
