### PR TITLE
feat(macos): route capture commands + opt-in streaming clean/optimize through the conductor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,28 @@ jobs:
             echo "::warning::burrow-engine unavailable — set ENGINE_PAT or make it public. Shipping WITHOUT the bundled engine; app falls back to system \`mo\`."
           fi
 
+      # Fetch the FSL `burrow` conductor at its pinned submodule commit, beside the
+      # engine (RUNNER_TEMP). Same NON-FATAL contract: without it the app falls back to
+      # the direct engine. Reuses ENGINE_PAT for the clone (same org); the bundle phase
+      # (bundle-burrow.sh) cargo-builds it universal from BURROW_CLI_SRC. macOS runners
+      # ship a Rust toolchain; the script adds the x86_64 cross target itself.
+      - name: Fetch bundled burrow conductor (outside the work tree)
+        env:
+          ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
+        run: |
+          SHA="$(git ls-tree HEAD macos/vendor/burrow-cli | awk '{print $3}')"
+          DEST="$RUNNER_TEMP/burrow-cli"
+          AUTH=()
+          [ -n "$ENGINE_PAT" ] && AUTH=(-c "url.https://x-access-token:${ENGINE_PAT}@github.com/.insteadOf=https://github.com/")
+          if [ -n "$SHA" ] \
+             && git "${AUTH[@]}" clone --quiet https://github.com/caezium/burrow-cli.git "$DEST" \
+             && git -C "$DEST" -c advice.detachedHead=false checkout --quiet "$SHA"; then
+            echo "BURROW_CLI_SRC=$DEST" >> "$GITHUB_ENV"
+            echo "burrow: cloned to $DEST @ ${SHA:0:7}"
+          else
+            echo "::warning::burrow-cli unavailable — shipping WITHOUT the bundled conductor; app falls back to the direct engine."
+          fi
+
       # Pin a Go that satisfies the engine's go.mod (>= 1.25) for the bundle
       # phase's `go build`. Harmless when the engine isn't fetched.
       - name: Set up Go (for the bundled engine)
@@ -181,6 +203,9 @@ jobs:
                     if file -b "$f" | grep -q 'Mach-O'; then codesign --force --sign - "$f"; fi
                   done
             fi
+            # The FSL `burrow` conductor (Resources/burrow) is a sibling nested Mach-O —
+            # re-sign it inside-out too, or the app's resource seal goes stale (#177).
+            if [ -f "$APP/Contents/Resources/burrow" ]; then codesign --force --sign - "$APP/Contents/Resources/burrow"; fi
             codesign --force --sign - --entitlements macos/Resources/Burrow.entitlements "$APP"
             codesign --verify --strict --verbose=2 "$APP"
             echo "signed=false" >> "$GITHUB_OUTPUT"
@@ -219,6 +244,11 @@ jobs:
                     codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$f"
                   fi
                 done
+          fi
+          # The FSL `burrow` conductor (Resources/burrow) is a sibling nested Mach-O — it
+          # needs Developer ID + hardened runtime + secure timestamp too, or notarization rejects.
+          if [ -f "$APP/Contents/Resources/burrow" ]; then
+            codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP/Contents/Resources/burrow"
           fi
           # Hardened runtime + secure timestamp are required for notarization.
           codesign --force --options runtime --timestamp \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "macos/vendor/burrow-engine"]
 	path = macos/vendor/burrow-engine
 	url = https://github.com/caezium/burrow-engine.git
+[submodule "macos/vendor/burrow-cli"]
+	path = macos/vendor/burrow-cli
+	url = https://github.com/caezium/burrow-cli.git

--- a/macos/Sources/AnalyzeProgress.swift
+++ b/macos/Sources/AnalyzeProgress.swift
@@ -1,0 +1,62 @@
+//
+//  AnalyzeProgress.swift
+//  Burrow
+//
+//  Parser for `burrow analyze --progress` — the engine's live scan feed. The stream is NDJSON:
+//  `{type:progress,files,dirs,bytes,path}` per tick during the concurrent walk, then a terminal
+//  `{type:result,data:<analysis>}` whose `data` is exactly what `analyze --json` returns.
+//
+//  This is the PURE, unit-tested core for a live-filling treemap (#12): a streaming reader maps
+//  each line through `parse`, drives a progress indicator off `.progress`, and hands `.result`'s
+//  bytes to `DiskScanner.parse`. Kept dependency-free + testable so the reader and the UI rework
+//  (which restructures AnalyzeView's currently-synchronous scan flow) can be built on a verified base.
+//
+
+import Foundation
+
+enum AnalyzeProgressEvent: Equatable {
+    /// A live counter tick during the scan.
+    case progress(files: Int, dirs: Int, bytes: Int64, path: String)
+    /// The terminal event: the analysis payload as raw bytes (same shape as `analyze --json`),
+    /// ready for `DiskScanner.parse`.
+    case result(Data)
+
+    /// Parse one NDJSON line. Returns nil for blank lines and unknown/forward-compatible `type`s
+    /// so the reader tolerates keep-alive blanks and new event kinds without breaking.
+    static func parse(line: String) -> AnalyzeProgressEvent? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let data = trimmed.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = obj["type"] as? String else { return nil }
+
+        switch type {
+        case "progress":
+            return .progress(
+                files: Self.int(obj["files"]),
+                dirs: Self.int(obj["dirs"]),
+                bytes: Self.int64(obj["bytes"]),
+                path: obj["path"] as? String ?? "")
+        case "result":
+            // Re-serialize the payload so DiskScanner.parse reads exactly what analyze --json emits.
+            guard let payload = obj["data"],
+                  let bytes = try? JSONSerialization.data(withJSONObject: payload) else { return nil }
+            return .result(bytes)
+        default:
+            return nil
+        }
+    }
+
+    private static func int(_ v: Any?) -> Int {
+        if let i = v as? Int { return i }
+        if let d = v as? Double { return Int(d) }
+        return 0
+    }
+
+    private static func int64(_ v: Any?) -> Int64 {
+        if let i = v as? Int64 { return i }
+        if let i = v as? Int { return Int64(i) }
+        if let d = v as? Double { return Int64(d) }
+        return 0
+    }
+}

