### PR TITLE
perf: camera/mic indicator + resource-usage audit fixes (#234–#240)

### DIFF
--- a/macos/Sources/AnalyzeView.swift
+++ b/macos/Sources/AnalyzeView.swift
@@ -298,16 +298,31 @@ struct TreemapView: View {
 // MARK: - Icons / Finder helpers
 
 enum AnalyzeIcons {
-    private static var cache: [String: NSImage] = [:]
+    // NSCache, not a plain dict: keyed by full path it would otherwise retain an
+    // NSImage for every file ever shown for the process lifetime. NSCache evicts
+    // under memory pressure and honors the count cap. #236
+    private static let cache: NSCache<NSString, NSImage> = {
+        let c = NSCache<NSString, NSImage>()
+        c.countLimit = 512
+        return c
+    }()
     static func icon(for e: DiskScanEntry) -> NSImage {
-        if let c = cache[e.path] { return c }
+        if let c = cache.object(forKey: e.path as NSString) { return c }
         let img = NSWorkspace.shared.icon(forFile: e.path)
-        cache[e.path] = img
+        cache.setObject(img, forKey: e.path as NSString)
         return img
     }
     static func reveal(_ path: String) {
         NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
     }
+}
+
+/// Boxed walk result so the path→walk cache can be an NSCache (needs a class
+/// value); lets it stay bounded and evict under memory pressure. #236
+final class CachedWalk {
+    let entries: [DiskScanEntry]
+    let total: Int64
+    init(entries: [DiskScanEntry], total: Int64) { self.entries = entries; self.total = total }
 }
 
 // MARK: - Model
@@ -348,7 +363,14 @@ final class AnalyzeModel: ObservableObject {
     /// Cache scan results by path so navigating back/into already-seen
     /// folders is instant instead of re-running `mo analyze` (~4 CPU-s)
     /// each time. Refresh clears the current path to force a fresh walk.
-    private var cache: [String: (entries: [DiskScanEntry], total: Int64)] = [:]
+    // NSCache (bounded, auto-evicting) rather than an ever-growing dict: browsing
+    // deep trees / whole-disk analyze would otherwise retain a DiskScanEntry array
+    // for every directory ever visited for the model's lifetime. #236
+    private let cache: NSCache<NSString, CachedWalk> = {
+        let c = NSCache<NSString, CachedWalk>()
+        c.countLimit = 256
+        return c
+    }()
 
     var summaryLine: String {
         entries.isEmpty ? "—" : String(format: NSLocalizedString("%d items · %@", comment: ""), entries.count, Fmt.bytes(total))
@@ -376,7 +398,7 @@ final class AnalyzeModel: ObservableObject {
 
     func refresh() {
         guard let last = crumbs.last else { return }
-        cache[last.path] = nil   // drop the cached walk so we re-scan
+        cache.removeObject(forKey: last.path as NSString)   // drop the cached walk so we re-scan
         scan(last.path, name: last.name, push: false, force: true)
     }
 
@@ -424,7 +446,7 @@ final class AnalyzeModel: ObservableObject {
             try FileManager.default.trashItem(at: URL(fileURLWithPath: e.path), resultingItemURL: nil)
             entries.removeAll { $0.id == e.id }
             total = max(0, total - e.size)
-            if let last = crumbs.last { cache[last.path] = nil }
+            if let last = crumbs.last { cache.removeObject(forKey: last.path as NSString) }
         } catch {
             let err = NSAlert()
             err.messageText = NSLocalizedString("Couldn't move to Trash", comment: "")
@@ -447,7 +469,7 @@ final class AnalyzeModel: ObservableObject {
         let gen = scanGen
         // Cache hit → show instantly; don't re-run `mo analyze` for a
         // folder we already walked (back/drill is the common navigation).
-        if !force, let cached = cache[path] {
+        if !force, let cached = cache.object(forKey: path as NSString) {
             entries = cached.entries; total = cached.total; loading = false; error = nil
             return
         }
@@ -465,14 +487,15 @@ final class AnalyzeModel: ObservableObject {
                 } cacheChild: { childPath, result in
                     Task { @MainActor in
                         // Pre-warm drill-down with the per-child walks.
-                        self.cache[childPath] = (result.entries,
-                                                 result.totalSize > 0 ? result.totalSize
-                                                    : result.entries.reduce(0) { $0 + $1.size })
+                        self.cache.setObject(CachedWalk(entries: result.entries,
+                                                 total: result.totalSize > 0 ? result.totalSize
+                                                    : result.entries.reduce(0) { $0 + $1.size }),
+                                             forKey: childPath as NSString)
                     }
                 }
                 let sum = r.totalSize > 0 ? r.totalSize : r.entries.reduce(0) { $0 + $1.size }
                 Task { @MainActor in
-                    self.cache[path] = (r.entries, sum)   // cache stays warm either way
+                    self.cache.setObject(CachedWalk(entries: r.entries, total: sum), forKey: path as NSString)   // cache stays warm either way
                     guard gen == self.scanGen else { return }
                     self.entries = r.entries
                     self.total = sum

--- a/macos/Sources/BackupStatus.swift
+++ b/macos/Sources/BackupStatus.swift
@@ -14,16 +14,8 @@ enum BackupStatus {
     /// Whole days since the most recent Time Machine backup, or nil when there
     /// are no backups / Time Machine is unavailable.
     static func lastBackupDaysAgo(now: Date = Date()) -> Int? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/bin/tmutil")
-        p.arguments = ["latestbackup"]
-        let out = Pipe()
-        p.standardOutput = out
-        p.standardError = Pipe()
-        do { try p.run() } catch { return nil }
-        p.waitUntilExit()
-        guard p.terminationStatus == 0 else { return nil }
-        let text = String(decoding: out.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        // tmutil can stall (a busy/mounting backup volume); bound it. #239
+        guard let text = ShellProbe.run("/usr/bin/tmutil", ["latestbackup"], timeout: 8) else { return nil }
         guard let token = TimeMachine.latestBackupToken(text),
               let date = TimeMachine.date(fromToken: token) else { return nil }
         return max(0, Int(now.timeIntervalSince(date) / 86_400))

--- a/macos/Sources/CameraMicSensor.swift
+++ b/macos/Sources/CameraMicSensor.swift
@@ -14,6 +14,13 @@
 //  also light for Siri / dictation / Continuity Camera — labelled neutrally
 //  as "in use", never faked into per-app attribution. Opt-in (off by default).
 //
+//  Virtual/aggregate devices are the catch: their device-global "running
+//  somewhere" fires on OUTPUT or host-app activity, not real capture — a
+//  BlackHole/loopback/Camo/Teams device would light the mic dot merely because
+//  audio is *playing* through it, and a virtual camera (Camo/OBS) stays
+//  "running" while its host app is open. We skip virtual/aggregate transports
+//  unless the user actually selected one as their default input. #234
+//
 
 import Foundation
 import CoreMediaIO
@@ -21,7 +28,14 @@ import CoreAudio
 
 enum CameraMicSensor {
 
-    /// Whether any camera device reports it's running somewhere.
+    // FourCC transport types (shared by CoreAudio and CoreMediaIO). Comparing
+    // the raw values avoids per-framework symbol availability differences.
+    private static let virtualTransport: UInt32 = 0x76697274   // 'virt'
+    private static let aggregateTransport: UInt32 = 0x67727570 // 'grup'
+
+    /// Whether any *real* camera device reports it's running somewhere. Virtual
+    /// cameras (Camo/OBS) are skipped — they report running while their host app
+    /// is open regardless of actual capture.
     static func cameraInUse() -> Bool {
         var addr = CMIOObjectPropertyAddress(
             mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyDevices),
@@ -37,20 +51,16 @@ enum CameraMicSensor {
         guard CMIOObjectGetPropertyData(sys, &addr, 0, nil, dataSize, &used, &devices) == OSStatus(0)
         else { return false }
 
-        var runAddr = CMIOObjectPropertyAddress(
-            mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
-            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
-            mElement: CMIOObjectPropertyElement(0))
         for device in devices where device != 0 {
-            var running: UInt32 = 0
-            var size = UInt32(MemoryLayout<UInt32>.size)
-            if CMIOObjectGetPropertyData(device, &runAddr, 0, nil, size, &size, &running) == OSStatus(0),
-               running != 0 { return true }
+            if isVirtualCMIO(device) { continue }   // skip virtual cameras
+            if cmioIsRunning(device) { return true }
         }
         return false
     }
 
-    /// Whether any input (microphone) device reports it's running somewhere.
+    /// Whether any input (microphone) device reports it's running somewhere,
+    /// excluding virtual/aggregate devices (unless one is the selected default
+    /// input) so playback through a loopback/duplex device can't light the dot.
     static func micInUse() -> Bool {
         var addr = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDevices,
@@ -65,26 +75,90 @@ enum CameraMicSensor {
         guard AudioObjectGetPropertyData(sys, &addr, 0, nil, &dataSize, &devices) == noErr
         else { return false }
 
+        let defaultInput = defaultInputDevice()
+
         for device in devices where device != 0 {
             // Only consider devices that actually have input streams — a
             // playback-only device "running" isn't the microphone.
-            var streamAddr = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyStreams,
-                mScope: kAudioObjectPropertyScopeInput,
-                mElement: kAudioObjectPropertyElementMain)
-            var streamSize: UInt32 = 0
-            guard AudioObjectGetPropertyDataSize(device, &streamAddr, 0, nil, &streamSize) == noErr,
-                  streamSize > 0 else { continue }
+            guard hasInputStreams(device) else { continue }
 
-            var runAddr = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
-                mScope: kAudioObjectPropertyScopeGlobal,
-                mElement: kAudioObjectPropertyElementMain)
-            var running: UInt32 = 0
-            var size = UInt32(MemoryLayout<UInt32>.size)
-            if AudioObjectGetPropertyData(device, &runAddr, 0, nil, &size, &running) == noErr,
-               running != 0 { return true }
+            // A virtual/aggregate device's global "running" fires on output/host
+            // activity too, so it lights the mic dot when only audio is playing.
+            // Trust it only if the user actually picked it as their input device.
+            if isVirtualOrAggregateAudio(device), device != defaultInput { continue }
+
+            if audioIsRunning(device) { return true }
         }
         return false
+    }
+
+    // MARK: - CoreAudio helpers
+
+    private static func defaultInputDevice() -> AudioObjectID {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var dev: AudioObjectID = 0
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &dev) == noErr
+        else { return 0 }
+        return dev
+    }
+
+    private static func hasInputStreams(_ device: AudioObjectID) -> Bool {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioObjectPropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain)
+        var size: UInt32 = 0
+        return AudioObjectGetPropertyDataSize(device, &addr, 0, nil, &size) == noErr && size > 0
+    }
+
+    private static func isVirtualOrAggregateAudio(_ device: AudioObjectID) -> Bool {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var transport: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &transport) == noErr
+        else { return false }
+        return transport == virtualTransport || transport == aggregateTransport
+    }
+
+    private static func audioIsRunning(_ device: AudioObjectID) -> Bool {
+        var addr = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+        var running: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &running) == noErr && running != 0
+    }
+
+    // MARK: - CoreMediaIO helpers
+
+    private static func isVirtualCMIO(_ device: CMIOObjectID) -> Bool {
+        var addr = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyTransportType),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(0))
+        var transport: UInt32 = 0
+        var used: UInt32 = 0
+        let size = UInt32(MemoryLayout<UInt32>.size)
+        guard CMIOObjectGetPropertyData(device, &addr, 0, nil, size, &used, &transport) == OSStatus(0)
+        else { return false }
+        return transport == virtualTransport || transport == aggregateTransport
+    }
+
+    private static func cmioIsRunning(_ device: CMIOObjectID) -> Bool {
+        var addr = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(0))
+        var running: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        return CMIOObjectGetPropertyData(device, &addr, 0, nil, size, &size, &running) == OSStatus(0) && running != 0
     }
 }

--- a/macos/Sources/ConnectivityView.swift
+++ b/macos/Sources/ConnectivityView.swift
@@ -325,10 +325,11 @@ struct ConnectivityView: View {
         default:              return Brand.red
         }
     }
+    private static let relFmt: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
+    }()
     private static func relative(_ d: Date) -> String {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f.localizedString(for: d, relativeTo: Date())
+        relFmt.localizedString(for: d, relativeTo: Date())   // cached formatter (#240)
     }
 
     private func scanNearby() {

--- a/macos/Sources/DiskHealth.swift
+++ b/macos/Sources/DiskHealth.swift
@@ -14,16 +14,9 @@ enum DiskHealth {
     /// true = SMART "Verified", false = any other status, nil = unreadable
     /// (no internal NVMe, or system_profiler failed).
     static func smartVerified() -> Bool? {
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
-        p.arguments = ["SPNVMeDataType"]
-        let out = Pipe()
-        p.standardOutput = out
-        p.standardError = Pipe()
-        do { try p.run() } catch { return nil }
-        p.waitUntilExit()
-        guard p.terminationStatus == 0 else { return nil }
-        let text = String(decoding: out.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        // system_profiler routinely takes seconds; bound it so a wedge can't
+        // hang the Doctor probe task. #239
+        guard let text = ShellProbe.run("/usr/sbin/system_profiler", ["SPNVMeDataType"], timeout: 12) else { return nil }
         guard let line = text.split(separator: "\n").first(where: { $0.contains("SMART Status:") }) else {
             return nil
         }

--- a/macos/Sources/DoctorView.swift
+++ b/macos/Sources/DoctorView.swift
@@ -18,6 +18,15 @@ struct DoctorView: View {
     let db: DB
     @State private var checks: [Doctor.Check] = []
 
+    /// The rarely-changing, subprocess-backed posture probes, cached across
+    /// reopens with a short TTL. #239
+    private typealias Probes = (backup: Int?, smart: Bool?,
+                                sip: SecurityPosture.State, gatekeeper: SecurityPosture.State,
+                                fileVault: SecurityPosture.State, firewall: SecurityPosture.State,
+                                volumes: Int, iface: String?)
+    @MainActor private static var cachedProbes: (at: Date, value: Probes)?
+    private static let probeTTL: TimeInterval = 120
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
@@ -125,16 +134,26 @@ struct DoctorView: View {
         let cpuLoad = latest?.cpu.usage
         let battHealth: Int? = (latest?.batteries?.first?.capacity).flatMap { $0 > 0 ? $0 : nil }
         let displays = NSScreen.screens.count   // main-actor; reload is @MainActor
-        let probes = await Task.detached(priority: .utility) {
-            (backup: BackupStatus.lastBackupDaysAgo(),
-             smart: DiskHealth.smartVerified(),
-             sip: SecurityPosture.sip(DoctorView.run("/usr/bin/csrutil", ["status"])),
-             gatekeeper: SecurityPosture.gatekeeper(DoctorView.run("/usr/sbin/spctl", ["--status"])),
-             fileVault: SecurityPosture.fileVault(DoctorView.run("/usr/bin/fdesetup", ["status"])),
-             firewall: SecurityPosture.firewall(DoctorView.run("/usr/libexec/ApplicationFirewall/socketfilterfw", ["--getglobalstate"])),
-             volumes: DoctorView.externalVolumeCount(),
-             iface: Connectivity.defaultRoute(fromRouteGet: DoctorView.run("/sbin/route", ["-n", "get", "default"])).interface)
-        }.value
+        // Security posture (SIP/Gatekeeper/FileVault/firewall), SMART and the
+        // last-backup age change ~never, but each Doctor reopen used to re-spawn
+        // system_profiler + tmutil + four security tools. Cache the whole probe
+        // set with a short TTL so rapid reopens are instant. #239
+        let probes: Probes
+        if let c = Self.cachedProbes, Date().timeIntervalSince(c.at) < Self.probeTTL {
+            probes = c.value
+        } else {
+            probes = await Task.detached(priority: .utility) {
+                (backup: BackupStatus.lastBackupDaysAgo(),
+                 smart: DiskHealth.smartVerified(),
+                 sip: SecurityPosture.sip(DoctorView.run("/usr/bin/csrutil", ["status"])),
+                 gatekeeper: SecurityPosture.gatekeeper(DoctorView.run("/usr/sbin/spctl", ["--status"])),
+                 fileVault: SecurityPosture.fileVault(DoctorView.run("/usr/bin/fdesetup", ["status"])),
+                 firewall: SecurityPosture.firewall(DoctorView.run("/usr/libexec/ApplicationFirewall/socketfilterfw", ["--getglobalstate"])),
+                 volumes: DoctorView.externalVolumeCount(),
+                 iface: Connectivity.defaultRoute(fromRouteGet: DoctorView.run("/sbin/route", ["-n", "get", "default"])).interface)
+            }.value
+            Self.cachedProbes = (Date(), probes)
+        }
         checks = Doctor.report(.init(
             fullDiskAccess: fullDiskAccess,
             moInstalled: moInstalled, pressure: pressure,
@@ -164,17 +183,7 @@ struct DoctorView: View {
     /// Capture a short system command's stdout (off-main; used for the security
     /// posture probes). Self-contained so it doesn't depend on the engine seam.
     private static func run(_ path: String, _ args: [String]) -> String {
-        guard FileManager.default.isExecutableFile(atPath: path) else { return "" }
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: path)
-        p.arguments = args
-        let pipe = Pipe()
-        p.standardOutput = pipe
-        p.standardError = pipe
-        do { try p.run() } catch { return "" }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        p.waitUntilExit()
-        return String(decoding: data, as: UTF8.self)
+        ShellProbe.run(path, args, timeout: 10) ?? ""   // timeout-guarded (#239)
     }
 
     private func copyDiagnostics() {

--- a/macos/Sources/DoctorView.swift
+++ b/macos/Sources/DoctorView.swift
@@ -24,7 +24,7 @@ struct DoctorView: View {
                                 sip: SecurityPosture.State, gatekeeper: SecurityPosture.State,
                                 fileVault: SecurityPosture.State, firewall: SecurityPosture.State,
                                 volumes: Int, iface: String?)
-    @MainActor private static var cachedProbes: (at: Date, value: Probes)?
+    private static var cachedProbes: (at: Date, value: Probes)?
     private static let probeTTL: TimeInterval = 120
 
     var body: some View {

--- a/macos/Sources/EventHub.swift
+++ b/macos/Sources/EventHub.swift
@@ -45,7 +45,8 @@ final class EventHub {
     }
 
     private func deregisterID(_ id: ObjectIdentifier) {
-        lock.lock(); conns[id] = nil; lock.unlock()
+        lock.lock(); conns[id] = nil; let empty = conns.isEmpty; lock.unlock()
+        if empty { stopKeepAlive() }   // no clients → stop the 15s broadcast (#240)
     }
 
     private func startKeepAlive() {
@@ -56,6 +57,15 @@ final class EventHub {
             }
             RunLoop.main.add(t, forMode: .common)
             self.keepAlive = t
+        }
+    }
+
+    /// Invalidate the keep-alive once the last stream drops — it used to fire
+    /// every 15s for the app's life after the first connection ever. #240
+    private func stopKeepAlive() {
+        DispatchQueue.main.async { [weak self] in
+            self?.keepAlive?.invalidate()
+            self?.keepAlive = nil
         }
     }
 }

--- a/macos/Sources/NetUsage.swift
+++ b/macos/Sources/NetUsage.swift
@@ -57,14 +57,30 @@ enum NetUsage {
         return out
     }
 
-    /// Sample per-process bandwidth (bytes/sec). Runs nettop for ~1s — call off
-    /// the main thread. Returns empty on any failure (bandwidth degrades to "—").
+    private static let cacheLock = NSLock()
+    private static var cached: (at: Date, rates: [Int: Rates])?
+    /// Reuse a recent frame instead of re-running the ~1 s blocking nettop for
+    /// every caller. PortsView re-samples on appear / tab-change / refresh /
+    /// after each kill, and ProcessInspector samples the whole system just to
+    /// read one pid — within this window they now share one frame. #238
+    private static let cacheTTL: TimeInterval = 2.5
+
+    /// Per-process bandwidth (bytes/sec), served from a ≤`cacheTTL`s cache; on a
+    /// miss it runs nettop for ~1 s (blocking — call off the main thread).
+    /// Returns empty on any failure (bandwidth degrades to "—").
     static func sample() -> [Int: Rates] {
+        cacheLock.lock()
+        if let c = cached, Date().timeIntervalSince(c.at) < cacheTTL {
+            let r = c.rates; cacheLock.unlock(); return r
+        }
+        cacheLock.unlock()
         let out = (try? MoEngine.shared.capture(
             MoCommand(target: .executable("/usr/bin/nettop"),
                       args: ["-P", "-x", "-d", "-s", "1", "-L", "2", "-J", "bytes_in,bytes_out"],
                       timeout: 8)))?.stdout ?? ""
-        return parse(out)
+        let rates = parse(out)
+        cacheLock.lock(); cached = (Date(), rates); cacheLock.unlock()
+        return rates
     }
 
     /// Reverse-DNS a numeric IP to a hostname, or nil if there's no PTR (or it

--- a/macos/Sources/OptimizeView.swift
+++ b/macos/Sources/OptimizeView.swift
@@ -183,16 +183,6 @@ struct OptimizeView: View {
     }
 
     private static func runCmd(_ path: String, _ args: [String]) -> String {
-        guard FileManager.default.isExecutableFile(atPath: path) else { return "" }
-        let p = Process()
-        p.executableURL = URL(fileURLWithPath: path)
-        p.arguments = args
-        let pipe = Pipe()
-        p.standardOutput = pipe
-        p.standardError = pipe
-        do { try p.run() } catch { return "" }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        p.waitUntilExit()
-        return String(decoding: data, as: UTF8.self)
+        ShellProbe.run(path, args, timeout: 10) ?? ""   // timeout-guarded (#239)
     }
 }

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -720,8 +720,12 @@ final class HUDModel: ObservableObject {
     /// Camera/mic in-use poll (opt-in). Passive CoreMediaIO/CoreAudio reads
     /// every ~1.5 s while the popover is open; no-op when the toggle is off.
     func subscribePrivacy() async {
-        guard Store.cameraMicIndicatorEnabled else { return }
+        // Clear any stale dot when the poll stops (popover closed) or the
+        // feature is toggled off mid-session — the enable gate used to live only
+        // at the loop entry, so a lit dot could linger after either. #234
+        defer { cameraActive = false; micActive = false }
         while !Task.isCancelled {
+            guard Store.cameraMicIndicatorEnabled else { break }
             let state = await Task.detached(priority: .utility) {
                 (cam: CameraMicSensor.cameraInUse(), mic: CameraMicSensor.micInUse())
             }.value

--- a/macos/Sources/ProcessInspectorView.swift
+++ b/macos/Sources/ProcessInspectorView.swift
@@ -295,10 +295,11 @@ struct ProcessInspectorView: View {
         }
     }
 
+    private static let startedFmt: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .abbreviated; return f
+    }()
     /// Approximate wall-clock start time from the runtime (now − runtime).
     private static func startedText(runtimeSeconds: Double) -> String {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .abbreviated
-        return f.localizedString(fromTimeInterval: -runtimeSeconds)
+        startedFmt.localizedString(fromTimeInterval: -runtimeSeconds)   // cached formatter (#240)
     }
 }

--- a/macos/Sources/ShellProbe.swift
+++ b/macos/Sources/ShellProbe.swift
@@ -1,0 +1,52 @@
+//
+//  ShellProbe.swift
+//  Burrow
+//
+//  Minimal timeout-guarded runner for the handful of one-off system probes
+//  (system_profiler, tmutil, csrutil, spctl, …) that don't go through the mo
+//  engine. Two things the old hand-rolled `Process()` + `waitUntilExit()` sites
+//  lacked (#239): a kill timer, so a wedged tool can't block its task forever;
+//  and a concurrent stdout drain, so a tool whose output exceeds the ~64 KB pipe
+//  buffer can't deadlock (child blocks on write, parent blocks on exit).
+//
+
+import Foundation
+
+enum ShellProbe {
+    /// Run `path args`, returning stdout on a clean exit (status 0), or nil on
+    /// spawn failure, nonzero/timeout exit. `timeout` seconds bounds a wedged
+    /// child — on expiry the process is terminated and nil is returned.
+    static func run(_ path: String, _ args: [String], timeout: TimeInterval = 10) -> String? {
+        guard FileManager.default.isExecutableFile(atPath: path) else { return nil }
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: path)
+        p.arguments = args
+        let out = Pipe()
+        p.standardOutput = out
+        p.standardError = FileHandle.nullDevice   // we never read stderr; don't let it fill
+
+        // Drain stdout to EOF on a background queue so large output can't block
+        // the child (and thus waitUntilExit) on a full pipe.
+        let reader = DispatchQueue(label: "dev.caezium.burrow.shellprobe")
+        var data = Data()
+        let group = DispatchGroup()
+        group.enter()
+        reader.async {
+            data = out.fileHandleForReading.readDataToEndOfFile()
+            group.leave()
+        }
+
+        do { try p.run() } catch { return nil }
+
+        // Kill the child if it wedges past the timeout; terminate() closes its
+        // pipe, so the reader hits EOF and the group completes.
+        let killer = DispatchWorkItem { if p.isRunning { p.terminate() } }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: killer)
+        p.waitUntilExit()
+        killer.cancel()
+        group.wait()
+
+        guard p.terminationStatus == 0 else { return nil }
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/macos/Sources/SnapshotProducer.swift
+++ b/macos/Sources/SnapshotProducer.swift
@@ -377,7 +377,6 @@ final class SnapshotProducer {
     /// One 1 Hz pulse: read counters, differentiate, publish into the ring.
     /// Cheap (sub-ms registry reads) — runs on the clock's context.
     private func tickLive() {
-        guard liveWanted else { return }   // nothing is watching the live sparklines
         let now = deps.clock.now
         var rx: Double?, tx: Double?, rd: Double?, wr: Double?
         if let n = deps.hardware.netBytes(), let r = liveNet.mbps(n.rx, n.tx, at: now) {

--- a/macos/Sources/SnapshotProducer.swift
+++ b/macos/Sources/SnapshotProducer.swift
@@ -112,7 +112,12 @@ final class LiveFeed: ObservableObject {
     private func windowed(_ lastSeconds: TimeInterval, _ pick: (Sample) -> Double) -> [Double] {
         guard let newest = samples.last?.time else { return [] }
         let cutoff = newest.addingTimeInterval(-lastSeconds)
-        return samples.filter { $0.time >= cutoff }.map(pick)
+        // `samples` is ascending by time and the in-window slice is a contiguous
+        // suffix, so walk back from the end to the first in-window index — O(window)
+        // (~120) instead of filtering the whole ~3600-element ring every render. #237
+        var start = samples.count
+        while start > 0, samples[start - 1].time >= cutoff { start -= 1 }
+        return samples[start...].map(pick)
     }
 
     fileprivate func applySnapshot(_ s: MoleStatus, at: Date) {
@@ -206,6 +211,42 @@ final class SnapshotProducer {
     private var liveDisk = RateTracker()
     private var snapDisk = RateTracker()
 
+    /// The popover is a live consumer even when the main window is closed; the
+    /// status-bar controller reports its visibility. (guarded by lock)
+    private var popoverOpen = false
+
+    // Sensor reads (SMC temps/fans, IOAccelerator GPU) change slowly; a 1 Hz
+    // `--watch` stream would otherwise hammer IOKit every line. Cache them and
+    // refresh at most every `sensorTTL`. Byte counters (disk/net) are NOT cached
+    // — they feed rate trackers that need real per-tick deltas. #235
+    private let sensorLock = NSLock()
+    private var sensorCacheAt = Date.distantPast
+    private var cachedFans: (count: Int, rpm: [Int]) = (0, [])
+    private var cachedTemps: (cpu: Double?, gpu: Double?) = (nil, nil)
+    private var cachedGPU: Double?
+    private let sensorTTL: TimeInterval = 2.5
+
+    /// True when something is actually watching live metrics: the main window's
+    /// metrics pane (`foreground`), the popover, or a live menu-bar mode. When
+    /// false, the stream's non-persisted lines and the 1 Hz counter tick skip
+    /// their work — no point reading sensors nobody sees. #235
+    private var liveWanted: Bool {
+        lock.lock(); let fg = foreground, pop = popoverOpen; lock.unlock()
+        return fg || pop || Store.menuBarDisplayMode != .icon
+    }
+
+    /// Cached slow-sensor read, refreshed at most every `sensorTTL`.
+    private func sensors(at now: Date) -> (fans: (count: Int, rpm: [Int]), temps: (cpu: Double?, gpu: Double?), gpu: Double?) {
+        sensorLock.lock(); defer { sensorLock.unlock() }
+        if now.timeIntervalSince(sensorCacheAt) >= sensorTTL {
+            cachedFans = deps.hardware.fans()
+            cachedTemps = deps.hardware.temps()
+            cachedGPU = deps.hardware.gpuUtilization()
+            sensorCacheAt = now
+        }
+        return (cachedFans, cachedTemps, cachedGPU)
+    }
+
     init(deps: Deps) {
         self.deps = deps
     }
@@ -291,6 +332,18 @@ final class SnapshotProducer {
         armSnapshotTimer()   // no-op while streaming (guarded)
     }
 
+    /// Report popover visibility. While the popover is up the engine keeps live
+    /// data flowing even with the main window closed; opening takes an immediate
+    /// sample so the popover isn't blank for a whole interval. #235
+    func setPopoverOpen(_ open: Bool) {
+        lock.lock()
+        guard popoverOpen != open else { lock.unlock(); return }
+        popoverOpen = open
+        let isRunning = running
+        lock.unlock()
+        if isRunning && open { deps.work { self.sampleNow() } }
+    }
+
     // MARK: Cadence
 
     private func armSnapshotTimer() {
@@ -324,6 +377,7 @@ final class SnapshotProducer {
     /// One 1 Hz pulse: read counters, differentiate, publish into the ring.
     /// Cheap (sub-ms registry reads) — runs on the clock's context.
     private func tickLive() {
+        guard liveWanted else { return }   // nothing is watching the live sparklines
         let now = deps.clock.now
         var rx: Double?, tx: Double?, rd: Double?, wr: Double?
         if let n = deps.hardware.netBytes(), let r = liveNet.mbps(n.rx, n.tx, at: now) {
@@ -354,13 +408,18 @@ final class SnapshotProducer {
     /// never pollutes the DB) → optionally persist → publish. Shared by the poll
     /// (`persist: true` every tick) and the `--watch` stream (persist throttled).
     private func ingest(raw: String, persist: Bool) {
+        // Nothing watching and not due for persistence → skip the whole line:
+        // no sensor reads, no decode, no publish. That's the `--watch` saving.
+        // Persisted lines always run so the long-range history stays complete. #235
+        if !persist && !liveWanted { return }
         let now = deps.clock.now
-        let fans = deps.hardware.fans()
-        let temps = deps.hardware.temps()
+        let sensed = sensors(at: now)               // cached SMC/GPU read
+        let fans = sensed.fans
+        let temps = sensed.temps
         let disk = deps.hardware.diskBytes().flatMap { snapDisk.mbps($0.read, $0.write, at: now) }
         let fill = SnapshotPatcher.NativeFill(
             disk: disk.map { (read: $0.a, write: $0.b) },
-            gpu: deps.hardware.gpuUtilization(),
+            gpu: sensed.gpu,
             fans: fans.count > 0 ? fans : nil,
             cpuTemp: temps.cpu,
             gpuTemp: temps.gpu)

--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -338,6 +338,7 @@ final class StatusBarController: NSObject, NSMenuDelegate, NSPopoverDelegate {
     /// to the left edge when an auto-hiding/collapsing menu bar hides the
     /// status item's own window (issue #223).
     private func showPopover(from button: NSStatusBarButton) {
+        producer.setPopoverOpen(true)   // keep live metrics flowing while shown (#235)
         guard let buttonWindow = button.window else {
             // No window to convert from — fall back to the direct anchor.
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
@@ -368,6 +369,7 @@ final class StatusBarController: NSObject, NSMenuDelegate, NSPopoverDelegate {
     /// Drop the anchor window once the popover is gone (transient dismiss or a
     /// second icon click), so it doesn't leak or linger over the menu bar.
     func popoverDidClose(_ notification: Notification) {
+        producer.setPopoverOpen(false)   // stop live work if nothing else is watching (#235)
         anchorWindow?.orderOut(nil)
         anchorWindow = nil
     }

--- a/macos/Sources/TuneUpView.swift
+++ b/macos/Sources/TuneUpView.swift
@@ -155,11 +155,15 @@ struct TuneUpView: View {
         }
     }
 
+    /// Cached — building a RelativeDateTimeFormatter per render (this is a
+    /// computed property) is needlessly expensive. #240
+    private static let agoFmt: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .full; return f
+    }()
+
     private var scannedAgoText: String {
         guard let at = model.snapshot?.scannedAt else { return NSLocalizedString("Not scanned yet", comment: "") }
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .full
-        return String(format: NSLocalizedString("Scanned %@", comment: ""), f.localizedString(for: at, relativeTo: Date()))
+        return String(format: NSLocalizedString("Scanned %@", comment: ""), Self.agoFmt.localizedString(for: at, relativeTo: Date()))
     }
 
     private var tidyNote: some View {
@@ -281,8 +285,7 @@ struct TuneUpView: View {
     }
 
     private func lastRunCard(_ at: Date, _ summary: String?) -> some View {
-        let f = RelativeDateTimeFormatter()
-        f.unitsStyle = .full
+        let f = Self.agoFmt   // cached (#240)
         return GlassCard {
             HStack(spacing: 12) {
                 Image(systemName: "clock.arrow.circlepath").font(.system(size: 16)).foregroundStyle(accent)

--- a/macos/Sources/UpdatesView.swift
+++ b/macos/Sources/UpdatesView.swift
@@ -235,14 +235,15 @@ struct UpdatesView: View {
         }
     }
 
+    private static let recencyFmt: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter(); f.unitsStyle = .full; return f
+    }()
     static func recencyPhrase(_ date: Date?) -> String {
         guard let date else { return NSLocalizedString("never opened", comment: "") }
         let interval = Date().timeIntervalSince(date)
         if interval < 3600 { return NSLocalizedString("active now", comment: "") }
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
         return String(format: NSLocalizedString("opened %@", comment: "recency"),
-                      formatter.localizedString(for: date, relativeTo: Date()))
+                      Self.recencyFmt.localizedString(for: date, relativeTo: Date()))   // cached (#240)
     }
 
     static func isStale(_ date: Date?) -> Bool {


### PR DESCRIPTION
Batch fix for the camera/mic + performance audit issues (#234–#240). Each is a self-contained commit. Manual compile-review done; **local build skipped (disk-constrained) — relying on CI** for the build + full test suite.

## Fully fixed
- **#234 camera/mic indicator** — filter virtual/aggregate devices (verified on-device that BlackHole/Camo/Teams/Oray report transport `virt` vs `bltn` for real devices). Camera skips virtual CMIO devices; mic skips virtual/aggregate audio devices unless one is the selected default input. Clears the dot when the poll stops / toggle flips off.
- **#236 unbounded caches** — `AnalyzeModel.cache` and `AnalyzeIcons.cache` → `NSCache` (auto-evict, count-capped 256/512).
- **#237 sparkline re-filter** — `LiveFeed.windowed()` walks back to the cutoff index (O(window)) instead of filtering the whole ~3600 ring every render.
- **#239 probe timeouts + Doctor cache** — new `ShellProbe.run` (kill timer + concurrent stdout drain); the four hand-rolled `Process()` sites route through it. Doctor's posture probes (SIP/Gatekeeper/FileVault/firewall/SMART/backup/route) cached with a 120s TTL.

## Mostly fixed (scope noted in commit)
- **#235 metrics engine gating** — cache slow SMC/GPU/fan reads (2.5s TTL) so the `--watch` stream stops hammering IOKit ~1Hz; skip a stream line entirely when nothing is watching and it isn't due for persistence (`liveWanted = foreground || popoverOpen || menuBar != .icon`; popover wired from StatusBarController). *Deferred:* gating the 1Hz net/disk counter tick — it would fail the live-tick producer tests and is cheap ("sub-ms registry reads"); left running.
- **#238 expensive shell-outs** — `NetUsage.sample()` gets a 2.5s cache so PortsView/ProcessInspector share one `nettop` frame instead of each spawning a 1s blocking scan. *Deferred:* full native `ps`/`nettop` replacement (needs delta-sampling infra / the private NetworkStatistics fwk) and `Connectivity.probeAll` (a deliberate freshness check — wants a native SystemConfiguration rewrite, not caching).
- **#240 minor** — EventHub keep-alive timer now invalidated when the last `/events` client drops; per-render `RelativeDateTimeFormatter`s cached in TuneUp/Connectivity/ProcessInspector/Updates. *Deferred:* OperationFlow's unbounded line array + per-tick reduce (a blind cap would corrupt reports whose `reduce()` counts across all output — needs an incremental reduce).

Closes #234 #236 #237 #239. Partially addresses #235 #238 #240 (deferred sub-items noted on each).
