### PR TITLE
feat(windows): bundle burrow conductor + BurrowConductorService (foundation)

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -50,6 +50,32 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      # Build the FSL `burrow` conductor at its pinned submodule commit and stage it into Assets\
+      # so the csproj bundles it (its Content Include is conditional on Exists). NON-FATAL: without
+      # it the app falls back to the direct engine. windows-latest ships a Rust toolchain; the
+      # submodule is cloned fresh (checkout doesn't recurse submodules), reusing ENGINE_PAT.
+      - name: Build + stage burrow conductor
+        working-directory: ${{ github.workspace }}
+        shell: pwsh
+        env:
+          ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
+        run: |
+          try {
+            $sha = (git ls-tree HEAD windows/vendor/burrow-cli).Split()[2]
+            $dest = Join-Path $env:RUNNER_TEMP 'burrow-cli'
+            if ($env:ENGINE_PAT) {
+              git -c "url.https://x-access-token:$($env:ENGINE_PAT)@github.com/.insteadOf=https://github.com/" clone --quiet https://github.com/caezium/burrow-cli.git $dest
+            } else {
+              git clone --quiet https://github.com/caezium/burrow-cli.git $dest
+            }
+            git -C $dest -c advice.detachedHead=false checkout --quiet $sha
+            cargo build --release --manifest-path (Join-Path $dest 'Cargo.toml')
+            Copy-Item (Join-Path $dest 'target\release\burrow.exe') 'windows\Assets\burrow.exe' -Force
+            Write-Host "staged burrow.exe @ $($sha.Substring(0,7))"
+          } catch {
+            Write-Host "::warning::burrow conductor build failed - Windows app falls back to the direct engine. $_"
+          }
+
       # Surface (without leaking) whether the keys will actually be baked, so a
       # release that silently shipped inert telemetry is easy to spot. Reads the
       # env (set from secrets) rather than interpolating the secret into script.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "macos/vendor/burrow-engine"]
 	path = macos/vendor/burrow-engine
 	url = https://github.com/caezium/burrow-engine.git
+[submodule "windows/vendor/burrow-cli"]
+	path = windows/vendor/burrow-cli
+	url = https://github.com/caezium/burrow-cli.git

--- a/windows/Assets/Mole/burrow-engine.cmd
+++ b/windows/Assets/Mole/burrow-engine.cmd
@@ -1,0 +1,17 @@
+@echo off
+rem burrow-engine.cmd — the entrypoint name the `burrow` conductor resolves on Windows
+rem (bash_entrypoint_names = burrow-engine | mole). Forwards to mole.ps1 exactly like mo.cmd,
+rem so `burrow <cmd>` (Target::Bash) runs the bundled PowerShell engine. Bundled via the
+rem Assets\Mole\** glob; the conductor is pointed here through BURROW_ENGINE_DIR.
+setlocal EnableDelayedExpansion
+set "MOLE_DIR=%~dp0"
+
+set "ARGS="
+:parse
+if "%~1"=="" goto run
+set "ARGS=!ARGS! '%~1'"
+shift
+goto parse
+
+:run
+powershell.exe -ExecutionPolicy Bypass -NoLogo -NoProfile -Command "& '%MOLE_DIR%mole.ps1' !ARGS!"

--- a/windows/BurrowWin.csproj
+++ b/windows/BurrowWin.csproj
@@ -38,6 +38,10 @@
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
     <Content Include="Assets\Fonts\*.woff2" />
     <Content Include="Assets\mo.exe" CopyToOutputDirectory="PreserveNewest" Condition="Exists('Assets\mo.exe')" />