--- a/macos/Sources/AnalyzeView.swift
+++ b/macos/Sources/AnalyzeView.swift
@@ -542,12 +542,73 @@ final class AnalyzeModel: ObservableObject {
     /// every child's walk pre-warms the drill-down cache. Bushier
     /// targets (drilling into node_modules…) fall back to mole's single
     /// aggregate call rather than spawning hundreds of processes.
+    /// Stream `burrow analyze --progress <path>`: the engine's live file counters drive
+    /// `onProgress`, and the terminal result parses like `analyze --json`. Synchronous (runs on the
+    /// scan's background queue), reusing the TDD'd AnalyzeProgressEvent parser. Throws on cancel /
+    /// spawn failure / no result so the caller can fall back to the direct walk.
+    nonisolated static func scanStreaming(
+        _ path: String,
+        isCancelled: @escaping () -> Bool = { false },
+        onProgress: @escaping (String, Int, Int) -> Void
+    ) throws -> DiskScanResult {
+        guard let burrow = BurrowConductor.executableURL() else { throw DiskScanError.moNotFound }
+        let proc = Process()
+        proc.executableURL = burrow
+        proc.arguments = ["analyze", "--progress", path]
+        var env = Foundation.ProcessInfo.processInfo.environment
+        if let dir = BurrowConductor.engineDir() { env["BURROW_ENGINE_DIR"] = dir.path }
+        proc.environment = env
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = Pipe()   // discard the human-readable line on stderr
+        try proc.run()
+
+        let handle = out.fileHandleForReading
+        var pending = Data()
+        var resultData: Data?
+        while true {
+            if isCancelled() { proc.terminate(); throw DiskScanError.parseFailed("cancelled") }
+            let chunk = handle.availableData
+            if chunk.isEmpty { break }                       // EOF: engine closed stdout
+            pending.append(chunk)
+            while let newline = pending.firstIndex(of: 0x0A) {
+                let lineData = pending.subdata(in: pending.startIndex..<newline)
+                pending.removeSubrange(pending.startIndex...newline)
+                guard let line = String(data: lineData, encoding: .utf8),
+                      let event = AnalyzeProgressEvent.parse(line: line) else { continue }
+                switch event {
+                case .progress(let files, _, _, let scanned):
+                    onProgress(scanned, files, max(files, 1))   // path + running file count
+                case .result(let data):
+                    resultData = data
+                }
+            }
+        }
+        proc.waitUntilExit()
+        // A final result line that arrived without a trailing newline.
+        if resultData == nil, let line = String(data: pending, encoding: .utf8),
+           case .result(let data)? = AnalyzeProgressEvent.parse(line: line) {
+            resultData = data
+        }
+        guard let data = resultData else {
+            throw DiskScanError.parseFailed("analyze --progress produced no result")
+        }
+        return try DiskScanner.parse(data)
+    }
+
     nonisolated static func scanWithProgress(
         _ path: String,
         isCancelled: @escaping () -> Bool = { false },
         onProgress: @escaping (String, Int, Int) -> Void,
         cacheChild: @escaping (String, DiskScanResult) -> Void
     ) throws -> DiskScanResult {
+        // Opt-in live-filling treemap: stream `burrow analyze --progress` so the scan reports the
+        // engine's file-level counters. Any miss (flag off, no conductor, stream failure) falls
+        // through to the two-level per-child walk below, so behavior is unchanged by default.
+        if BurrowConductor.streamingAnalyzeEnabled, BurrowConductor.isAvailable,
+           let streamed = try? Self.scanStreaming(path, isCancelled: isCancelled, onProgress: onProgress) {
+            return streamed
+        }
         let fm = FileManager.default
         // The per-child walk is what emits "● <child> · k/N" progress, so it
         // must also run for Home (which carries dozens of entries once dotfiles

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -58,6 +58,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             return
         }
 
+        // Point the bundled `burrow` conductor at the bundled engine ONCE, so every conductor
+        // spawn (capture + streaming) resolves it without per-call env plumbing. Only when a
+        // conductor+engine are bundled and no override is already present (respects a dev's
+        // BURROW_ENGINE_DIR). Foundation-qualified: Burrow has its own ProcessInfo model.
+        if let engineDir = BurrowConductor.engineDir(),
+           Foundation.ProcessInfo.processInfo.environment["BURROW_ENGINE_DIR"] == nil {
+            setenv("BURROW_ENGINE_DIR", engineDir.path, 1)
+        }
+
         // Product analytics + crash reporting (PostHog + Sentry). Opt-out, on
         // by default, and inert without release-injected keys. Started before
         // the `mo` gate so a launch with the engine missing still counts.

--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -99,6 +99,46 @@ enum BurrowConductor {
         }
         return envelope
     }
