### PR TITLE
feat(win): BurrowEnvelope — bind the Windows GUI to burrow-cli's result envelope

### DIFF
--- a/windows/Models/BurrowEnvelope.cs
+++ b/windows/Models/BurrowEnvelope.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BurrowWin.Models;
+
+/// <summary>
+/// The unified result envelope that burrow-cli (<c>burrow.exe</c>) writes to stdout
+/// for every command. Success and failure share ONE shape — branch on <see cref="Ok"/>,
+/// then read <see cref="Data"/> (success) or <see cref="Error"/> (failure).
+/// Contract: caezium/burrow-cli#4.
+/// </summary>
+public sealed record BurrowEnvelope
+{
+    [JsonPropertyName("ok")]
+    public bool Ok { get; init; }
+
+    [JsonPropertyName("command")]
+    public string? Command { get; init; }
+
+    [JsonPropertyName("burrow_cli")]
+    public string? BurrowCli { get; init; }
+
+    /// <summary>The engine payload on success (absent/undefined on failure).</summary>
+    [JsonPropertyName("data")]
+    public JsonElement Data { get; init; }
+
+    /// <summary>The error message on failure (null on success).</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    /// <summary>
+    /// Parse <c>burrow.exe</c> stdout into an envelope.
+    /// Throws <see cref="JsonException"/> on non-JSON / empty output.
+    /// </summary>
+    public static BurrowEnvelope Parse(string stdout)
+        => JsonSerializer.Deserialize<BurrowEnvelope>(stdout, Options)
+           ?? throw new JsonException("empty burrow envelope");
+}

--- a/windows/Models/BurrowEnvelope.cs
+++ b/windows/Models/BurrowEnvelope.cs
@@ -24,9 +24,9 @@ public sealed record BurrowEnvelope
     [JsonPropertyName("data")]
     public JsonElement Data { get; init; }
 
-    /// <summary>The error message on failure (null on success).</summary>
+    /// <summary>The structured error on failure (null on success): kind + message + platform.</summary>
     [JsonPropertyName("error")]
-    public string? Error { get; init; }
+    public BurrowError? Error { get; init; }
 
     private static readonly JsonSerializerOptions Options = new()
     {
@@ -40,4 +40,22 @@ public sealed record BurrowEnvelope
     public static BurrowEnvelope Parse(string stdout)
         => JsonSerializer.Deserialize<BurrowEnvelope>(stdout, Options)
            ?? throw new JsonException("empty burrow envelope");
+}
+
+/// <summary>
+/// The structured error payload on a failure envelope (burrow-cli#4): a
+/// machine-readable <see cref="Kind"/> (permission_denied / unsupported / not_found /
+/// process_failed / error), the human <see cref="Message"/>, and the
+/// <see cref="Platform"/> it occurred on.
+/// </summary>
+public sealed record BurrowError
+{
+    [JsonPropertyName("kind")]
+    public string? Kind { get; init; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    [JsonPropertyName("platform")]
+    public string? Platform { get; init; }
 }

--- a/windows/Tests/BurrowWin.Tests/BurrowEnvelopeTests.cs
+++ b/windows/Tests/BurrowWin.Tests/BurrowEnvelopeTests.cs
@@ -24,10 +24,12 @@ public sealed class BurrowEnvelopeTests
     public void Parses_Failure_With_Error_And_No_Data()
     {
         var e = BurrowEnvelope.Parse(
-            """{"ok":false,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"uninstall","error":"needs an app"}""");
+            """{"ok":false,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"uninstall","error":{"kind":"not_found","message":"needs an app","platform":"macos"}}""");
 
         Assert.False(e.Ok);
         Assert.Equal("uninstall", e.Command);
-        Assert.Equal("needs an app", e.Error);
+        Assert.Equal("not_found", e.Error?.Kind);
+        Assert.Equal("needs an app", e.Error?.Message);
+        Assert.Equal("macos", e.Error?.Platform);
     }
 }

--- a/windows/Tests/BurrowWin.Tests/BurrowEnvelopeTests.cs
+++ b/windows/Tests/BurrowWin.Tests/BurrowEnvelopeTests.cs
@@ -1,0 +1,33 @@
+using BurrowWin.Models;
+using Xunit;
+
+namespace BurrowWin.Tests;
+
+// Binds the Windows GUI to burrow-cli's unified result envelope (caezium/burrow-cli#4):
+// one shape per call, branch on `ok`. Mirrors the burrow-cli-side tests.
+// NOTE: authored without a local .NET/Windows toolchain — verified on CI only.
+public sealed class BurrowEnvelopeTests
+{
+    [Fact]
+    public void Parses_Success_And_Branches_On_Ok()
+    {
+        var e = BurrowEnvelope.Parse(
+            """{"ok":true,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"status","data":{"health_score":92}}""");
+
+        Assert.True(e.Ok);
+        Assert.Equal("status", e.Command);
+        Assert.Equal(92, e.Data.GetProperty("health_score").GetInt32());
+        Assert.Null(e.Error);
+    }
+
+    [Fact]
+    public void Parses_Failure_With_Error_And_No_Data()
+    {
+        var e = BurrowEnvelope.Parse(
+            """{"ok":false,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"uninstall","error":"needs an app"}""");
+
+        Assert.False(e.Ok);
+        Assert.Equal("uninstall", e.Command);
+        Assert.Equal("needs an app", e.Error);
+    }
+}

--- a/windows/Tests/BurrowWin.Tests/BurrowWin.Tests.csproj
+++ b/windows/Tests/BurrowWin.Tests/BurrowWin.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\Models\CleanupPreviewItem.cs" Link="Production\Models\CleanupPreviewItem.cs" />
+    <Compile Include="..\..\Models\BurrowEnvelope.cs" Link="Production\Models\BurrowEnvelope.cs" />
     <Compile Include="..\..\Models\BurrowSettings.cs" Link="Production\Models\BurrowSettings.cs" />
     <Compile Include="..\..\Models\DiskAnalysisOptions.cs" Link="Production\Models\DiskAnalysisOptions.cs" />
     <Compile Include="..\..\Models\DiskTreemapRect.cs" Link="Production\Models\DiskTreemapRect.cs" />


### PR DESCRIPTION
Parallel GUI half of the burrow-cli migration (companion to **caezium/burrow-cli#4**, tracked by burrow-cli#1).

Adds a plain-C# `BurrowEnvelope.Parse()` that reads `burrow.exe`'s **unified stdout envelope** — one shape per call: `{ok, burrow_cli, engine, command, data|error}` — so the Windows GUI branches on `ok`, then reads `data` or `error`. xUnit tests mirror the burrow-cli-side contract tests (success + failure). Additive: two new files + one `<Compile Include>` in the test csproj.

⚠️ **Verified on CI only** — authored without a local .NET/Windows toolchain (no `dotnet`; the test project targets `net8.0-windows`), per the agreed plan. Please let the Windows CI matrix confirm it builds + the two facts pass.

Next slice: point `IMoleEngineService`/`MoleEngineService` at `burrow.exe` and map `ExecuteAsync` results through `BurrowEnvelope`.