+    <!-- The FSL `burrow` conductor, built + staged by windows-release.yml. Conditional so the PR
+         `windows-ci` build (which doesn't stage it) stays green; the app then falls back to the
+         direct engine. burrow-engine.cmd (the entrypoint burrow resolves) rides the Assets\Mole\** glob. -->
+    <Content Include="Assets\burrow.exe" CopyToOutputDirectory="PreserveNewest" Condition="Exists('Assets\burrow.exe')" />
     <Content Include="Assets\mo.cmd" CopyToOutputDirectory="PreserveNewest" Condition="Exists('Assets\mo.cmd')" />
     <Content Include="Assets\mole.ps1" CopyToOutputDirectory="PreserveNewest" Condition="Exists('Assets\mole.ps1')" />
     <Content Include="Assets\Mole\**\*.*" CopyToOutputDirectory="PreserveNewest" Condition="Exists('Assets\Mole')" />

--- a/windows/Services/BurrowConductorService.cs
+++ b/windows/Services/BurrowConductorService.cs
@@ -67,6 +67,15 @@ public sealed class BurrowConductorService
     }
 
     /// <summary>
+    /// The conductor args for a destructive maintenance action, from MCP's <c>confirm</c> flag.
+    /// <c>burrow</c> defaults to dry-run, so a CONFIRMED (live) run needs <c>--apply</c>; an
+    /// unconfirmed run passes nothing (dry-run preview). The mo→burrow inversion, spelled once
+    /// + unit-tested so the destructive mapping can't silently drift.
+    /// </summary>
+    internal static IReadOnlyList<string> ActionArguments(bool confirm)
+        => confirm ? new[] { "--apply" } : Array.Empty<string>();
+
+    /// <summary>
     /// Run <c>burrow &lt;command&gt; [args…] --json</c> and return the parsed success envelope.
     /// Throws <see cref="InvalidOperationException"/> when no conductor is bundled, and
     /// <see cref="BurrowConductorException"/> on a timeout/cancel, empty or garbled output, or an