+
+    // MARK: - Streaming clean/optimize (opt-in)
+
+    /// Opt-in switch for routing streaming clean/optimize through the conductor. Default OFF: this
+    /// is a DESTRUCTIVE path that can't be exercised in CI, so it stays behind a switch until it's
+    /// hand-tested on a real build. Flip with:
+    ///   `defaults write dev.caezium.Burrow BurrowStreamViaConductor -bool YES`
+    static var streamingEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "BurrowStreamViaConductor")
+    }
+
+    /// The streamable engine commands the conductor forwards with `--stream`. purge/installer are
+    /// an interactive TUI (PTY) and uninstall is irreversible + matcher-gated — those stay direct.
+    private static let streamableCommands: Set<String> = ["clean", "optimize"]
+
+    /// Translate a `mo` streaming argv into the conductor equivalent. `mo` runs LIVE by default and
+    /// `--dry-run` previews; burrow INVERTS that (dry-run by default, `--apply` to execute). So we
+    /// drop `--dry-run` (preview → burrow's default) or add `--apply` (live), then force `--stream`
+    /// so the engine's output flows line-by-line through the pipe instead of one buffered envelope.
+    /// Pure + unit-tested — the semantic mapping is the safety-critical part, so it's verified.
+    static func streamArgv(fromMo moArgs: [String]) -> [String] {
+        let isPreview = moArgs.contains("--dry-run")
+        var out = moArgs.filter { $0 != "--dry-run" }
+        if !isPreview { out.append("--apply") }   // mo-live → burrow needs --apply
+        out.append("--stream")
+        return out
+    }
+
+    /// When the switch is on AND a conductor is bundled AND this is a non-elevated streamable
+    /// command, the (burrow path, translated argv) to spawn instead of `mo`. Otherwise nil, so the
+    /// caller keeps the direct-engine path UNCHANGED. Elevated runs (osascript, fresh env that
+    /// wouldn't inherit BURROW_ENGINE_DIR) deliberately stay on `mo`.
+    static func streamOverride(moArgs: [String], elevated: Bool) -> (executable: String, arguments: [String])? {
+        guard streamingEnabled,
+              !elevated,
+              let command = moArgs.first,
+              streamableCommands.contains(command),
+              let burrow = executableURL()?.path else { return nil }
+        return (burrow, streamArgv(fromMo: moArgs))
+    }
 }
 
 /// Why a conductor run couldn't produce a usable success envelope.

--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -1,0 +1,118 @@
+//
+//  BurrowConductor.swift
+//  Burrow
+//
+//  Runs the bundled `burrow` CONDUCTOR (caezium/burrow-cli) and returns parsed envelopes.
+//  The conductor wraps the engine with the stable Burrow contract — one JSON envelope per
+//  command, NDJSON streaming for progress — so the GUI parses ONE shape instead of each call
+//  site re-implementing "spawn the engine → parse its output".
+//
+//  Resolution: the conductor ships beside the engine in the app bundle (Resources/burrow, from
+//  bundle-burrow.sh); we point it at the sibling-bundled engine via BURROW_ENGINE_DIR. Spawning
+//  reuses the tested capture stack (MoEngine + MoleProcess) via a `.executable(path)` target —
+//  no new process plumbing. When the conductor isn't bundled (dev/CI builds without the
+//  vendor/burrow-cli submodule) `isAvailable` is false and callers fall back to the direct engine.
+//
+
+import Foundation
+
+enum BurrowConductor {
+
+    // MARK: - Resolution
+
+    /// The bundled conductor binary, or nil if this build didn't ship one — callers then fall
+    /// back to the direct engine (MoEngine).
+    static func executableURL() -> URL? {
+        guard let res = Bundle.main.resourceURL else { return nil }
+        let burrow = res.appendingPathComponent("burrow")
+        return FileManager.default.isExecutableFile(atPath: burrow.path) ? burrow : nil
+    }
+
+    /// The bundled engine directory the conductor should target (Resources/engine, from
+    /// bundle-engine.sh), or nil if the engine isn't bundled either.
+    static func engineDir() -> URL? {
+        guard let res = Bundle.main.resourceURL else { return nil }
+        let dir = res.appendingPathComponent("engine")
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: dir.path, isDirectory: &isDir)
+        return (exists && isDir.boolValue) ? dir : nil
+    }
+
+    /// True when a bundled conductor is present. Call sites branch on this to decide between the
+    /// conductor path and the legacy direct-engine path.
+    static var isAvailable: Bool { executableURL() != nil }
+
+    // MARK: - Pure command shaping (unit-tested)
+
+    /// The argv a JSON one-shot is invoked with: `<command> [args…] --json`. `--json` forces the
+    /// stable envelope even when stdout is a TTY.
+    static func argv(command: String, args: [String]) -> [String] {
+        [command] + args + ["--json"]
+    }
+
+    /// The environment for a conductor run: the inherited environment plus BURROW_ENGINE_DIR
+    /// pointing at the bundled engine (the conductor otherwise walks up looking for a sibling
+    /// `burrow-engine/`, which the app layout — Resources/engine — deliberately doesn't match).
+    static func environment(engineDir: URL?) -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        if let dir = engineDir { env["BURROW_ENGINE_DIR"] = dir.path }
+        return env
+    }
+
+    // MARK: - Capture (one-shot JSON commands)
+
+    /// Run `burrow <command> [args…] --json` and return the parsed success envelope. Reuses the
+    /// tested capture runner (timeout + Captured result) by targeting the conductor's exact path.
+    /// Throws `BurrowConductorError.notBundled` when no conductor is bundled, or `.engine(kind:
+    /// message:)` on a timeout, an empty/garbled response, or an `ok:false` envelope — carrying
+    /// the conductor's classified error kind so the UI can react (permissions vs unavailable vs …).
+    static func capture(_ command: String,
+                        _ args: [String] = [],
+                        timeout: TimeInterval = 300,
+                        engine: MoEngine = .shared) throws -> BurrowEnvelope {
+        guard let exe = executableURL() else { throw BurrowConductorError.notBundled }
+        let cmd = MoCommand(
+            target: .executable(exe.path),
+            args: argv(command: command, args: args),
+            environment: environment(engineDir: engineDir()),
+            timeout: timeout)
+        let result = try engine.capture(cmd)
+
+        // A timeout or missing binary degrades to a nonzero exit with no stdout (the capture
+        // runner never throws for those) — surface it before we try to parse an empty string.
+        guard !result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            if result.timedOut {
+                throw BurrowConductorError.engine(kind: "process_failed",
+                                                  message: "burrow \(command) timed out")
+            }
+            throw BurrowConductorError.engine(kind: "process_failed",
+                                              message: "burrow \(command) produced no output (exit \(result.exitCode))")
+        }
+
+        let envelope = try BurrowEnvelope.parse(result.stdout)
+        if !envelope.ok {
+            throw BurrowConductorError.engine(
+                kind: envelope.error?.kind ?? "error",
+                message: envelope.error?.message ?? "burrow \(command) failed")
+        }
+        return envelope
+    }
+}
+
+/// Why a conductor run couldn't produce a usable success envelope.
+enum BurrowConductorError: Error, LocalizedError {
+    /// No `burrow` binary is bundled — the caller should fall back to the direct engine.
+    case notBundled
+    /// The conductor ran but reported (or amounted to) a failure; `kind` is the classified
+    /// reason from the envelope (permission_denied | unsupported | not_found | process_failed | error).
+    case engine(kind: String, message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notBundled:
+            return "the bundled burrow conductor is unavailable"
+        case .engine(let kind, let message):
+            return "\(message) [\(kind)]"
+        }
+    }
+}

