### PR TITLE
fix(menubar): re-pin HUD popover when the menu bar auto-hides after it opens (#223)

### DIFF
--- a/macos/Sources/StatusBarController.swift
+++ b/macos/Sources/StatusBarController.swift
@@ -27,6 +27,14 @@ final class StatusBarController: NSObject, NSMenuDelegate, NSPopoverDelegate {
     /// anchored to that button rides along with it (issue #223). Anchoring to a
     /// window we place and own keeps the popover put. Alive only while shown.
     private var anchorWindow: NSWindow?
+    /// The screen-space frame the anchor was pinned to at show time, so it can be
+    /// re-asserted if the menu bar later collapses (see `screenParamsObserver`).
+    private var anchorFrame: NSRect = .zero
+    /// Fires while the popover is open: an auto-hiding menu bar collapsing
+    /// changes the screen's visibleFrame (a screen-parameters change) and
+    /// reshuffles status-bar-level windows, dragging the anchor — and the popover
+    /// — to the corner. We re-pin and re-position on that event (issue #223).
+    private var screenParamsObserver: NSObjectProtocol?
     private let db: DB
     private let producer: SnapshotProducer
     private weak var delegate: AppDelegate?
@@ -309,6 +317,7 @@ final class StatusBarController: NSObject, NSMenuDelegate, NSPopoverDelegate {
 
     deinit {
         if let o = updateObserver { NotificationCenter.default.removeObserver(o) }
+        if let o = screenParamsObserver { NotificationCenter.default.removeObserver(o) }
         anchorWindow?.orderOut(nil)
         runnerTimer?.cancel()
         // Explicitly remove the item so toggling the menu-bar setting off
@@ -360,9 +369,27 @@ final class StatusBarController: NSObject, NSMenuDelegate, NSPopoverDelegate {
         anchor.contentView = NSView(frame: NSRect(origin: .zero, size: screenFrame.size))
         anchor.orderFrontRegardless()
         self.anchorWindow = anchor
+        self.anchorFrame = screenFrame
 
         if let content = anchor.contentView {
             popover.show(relativeTo: content.bounds, of: content, preferredEdge: .minY)
+        }
+
+        // The show-time pin isn't enough: when the menu bar auto-hides *after*
+        // the popover is up, the resulting screen-parameters change moves/hides
+        // the anchor and NSPopover re-homes to the screen corner. Re-assert the
+        // anchor's frame and re-show (which repositions a visible popover) each
+        // time that fires, so it stays put through reveal/collapse. (#223)
+        if screenParamsObserver == nil {
+            screenParamsObserver = NotificationCenter.default.addObserver(
+                forName: NSApplication.didChangeScreenParametersNotification,
+                object: nil, queue: .main) { [weak self] _ in
+                guard let self, self.popover.isShown,
+                      let anchor = self.anchorWindow, let content = anchor.contentView else { return }
+                anchor.setFrame(self.anchorFrame, display: false)
+                anchor.orderFrontRegardless()
+                self.popover.show(relativeTo: content.bounds, of: content, preferredEdge: .minY)
+            }
         }
     }
 
@@ -370,6 +397,7 @@ final class StatusBarController: NSObject, NSMenuDelegate, NSPopoverDelegate {
     /// second icon click), so it doesn't leak or linger over the menu bar.
     func popoverDidClose(_ notification: Notification) {
         producer.setPopoverOpen(false)   // stop live work if nothing else is watching (#235)
+        if let o = screenParamsObserver { NotificationCenter.default.removeObserver(o); screenParamsObserver = nil }
         anchorWindow?.orderOut(nil)
         anchorWindow = nil
     }


### PR DESCRIPTION
Reopened follow-up to #225/#227. Those pinned the popover at **show** time, which fixed opening it while the menu bar was already hidden — but not the reported repro: with **"Automatically hide and show the menu bar"**, revealing on hover → opening the popover → then letting the bar **collapse** sends the popover to the top-left corner every time.

### Root cause
When the auto-hiding menu bar collapses *after* the popover is already open, the screen's `visibleFrame` changes → macOS posts `didChangeScreenParametersNotification` and reshuffles status-bar-level windows. Our invisible anchor window lives at `.statusBar` level inside that volatile menu-bar strip, so it gets moved/hidden, NSPopover loses its positioning view, and re-homes to the screen corner. The existing fix only captured the anchor position once (at show time); nothing re-pins it on the *later* collapse.

### Fix
Add a `didChangeScreenParametersNotification` observer that's live only while the popover is shown. On each fire it re-asserts the anchor's captured frame, re-orders it front, and re-shows the popover (which repositions an already-visible one) — keeping it pinned through reveal→collapse cycles. Observer is removed on close and in `deinit`.

### ⚠️ Needs on-device verification
I couldn't build or runtime-test this locally (disk-constrained + the repro needs auto-hide menu bar on a real display). Please verify with **System Settings → Control Center → "Automatically hide and show the menu bar" = Always**: open the HUD, move the mouse away so the bar collapses, and confirm the popover stays put. If it still drifts, the anchor likely needs to live *below* the menu-bar line (in the stable content area) rather than being re-pinned in place — I can switch to that approach.