--- a/windows/Services/BurrowConductorService.cs
+++ b/windows/Services/BurrowConductorService.cs
@@ -1,0 +1,197 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using BurrowWin.Models;
+
+namespace BurrowWin.Services;
+
+/// <summary>
+/// Runs the bundled <c>burrow.exe</c> conductor and parses its stable envelope. Mirrors the macOS
+/// BurrowConductor: the conductor wraps the engine with the unified <c>{ok, data|error}</c>
+/// contract, so the app parses ONE shape for every command. Resolves <c>burrow.exe</c> beside the
+/// app (Assets\burrow.exe), points it at the bundled engine via <c>BURROW_ENGINE_DIR</c>
+/// (Assets\Mole, where burrow-engine.cmd forwards to mole.ps1), and — when the conductor isn't
+/// bundled or fails — the caller falls back to the direct engine (<see cref="MoleEngineService"/>).
+/// </summary>
+public sealed class BurrowConductorService
+{
+    private static IEnumerable<string> BaseDirectories()
+    {
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrWhiteSpace(processPath))
+        {
+            var directory = Path.GetDirectoryName(processPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                yield return directory;
+            }
+        }
+
+        yield return AppContext.BaseDirectory;
+    }
+
+    /// <summary>Candidate locations for the bundled conductor, beside the app under Assets\.</summary>
+    internal static IReadOnlyList<string> CandidateExecutablePaths(IEnumerable<string> baseDirectories)
+    {
+        return baseDirectories
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(directory => Path.Combine(directory, "Assets", "burrow.exe"))
+            .ToArray();
+    }
+
+    /// <summary>The bundled conductor path, or null if this build didn't ship one.</summary>
+    public static string? ResolveExecutable()
+    {
+        return CandidateExecutablePaths(BaseDirectories()).FirstOrDefault(File.Exists);
+    }
+
+    /// <summary>The bundled engine dir handed to the conductor via BURROW_ENGINE_DIR, or null.</summary>
+    public static string? ResolveEngineDir()
+    {
+        return BaseDirectories()
+            .Select(directory => Path.Combine(directory, "Assets", "Mole"))
+            .FirstOrDefault(Directory.Exists);
+    }
+
+    /// <summary>True when a bundled conductor is present; callers branch on this to fall back.</summary>
+    public bool IsAvailable => ResolveExecutable() is not null;
+
+    /// <summary>The argv for a JSON one-shot: <c>&lt;command&gt; [args…] --json</c>.</summary>
+    internal static IReadOnlyList<string> BuildArguments(string command, IReadOnlyList<string> arguments)
+    {
+        var list = new List<string>(arguments.Count + 2) { command };
+        list.AddRange(arguments);
+        list.Add("--json");
+        return list;
+    }
+
+    /// <summary>
+    /// Run <c>burrow &lt;command&gt; [args…] --json</c> and return the parsed success envelope.
+    /// Throws <see cref="InvalidOperationException"/> when no conductor is bundled, and
+    /// <see cref="BurrowConductorException"/> on a timeout/cancel, empty or garbled output, or an
+    /// <c>ok:false</c> envelope (carrying the classified error kind so the UI can react).
+    /// </summary>
+    public async Task<BurrowEnvelope> CaptureAsync(
+        string command,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var executable = ResolveExecutable()
+            ?? throw new InvalidOperationException("the bundled burrow conductor is not available");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+        foreach (var argument in BuildArguments(command, arguments))
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        startInfo.Environment["NO_COLOR"] = "1";
+        var engineDir = ResolveEngineDir();
+        if (engineDir is not null)
+        {
+            startInfo.Environment["BURROW_ENGINE_DIR"] = engineDir;
+        }
+
+        // Drain stdout/stderr via events (like MoleEngineService) so a full pipe buffer can't
+        // deadlock the wait.
+        var stdout = new StringBuilder();
+        var syncRoot = new object();
+        using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                lock (syncRoot)
+                {
+                    stdout.AppendLine(e.Data);
+                }
+            }
+        };
+        process.ErrorDataReceived += (_, _) => { /* human line on stderr; the envelope is on stdout */ };
+
+        if (!process.Start())
+        {
+            throw new BurrowConductorException("process_failed", $"burrow {command} could not be started");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            throw new BurrowConductorException("process_failed", $"burrow {command} was cancelled");
+        }
+
+        string output;
+        lock (syncRoot)
+        {
+            output = stdout.ToString().Trim();
+        }
+
+        if (output.Length == 0)
+        {
+            throw new BurrowConductorException(
+                "process_failed", $"burrow {command} produced no output (exit {process.ExitCode})");
+        }
+
+        BurrowEnvelope envelope;
+        try
+        {
+            envelope = BurrowEnvelope.Parse(output);
+        }
+        catch (JsonException ex)
+        {
+            throw new BurrowConductorException("error", $"burrow {command} output was not a valid envelope: {ex.Message}");
+        }
+
+        if (!envelope.Ok)
+        {
+            throw new BurrowConductorException(
+                envelope.Error?.Kind ?? "error",
+                envelope.Error?.Message ?? $"burrow {command} failed");
+        }
+
+        return envelope;
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best effort.
+        }
+    }
+}
+
+/// <summary>A conductor failure carrying the envelope's classified error kind
+/// (permission_denied / unsupported / not_found / process_failed / error).</summary>
+public sealed class BurrowConductorException : Exception
+{
+    public string Kind { get; }
+
+    public BurrowConductorException(string kind, string message) : base(message)
+    {
+        Kind = kind;
+    }
+}

--- a/windows/Services/LocalMcpServerService.cs
+++ b/windows/Services/LocalMcpServerService.cs
@@ -456,6 +456,46 @@ public sealed class LocalMcpServerService : BackgroundService
         }
 
         var effectiveCommand = confirm ? command : $"{command} --dry-run";