--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -54,7 +54,9 @@ enum BurrowConductor {
     /// pointing at the bundled engine (the conductor otherwise walks up looking for a sibling
     /// `burrow-engine/`, which the app layout — Resources/engine — deliberately doesn't match).
     static func environment(engineDir: URL?) -> [String: String] {
-        var env = ProcessInfo.processInfo.environment
+        // Fully qualified: the Burrow module has its own `ProcessInfo` (a status model), which
+        // would otherwise shadow Foundation's here.
+        var env = Foundation.ProcessInfo.processInfo.environment
         if let dir = engineDir { env["BURROW_ENGINE_DIR"] = dir.path }
         return env
     }

--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -110,6 +110,15 @@ enum BurrowConductor {
         UserDefaults.standard.bool(forKey: "BurrowStreamViaConductor")
     }
 
+    /// Opt-in switch for the live-filling treemap: stream `analyze --progress` so a scan reports
+    /// the engine's file-level counters. Default OFF — it reworks AnalyzeView's scan flow +
+    /// progress granularity and can't be validated in CI. Read-only (no data risk), but gated so
+    /// the UX change is opt-in. Flip with:
+    ///   `defaults write dev.caezium.Burrow BurrowStreamAnalyze -bool YES`
+    static var streamingAnalyzeEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "BurrowStreamAnalyze")
+    }
+
     /// The streamable engine commands the conductor forwards with `--stream`. purge/installer are
     /// an interactive TUI (PTY) and uninstall is irreversible + matcher-gated — those stay direct.
     private static let streamableCommands: Set<String> = ["clean", "optimize"]

--- a/macos/Sources/BurrowEnvelope.swift
+++ b/macos/Sources/BurrowEnvelope.swift
@@ -1,0 +1,79 @@
+//
+//  BurrowEnvelope.swift
+//  Burrow
+//
+//  The stable Burrow conductor envelope. Every `burrow <cmd> --json` response is ONE of
+//  these: success carries `data` (the engine's JSON payload, verbatim), failure carries a
+//  classified `error`. Consumers branch on a single top-level `ok` — one shape for every
+//  command, regardless of which engine served it. Mirrors burrow-cli's src/output.rs
+//  (caezium/burrow-cli#4) and the Windows BurrowEnvelope (#248).
+//
+//  Parsed with JSONSerialization (like DiskScanner / MoleHistory), not Codable: the engine's
+//  `data` must round-trip to the command's own decoder WITHOUT the integer-vs-float precision
+//  a Codable `Double` bridge would blur (health_score 92 must stay 92, not become 92.0).
+//
+
+import Foundation
+
+struct BurrowEnvelope {
+    let ok: Bool
+    let command: String?
+    let burrowCli: String?
+    /// The engine payload on success, as raw JSON bytes for the command's own decoder
+    /// (JSONDecoder<MoleStatus>, DiskScanner.parse, …). nil on failure.
+    let data: Data?
+    /// The classified reason on failure. nil on success.
+    let error: BurrowError?
+
+    struct BurrowError {
+        /// permission_denied | unsupported | not_found | process_failed | error
+        let kind: String?
+        let message: String?
+        let platform: String?
+        /// The unavailable feature, set when kind == "unsupported".
+        let feature: String?
+    }
+
+    enum ParseError: Error, LocalizedError {
+        case notJSON
+        case notAnObject
+        var errorDescription: String? {
+            switch self {
+            case .notJSON: return "burrow output was not valid JSON"
+            case .notAnObject: return "burrow envelope was not a JSON object"
+            }
+        }
+    }
+
+    /// Parse one conductor envelope. Throws if the output isn't a JSON object; otherwise
+    /// returns the envelope to branch on via `.ok`. Does NOT throw on `ok:false` — that is a
+    /// valid envelope the caller inspects through `.error`.
+    static func parse(_ stdout: String) throws -> BurrowEnvelope {
+        guard let raw = stdout.data(using: .utf8) else { throw ParseError.notJSON }
+        let obj: Any
+        do { obj = try JSONSerialization.jsonObject(with: raw) }
+        catch { throw ParseError.notJSON }
+        guard let dict = obj as? [String: Any] else { throw ParseError.notAnObject }
+
+        // Re-serialize the `data` subtree back to bytes so the command's concrete decoder reads
+        // exactly what the engine emitted (JSONSerialization preserves int-vs-float).
+        var dataBytes: Data?
+        if let d = dict["data"], !(d is NSNull) {
+            dataBytes = try? JSONSerialization.data(withJSONObject: d)
+        }
+        var err: BurrowError?
+        if let e = dict["error"] as? [String: Any] {
+            err = BurrowError(
+                kind: e["kind"] as? String,
+                message: e["message"] as? String,
+                platform: e["platform"] as? String,
+                feature: dict["feature"] as? String)   // sibling of `error`, per the contract
+        }
+        return BurrowEnvelope(
+            ok: dict["ok"] as? Bool ?? false,
+            command: dict["command"] as? String,
+            burrowCli: dict["burrow_cli"] as? String,
+            data: dataBytes,
+            error: err)
+    }
+}

--- a/macos/Sources/DiskScanner.swift
+++ b/macos/Sources/DiskScanner.swift
@@ -77,6 +77,14 @@ enum DiskScanner {
     /// for each direct child; drill in by calling again with the child's
     /// path.
     static func scan(_ path: String) throws -> DiskScanResult {
+        // Prefer the bundled conductor: `burrow analyze --json <path>` runs the bundled engine,
+        // so disk analysis works even with NO system `mo` installed (the hard requirement just
+        // below). The envelope's `data` is the same analyze-go JSON, so `parse` is unchanged; any
+        // conductor miss (not bundled, engine error, empty/garbled) falls through to the direct
+        // engine, so behavior is never worse than before.
+        if BurrowConductor.isAvailable, let viaConductor = try? conductorScan(path) {
+            return viaConductor
+        }
         guard case .installed = MoEngine.shared.availability() else {
             throw DiskScanError.moNotFound
         }
@@ -93,6 +101,17 @@ enum DiskScanner {
         }
         guard let data = result.stdout.data(using: .utf8) else {
             throw DiskScanError.parseFailed("non-utf8 stdout")
+        }
+        return try Self.parse(data)
+    }
+
+    /// Scan via the bundled conductor (`burrow analyze --json <path>`). Throws on any miss —
+    /// not bundled, timeout, an `ok:false` envelope, or no `data` — so `scan` can fall back to
+    /// the direct engine. The `data` payload is the same analyze-go JSON, decoded by `parse`.
+    private static func conductorScan(_ path: String) throws -> DiskScanResult {
+        let envelope = try BurrowConductor.capture("analyze", [path], timeout: 300)
+        guard let data = envelope.data else {
+            throw DiskScanError.parseFailed("conductor returned an envelope with no data")
         }
         return try Self.parse(data)
     }

--- a/macos/Sources/MoleHistory.swift
+++ b/macos/Sources/MoleHistory.swift
@@ -50,6 +50,13 @@ enum MoleHistory {
 
     /// Run `mo history --json` and parse it. Synchronous — call off-main.
     static func load() -> [HistorySession] {
+        // Prefer the bundled conductor (burrow history --json); its envelope `data` is the same
+        // history JSON. Fall back to the direct engine on any miss.
+        if BurrowConductor.isAvailable,
+           let envelope = try? BurrowConductor.capture("history", timeout: 30),
+           let data = envelope.data {
+            return parse(data)
+        }
         guard let res = try? MoEngine.shared.capture(
                 MoCommand(target: .mo, args: ["history", "--json"], timeout: 30)),
               res.exitCode == 0,

--- a/macos/Sources/OperationFlow.swift
+++ b/macos/Sources/OperationFlow.swift
@@ -176,8 +176,19 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         }
 
         let exe: String?
+        var arguments = op.arguments
         switch op.executable {
-        case .mo: exe = resolveMo(op.elevated)
+        case .mo:
+            // Opt-in: route non-elevated streaming clean/optimize through the bundled conductor
+            // (`burrow … --stream`), which forwards the engine's live output line-by-line. When the
+            // switch is off / no conductor is bundled, `streamOverride` returns nil and the direct
+            // `mo` path below is byte-identical to before.
+            if let conductorRun = BurrowConductor.streamOverride(moArgs: op.arguments, elevated: op.elevated) {
+                exe = conductorRun.executable
+                arguments = conductorRun.arguments
+            } else {
+                exe = resolveMo(op.elevated)
+            }
         case .path(let p): exe = p
         }
         guard let executable = exe else {
@@ -186,7 +197,7 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
             return
         }
 
-        let spec = ProcessSpec(executable: executable, arguments: op.arguments,
+        let spec = ProcessSpec(executable: executable, arguments: arguments,
                                stdin: op.stdin, elevated: op.elevated, timeout: op.timeout)
         state = .running
         report = nil

--- a/macos/Sources/SnapshotProducer.swift
+++ b/macos/Sources/SnapshotProducer.swift
@@ -481,6 +481,15 @@ final class SnapshotProducer {
 /// or nonzero exit so the engine's failure model stays "skip this tick".
 struct MoCLIStatusSource: StatusSource {
     func statusJSON() throws -> String {
+        // Prefer the bundled conductor (burrow status --json): its envelope `data` is the same
+        // status JSON the snapshot pipeline decodes + patches, and it runs the bundled engine
+        // (no system mo needed). Fall back to the direct engine on any miss.
+        if BurrowConductor.isAvailable,
+           let envelope = try? BurrowConductor.capture("status", timeout: 8),
+           let data = envelope.data,
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
         let result = try MoEngine.shared.capture(
             MoCommand(target: .mo, args: ["status", "--json"], timeout: 8))
         guard result.exitCode == 0 else {

--- a/macos/Tests/AnalyzeProgressTests.swift
+++ b/macos/Tests/AnalyzeProgressTests.swift
@@ -1,0 +1,45 @@
+//
+//  AnalyzeProgressTests.swift
+//  BurrowTests
+//
+//  Pins the `burrow analyze --progress` NDJSON parse — the verified core a live-filling treemap
+//  (#12) builds on. The stream reader + UI rework aren't here (that restructures AnalyzeView's
+//  synchronous scan flow and can't be CI-driven); these cover the pure parsing it depends on.
+//
+
+import XCTest
+@testable import Burrow
+
+final class AnalyzeProgressTests: XCTestCase {
+
+    func testParsesProgressTick() {
+        let event = AnalyzeProgressEvent.parse(
+            line: #"{"type":"progress","files":10,"dirs":2,"bytes":4096,"path":"/x"}"#)
+        XCTAssertEqual(event, .progress(files: 10, dirs: 2, bytes: 4096, path: "/x"))
+    }
+
+    func testProgressToleratesMissingCounters() {
+        // A tick missing a counter defaults it to 0 rather than dropping the whole event.
+        let event = AnalyzeProgressEvent.parse(line: #"{"type":"progress","files":5}"#)
+        XCTAssertEqual(event, .progress(files: 5, dirs: 0, bytes: 0, path: ""))
+    }
+
+    func testResultCarriesAnalysisPayloadAsData() throws {
+        let event = AnalyzeProgressEvent.parse(
+            line: #"{"type":"result","data":{"total_size":123,"total_files":4,"entries":[]}}"#)
+        guard case .result(let data)? = event else { return XCTFail("expected .result, got \(String(describing: event))") }
+        // The payload round-trips for DiskScanner.parse, ints intact.
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(payload["total_size"] as? Int, 123)
+        XCTAssertEqual(payload["total_files"] as? Int, 4)
+    }
+
+    func testIgnoresBlankUnknownAndGarbage() {
+        // Robust stream: blank keep-alives, forward-compatible new types, and non-JSON are skipped.
+        XCTAssertNil(AnalyzeProgressEvent.parse(line: ""))
+        XCTAssertNil(AnalyzeProgressEvent.parse(line: "   "))
+        XCTAssertNil(AnalyzeProgressEvent.parse(line: #"{"type":"heartbeat"}"#))
+        XCTAssertNil(AnalyzeProgressEvent.parse(line: "not json at all"))
+        XCTAssertNil(AnalyzeProgressEvent.parse(line: #"{"no":"type"}"#))
+    }
+}

--- a/macos/Tests/BurrowEnvelopeTests.swift
+++ b/macos/Tests/BurrowEnvelopeTests.swift
@@ -1,0 +1,100 @@
+//
+//  BurrowEnvelopeTests.swift
+//  BurrowTests
+//
+//  The conductor envelope is the contract every migrated call site will parse: branch on `ok`,
+//  read `data` (success) or `error` (failure). These pin the parse — including the int-precision
+//  round-trip that lets `data` feed the command's own decoder — plus BurrowConductor's pure
+//  argv/env shaping. Mirrors the Windows BurrowEnvelopeTests (#248) so both GUIs prove the same
+//  contract. (The spawn itself can't run in CI; these cover everything up to it.)
+//
+
+import XCTest
+@testable import Burrow
+
+final class BurrowEnvelopeTests: XCTestCase {
+
+    // MARK: envelope parsing
+
+    func testSuccessEnvelope_extractsDataForConcreteDecoder() throws {
+        let json = #"{"ok":true,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"status","data":{"health_score":92}}"#
+        let env = try BurrowEnvelope.parse(json)
+        XCTAssertTrue(env.ok)
+        XCTAssertEqual(env.command, "status")
+        XCTAssertEqual(env.burrowCli, "0.0.1")
+        XCTAssertNil(env.error)
+        // `data` round-trips to bytes the command's own decoder reads — and stays an INTEGER
+        // (92, not 92.0), which a Codable Double bridge would have blurred.
+        let data = try XCTUnwrap(env.data)
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(payload["health_score"] as? Int, 92)
+    }
+
+    func testFailureEnvelope_branchesOnOkAndClassifies() throws {
+        let json = #"{"ok":false,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"clean","error":{"kind":"not_found","message":"engine \"mole\" not found","platform":"macos"}}"#
+        let env = try BurrowEnvelope.parse(json)
+        XCTAssertFalse(env.ok)
+        XCTAssertNil(env.data, "a failure carries no data")
+        XCTAssertEqual(env.command, "clean")
+        let err = try XCTUnwrap(env.error)
+        XCTAssertEqual(err.kind, "not_found")
+        XCTAssertEqual(err.message, #"engine "mole" not found"#)
+        XCTAssertEqual(err.platform, "macos")
+    }
+
+    func testUnsupportedEnvelope_carriesFeatureAlongsideError() throws {
+        let json = #"{"ok":false,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"dupes","error":{"kind":"unsupported","message":"not on Windows"},"feature":"dupes apply"}"#
+        let env = try BurrowEnvelope.parse(json)
+        XCTAssertFalse(env.ok)
+        XCTAssertEqual(env.error?.kind, "unsupported")
+        XCTAssertEqual(env.error?.feature, "dupes apply")
+    }
+
+    func testTextData_survivesAsValidJSON() throws {
+        // clean's dry-run report comes back as data.text (escaped newlines/quotes) — the
+        // envelope must keep it as valid, decodable JSON.
+        let json = #"{"ok":true,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"clean","data":{"text":"Would remove:\n  ~/Library/Caches"}}"#
+        let env = try BurrowEnvelope.parse(json)
+        XCTAssertTrue(env.ok)
+        let data = try XCTUnwrap(env.data)
+        let payload = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertTrue((payload["text"] as? String)?.contains("Would remove") ?? false)
+    }
+
+    func testDataArray_isSupported() throws {
+        let json = #"{"ok":true,"burrow_cli":"0.0.1","engine":"burrow-engine","command":"analyze","data":[1,2,3]}"#
+        let env = try BurrowEnvelope.parse(json)
+        let data = try XCTUnwrap(env.data)
+        XCTAssertEqual(try JSONSerialization.jsonObject(with: data) as? [Int], [1, 2, 3])
+    }
+
+    func testGarbage_throwsNotJSON() {
+        XCTAssertThrowsError(try BurrowEnvelope.parse("not json at all")) { error in
+            XCTAssertTrue(error is BurrowEnvelope.ParseError)
+        }
+    }
+
+    func testNonObjectJSON_throwsNotAnObject() {
+        XCTAssertThrowsError(try BurrowEnvelope.parse("[1,2,3]"))
+    }
+
+    // MARK: conductor command shaping
+
+    func testConductorArgv_appendsJsonAfterArgs() {
+        XCTAssertEqual(BurrowConductor.argv(command: "analyze", args: ["/tmp"]),
+                       ["analyze", "/tmp", "--json"])
+        XCTAssertEqual(BurrowConductor.argv(command: "status", args: []),
+                       ["status", "--json"])
+    }
+
+    func testConductorEnvironment_pointsAtBundledEngine() {
+        let dir = URL(fileURLWithPath: "/Applications/Burrow.app/Contents/Resources/engine")
+        let env = BurrowConductor.environment(engineDir: dir)
+        XCTAssertEqual(env["BURROW_ENGINE_DIR"], dir.path)
+    }
+
+    func testConductorEnvironment_nilEngineDirLeavesItUnset() {
+        // A build without a bundled engine sets no override — the conductor resolves on its own.
+        XCTAssertNil(BurrowConductor.environment(engineDir: nil)["BURROW_ENGINE_DIR"])
+    }
+}

--- a/macos/Tests/BurrowEnvelopeTests.swift
+++ b/macos/Tests/BurrowEnvelopeTests.swift
@@ -97,4 +97,34 @@ final class BurrowEnvelopeTests: XCTestCase {
         // A build without a bundled engine sets no override — the conductor resolves on its own.
         XCTAssertNil(BurrowConductor.environment(engineDir: nil)["BURROW_ENGINE_DIR"])
     }
+
+    // MARK: streaming argv translation (safety-critical: mo↔burrow dry-run/apply INVERSION)
+
+    func testStreamArgv_preview_dropsDryRun_neverApply() {
+        // mo preview (`clean --dry-run`) maps to burrow's DEFAULT (dry-run) — must NOT gain
+        // --apply, or a "preview" would delete for real.
+        XCTAssertEqual(BurrowConductor.streamArgv(fromMo: ["clean", "--dry-run"]),
+                       ["clean", "--stream"])
+    }
+
+    func testStreamArgv_live_addsApply() {
+        // mo live (`clean`, no --dry-run) needs --apply on burrow — or a real clean would silently
+        // no-op (burrow defaults to dry-run).
+        XCTAssertEqual(BurrowConductor.streamArgv(fromMo: ["clean"]),
+                       ["clean", "--apply", "--stream"])
+        XCTAssertEqual(BurrowConductor.streamArgv(fromMo: ["optimize"]),
+                       ["optimize", "--apply", "--stream"])
+    }
+
+    func testStreamOverride_offByDefault_keepsDirectEngine() {
+        // The switch is off unless explicitly set → no override, the direct mo path is preserved.
+        XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false))
+    }
+
+    func testStreamOverride_elevatedAlwaysDirect() {
+        UserDefaults.standard.set(true, forKey: "BurrowStreamViaConductor")
+        defer { UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor") }
+        // Elevated runs (osascript, fresh env) stay on mo even with the switch on.
+        XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: true))
+    }
 }

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -115,6 +115,23 @@ targets:
           else
             echo "warning: burrow-engine source not present at $ENGINE_SRC — Burrow falls back to a system engine. Set BURROW_ENGINE_SRC or init the vendor/burrow-engine submodule."
           fi
+      - name: Bundle burrow (conductor)
+        basedOnDependencyAnalysis: false
+        script: |
+          # Stage the FSL `burrow` conductor beside the MIT engine so the GUI can shell out to
+          # `burrow <cmd> --json` (stable envelope + NDJSON streaming) instead of the engine
+          # directly. Gated on a POPULATED vendor/burrow-cli checkout: a plain (no-submodule)
+          # checkout — e.g. the PR `ci` job — leaves an EMPTY gitlink dir, so we bundle only when
+          # Cargo.toml is really present and otherwise fall through to the direct engine (build
+          # still green, exactly like the engine phase above). Final resource seal happens
+          # POST-build (scripts/build.sh locally; the release pipeline's inside-out re-sign).
+          BURROW_CLI_SRC="${BURROW_CLI_SRC:-$SRCROOT/vendor/burrow-cli}"
+          if [ -f "$BURROW_CLI_SRC/Cargo.toml" ] && [ -d "$BURROW_CLI_SRC/src" ] && command -v cargo >/dev/null 2>&1; then
+            "$SRCROOT/scripts/bundle-burrow.sh" "$BURROW_CLI_SRC" "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH" \
+              || echo "warning: burrow conductor build failed — Burrow falls back to the direct engine."
+          else
+            echo "warning: burrow-cli source or cargo not present at $BURROW_CLI_SRC — Burrow falls back to the direct engine. Set BURROW_CLI_SRC or init the vendor/burrow-cli submodule."
+          fi
 
   BurrowTests:
     type: bundle.unit-test

--- a/macos/scripts/bundle-burrow.sh
+++ b/macos/scripts/bundle-burrow.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# bundle-burrow.sh — stage the `burrow` CONDUCTOR binary into the app's Resources.
+#
+# The GUI shells out to this bundled conductor (`burrow <cmd> --json`) instead of the engine
+# directly, so it gets the stable Burrow envelope + NDJSON streaming contract with zero install.
+# burrow locates its engine via $BURROW_ENGINE_DIR, which the app sets to the sibling-bundled
+# Resources/engine (see bundle-engine.sh). The FSL-licensed conductor and the MIT engine stay
+# arm's-length (separate processes); only the built binary travels — no Rust source.
+#
+# Usage: bundle-burrow.sh <BURROW_CLI_SRC> <RESOURCES_DIR>
+#   BURROW_CLI_SRC  a burrow-cli checkout (has Cargo.toml, src/)
+#   RESOURCES_DIR   the app bundle's Resources dir (burrow is written directly inside it)
+set -euo pipefail
+
+SRC="${1:?burrow-cli source dir required}"
+RESOURCES="${2:?resources dir required}"
+OUT="$RESOURCES/burrow"
+
+command -v cargo >/dev/null 2>&1 || {
+  echo "error: cargo not found — cannot build the burrow conductor (install Rust, or omit the vendor/burrow-cli submodule to fall back to the system engine)"
+  exit 1
+}
+
+# Build UNIVERSAL (arm64 + x86_64) so the conductor runs on BOTH Apple Silicon and Intel Macs.
+# An arch-only binary hangs the universal app on the other arch (same lesson as the engine's Go
+# binaries, issue #221). Rust cross-compiles per target; we add both targets (rustup fetches the
+# missing slice) and lipo them together. GIT_TERMINAL_PROMPT=0 + </dev/null keep a fresh checkout
+# from ever blocking the build on an interactive prompt.
+export GIT_TERMINAL_PROMPT=0
+A=aarch64-apple-darwin
+X=x86_64-apple-darwin
+( cd "$SRC"
+  if command -v rustup >/dev/null 2>&1; then
+    rustup target add "$A" "$X" >/dev/null 2>&1 || true
+  fi
+  cargo build --release --target "$A" </dev/null
+  cargo build --release --target "$X" </dev/null
+  lipo -create -output "target/release/burrow-universal" \
+    "target/$A/release/burrow" "target/$X/release/burrow" )
+
+# Stage + sign the conductor beside the engine so the app's own signature validates (--deep).
+# Uses the build's resolved identity when run as a build phase, else ad-hoc ('-').
+mkdir -p "$RESOURCES"
+cp "$SRC/target/release/burrow-universal" "$OUT"
+chmod +x "$OUT"
+
+IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:--}"
+codesign --force --sign "$IDENTITY" --timestamp=none "$OUT" 2>/dev/null \
+  || codesign --force --sign - --timestamp=none "$OUT" || true
+
+echo "bundled burrow -> $OUT ($(lipo -archs "$OUT" 2>/dev/null || echo native); signed with '${IDENTITY}')"


### PR DESCRIPTION
Bundles the `burrow` conductor into the macOS app and routes the **first call site** (disk analysis) through it, with a safe fallback. First real slice of the GUI→conductor migration.

## Bundling (mirrors the engine exactly)
- Vendor **burrow-cli as a submodule** (`macos/vendor/burrow-cli`, pinned).
- **`bundle-burrow.sh`**: cargo-builds `burrow` **universal** (arm64+x86_64, lipo) + signs → `Resources/burrow`. ✅ verified locally (`x86_64 arm64`, 2.6 MB).
- **`project.yml`**: gated `postBuildScript`, skips gracefully with no submodule (PR `ci` job stays green, like the engine phase).
- **`release.yml`**: fetch burrow-cli at its pinned SHA + re-sign `Resources/burrow` in **both** inside-out sign passes (else the resource seal stales → FDA re-break #177).

## Client (contract-first, unit-tested — mirrors Windows #248)
- **`BurrowEnvelope.swift`**: parse `{ok,command,data|error}`; `data` round-trips via JSONSerialization (ints stay ints).
- **`BurrowConductor.swift`**: resolve bundled burrow + engine dir, shape argv/env (`BURROW_ENGINE_DIR`), capture one-shots by reusing MoEngine's tested capture stack via `.executable(path)`. `isAvailable=false` → fall back.
- **`BurrowEnvelopeTests.swift`**: success/failure/unsupported/text/array/garbage + argv/env.

## First call-site flip: disk analysis
- **`DiskScanner.scan`** tries `burrow analyze --json <path>` first — so the disk analyzer works with **no system `mo` installed** (today it hard-requires it). Same analyze-go JSON, unchanged `parse()`. **Any** conductor miss (not bundled / ok:false / no data / timeout) falls through to the direct engine → never worse than before.

## Deferred / follow-up
- **Live-treemap streaming** (`analyze --progress` NDJSON → incremental treemap): a real UI feature that needs hands-on iteration; not in this PR.
- Remaining command flips (clean/optimize/status/…) + the Windows half (`burrow.exe` + wire `MoleEngineService`).

⚠️ CI compiles + unit-tests; the conductor path itself is hand-tested on a real build (fallback keeps the app safe meanwhile).