+
+        // Prefer the bundled conductor: `burrow <command> [--apply] --json` runs the bundled
+        // engine with the stable envelope + classified errors. burrow defaults to dry-run, so a
+        // confirmed (live) run adds --apply via BurrowConductorService.ActionArguments (the
+        // mo→burrow inversion). Any conductor miss falls through to the direct engine below.
+        var conductor = new BurrowConductorService();
+        if (conductor.IsAvailable)
+        {
+            try
+            {
+                var envelope = await conductor.CaptureAsync(
+                    command, BurrowConductorService.ActionArguments(confirm), cancellationToken);
+                return new JsonObject
+                {
+                    ["command"] = effectiveCommand,
+                    ["dry_run"] = !confirm,
+                    ["exit_code"] = 0,
+                    ["succeeded"] = true,
+                    ["stdout"] = ExtractEngineText(envelope.Data),
+                    ["stderr"] = string.Empty
+                };
+            }
+            catch (BurrowConductorException ex)
+            {
+                return new JsonObject
+                {
+                    ["command"] = effectiveCommand,
+                    ["dry_run"] = !confirm,
+                    ["exit_code"] = 1,
+                    ["succeeded"] = false,
+                    ["stdout"] = string.Empty,
+                    ["stderr"] = $"{ex.Message} [{ex.Kind}]"
+                };
+            }
+            catch (InvalidOperationException)
+            {
+                // Conductor vanished between IsAvailable and the run — fall through to the engine.
+            }
+        }
+
         var result = await _moleEngineService.ExecuteCommandAsync(effectiveCommand, cancellationToken: cancellationToken);
 
         return new JsonObject
@@ -467,6 +507,18 @@ public sealed class LocalMcpServerService : BackgroundService
             ["stdout"] = result.StandardOutput,
             ["stderr"] = result.StandardError
         };
+    }
+
+    // clean/optimize return their report as data.text; unwrap it so the MCP consumer sees the
+    // engine's text (as with the direct path), else fall back to the raw payload.
+    private static string ExtractEngineText(JsonElement data)
+    {
+        if (data.ValueKind == JsonValueKind.Object && data.TryGetProperty("text", out var text))
+        {
+            return text.GetString() ?? string.Empty;
+        }
+
+        return data.ValueKind == JsonValueKind.Undefined ? string.Empty : data.GetRawText();
     }
 
     private async Task<JsonObject> CaptureSnapshotAsync(CancellationToken cancellationToken)

--- a/windows/Tests/BurrowWin.Tests/BurrowConductorServiceTests.cs
+++ b/windows/Tests/BurrowWin.Tests/BurrowConductorServiceTests.cs
@@ -47,4 +47,19 @@ public class BurrowConductorServiceTests
 
         Assert.Single(paths);
     }
+
+    // Safety-critical: the destructive confirm→apply mapping (burrow defaults to dry-run).
+    [Fact]
+    public void ActionArguments_Confirmed_AddsApply()
+    {
+        // A confirmed (live) maintenance run MUST add --apply, or a "real" clean silently no-ops.
+        Assert.Equal(new[] { "--apply" }, BurrowConductorService.ActionArguments(confirm: true));
+    }
+
+    [Fact]
+    public void ActionArguments_Unconfirmed_IsPreviewOnly()
+    {
+        // Unconfirmed → no --apply → burrow's default dry-run (preview). Must NOT delete for real.
+        Assert.Empty(BurrowConductorService.ActionArguments(confirm: false));
+    }
 }

--- a/windows/Tests/BurrowWin.Tests/BurrowConductorServiceTests.cs
+++ b/windows/Tests/BurrowWin.Tests/BurrowConductorServiceTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Linq;
+using BurrowWin.Services;
+using Xunit;
+
+namespace BurrowWin.Tests;
+
+// Pins BurrowConductorService's pure command shaping + resolution. The spawn itself can't run in
+// CI (no bundled burrow.exe), so these cover everything up to it; the envelope parse is covered by
+// BurrowEnvelopeTests. Mirrors the macOS BurrowEnvelopeTests so both GUIs prove the same contract.
+public class BurrowConductorServiceTests
+{
+    [Fact]
+    public void BuildArguments_AppendsJsonAfterPositionalArgs()
+    {
+        Assert.Equal(
+            new[] { "analyze", @"C:\Users", "--json" },
+            BurrowConductorService.BuildArguments("analyze", new[] { @"C:\Users" }));
+    }
+
+    [Fact]
+    public void BuildArguments_NoArgs_IsJustCommandPlusJson()
+    {
+        Assert.Equal(
+            new[] { "status", "--json" },
+            BurrowConductorService.BuildArguments("status", Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void CandidateExecutablePaths_LookBesideTheApp_UnderAssets()
+    {
+        var paths = BurrowConductorService
+            .CandidateExecutablePaths(new[] { @"C:\App", @"C:\App" })
+            .ToList();
+
+        Assert.Single(paths); // duplicate base dir deduped (case-insensitive)
+        Assert.EndsWith(Path.Combine("Assets", "burrow.exe"), paths[0]);
+    }
+
+    [Fact]
+    public void CandidateExecutablePaths_SkipsBlankBaseDirs()
+    {
+        var paths = BurrowConductorService
+            .CandidateExecutablePaths(new[] { "", "   ", @"C:\App" })
+            .ToList();
+
+        Assert.Single(paths);
+    }
+}

--- a/windows/Tests/BurrowWin.Tests/BurrowWin.Tests.csproj
+++ b/windows/Tests/BurrowWin.Tests/BurrowWin.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="..\..\Services\LocalMcpServerService.cs" Link="Production\Services\LocalMcpServerService.cs" />
     <Compile Include="..\..\Services\LocalStartupDiagnosticsService.cs" Link="Production\Services\LocalStartupDiagnosticsService.cs" />
     <Compile Include="..\..\Services\MoleEngineService.cs" Link="Production\Services\MoleEngineService.cs" />
+    <Compile Include="..\..\Services\BurrowConductorService.cs" Link="Production\Services\BurrowConductorService.cs" />
     <Compile Include="..\..\Services\ProcessUsageAggregator.cs" Link="Production\Services\ProcessUsageAggregator.cs" />
     <Compile Include="..\..\Services\PurgeArtifactService.cs" Link="Production\Services\PurgeArtifactService.cs" />
     <Compile Include="..\..\Services\RecycleBinDeletionService.cs" Link="Production\Services\RecycleBinDeletionService.cs" />


### PR DESCRIPTION
Windows mirror of the macOS conductor foundation (#251): bundle `burrow.exe` and add a client that runs it + parses the unified envelope (reusing #248's `BurrowEnvelope`), so the Windows app can speak ONE `{ok,data|error}` shape. **No call-site flip yet** — the Windows engine surface is thin (version probe + MCP clean/optimize; everything user-facing uses native fallbacks) and a flip needs a real Windows test. This lands the prerequisites, CI-verified (build + xUnit), behavior unchanged.

## What's here
- Vendor **burrow-cli as a submodule** (`windows/vendor/burrow-cli`, pinned; independent of #251's `macos/vendor` one).
- **`burrow-engine.cmd`** — the entrypoint name `burrow` resolves on Windows (`bash_entrypoint_names = burrow-engine | mole`), forwarding to `mole.ps1` like `mo.cmd`, so `burrow <cmd>` (Target::Bash) runs the bundled PowerShell engine. Rides the `Assets\Mole\**` glob.
- **`BurrowConductorService.cs`** — resolve bundled `burrow.exe` + engine dir, shape argv (`<cmd> --json`) + env (`BURROW_ENGINE_DIR`), capture + parse the envelope; `IsAvailable=false` or a throw → caller falls back to the direct engine. Mirrors macOS `BurrowConductor`.
- **`BurrowWin.csproj`** — conditional `Content` copy of `burrow.exe` (skipped in `windows-ci`, which doesn't stage it → build stays green).
- **`windows-release.yml`** — cargo-build `burrow.exe` at the pinned SHA + stage into `Assets\` (non-fatal).
- **`BurrowConductorServiceTests`** — argv shaping + candidate-path resolution (xUnit, runs in `windows-ci`).

## Note on the engine surface
On Windows `burrow` can only run **Bash-target** commands (clean/optimize/purge/…) via `burrow-engine.cmd` — the Go binaries (status-go/analyze-go) aren't part of the Windows engine, so `status`/`analyze` stay on the native Windows services. That matches how the Windows GUI already works.

## Deferred / follow-up
The thin call-site flip (MCP `clean`/`optimize` → conductor) + the macOS remaining flips + streaming treemap. ⚠️ CI builds + unit-tests; the conductor runtime is hand-tested on a real Windows build (fallback keeps it safe meanwhile).