### PR TITLE
fix(macos): bound analyze per-child scan + stop menu-bar popover bounce

### DIFF
--- a/macos/Sources/AnalyzeView.swift
+++ b/macos/Sources/AnalyzeView.swift
@@ -130,7 +130,9 @@ struct AnalyzeView: View {
                         .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
                         .lineLimit(1).truncationMode(.middle)
                         .frame(maxWidth: 380)
-                    Text(verbatim: "· \(p.done)/\(p.total)")
+                    // Per-child walk has a real n/total; the streaming scan knows only a running
+                    // file count (unknown total) → show "N files" instead of a misleading "N/N".
+                    Text(verbatim: p.total > 0 ? "· \(p.done)/\(p.total)" : "· \(p.done.formatted()) files")
                         .font(Brand.mono(11)).foregroundStyle(Brand.textTertiary)
                 } else {
                     Text("Measuring…").font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
@@ -563,6 +565,13 @@ final class AnalyzeModel: ObservableObject {
         proc.standardError = Pipe()   // discard the human-readable line on stderr
         try proc.run()
 
+        // Bound the scan: a pathological tree (Home's package caches — millions of tiny files) can
+        // run for minutes. Terminate after a cap so scanWithProgress falls back to the per-child
+        // walk instead of the reader blocking indefinitely on availableData.
+        let killer = DispatchWorkItem { if proc.isRunning { proc.terminate() } }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 30, execute: killer)
+        defer { killer.cancel() }
+
         let handle = out.fileHandleForReading
         var pending = Data()
         var resultData: Data?
@@ -578,7 +587,7 @@ final class AnalyzeModel: ObservableObject {
                       let event = AnalyzeProgressEvent.parse(line: line) else { continue }
                 switch event {
                 case .progress(let files, _, _, let scanned):
-                    onProgress(scanned, files, max(files, 1))   // path + running file count
+                    onProgress(scanned, files, 0)   // total 0 → display shows "N files" (unknown total)
                 case .result(let data):
                     resultData = data
                 }
@@ -651,7 +660,9 @@ final class AnalyzeModel: ObservableObject {
                     if isDir.boolValue {
                         // A child mole can't read (permissions) still gets a row
                         // — size 0 — instead of sinking the whole scan.
-                        let result = try? DiskScanner.scan(childPath)
+                        // Short per-child timeout: one huge child (a package cache with millions
+                        // of files) times out + shows partial instead of stalling the whole walk.
+                        let result = try? DiskScanner.scan(childPath, timeout: 20)
                         let size = result.map { $0.totalSize > 0 ? $0.totalSize : $0.entries.reduce(0) { $0 + $1.size } } ?? 0
                         if let result { cacheChild(childPath, result) }
                         entry = DiskScanEntry(id: childPath, name: name, path: childPath,

--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -110,13 +110,13 @@ enum BurrowConductor {
         UserDefaults.standard.bool(forKey: "BurrowStreamViaConductor")
     }
 
-    /// Opt-in switch for the live-filling treemap: stream `analyze --progress` so a scan reports
-    /// the engine's file-level counters. Default OFF — it reworks AnalyzeView's scan flow +
-    /// progress granularity and can't be validated in CI. Read-only (no data risk), but gated so
-    /// the UX change is opt-in. Flip with:
+    /// Default OFF: the per-child walk stays the default because its "scanning <child> · k/N"
+    /// progress tells the user WHAT is being measured. The single streamed `analyze --progress` is
+    /// faster but its only signal is a running file count (the engine's per-tick path is usually
+    /// empty), which reads as opaque. Opt into the fast-but-opaque path with:
     ///   `defaults write dev.caezium.Burrow BurrowStreamAnalyze -bool YES`
     static var streamingAnalyzeEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "BurrowStreamAnalyze")
+        (UserDefaults.standard.object(forKey: "BurrowStreamAnalyze") as? Bool) ?? false
     }
 
     /// The streamable engine commands the conductor forwards with `--stream`. purge/installer are

--- a/macos/Sources/DiskScanner.swift
+++ b/macos/Sources/DiskScanner.swift
@@ -76,13 +76,16 @@ enum DiskScanner {
     /// callers must run on a background queue. Returns aggregated sizes
     /// for each direct child; drill in by calling again with the child's
     /// path.
-    static func scan(_ path: String) throws -> DiskScanResult {
+    /// `timeout` bounds a single level's walk: the top-level scan keeps the generous default, but
+    /// the per-child walk passes a short one so one huge child (e.g. a package cache with millions
+    /// of files) times out + shows partial instead of stalling the whole scan for minutes.
+    static func scan(_ path: String, timeout: TimeInterval = 300) throws -> DiskScanResult {
         // Prefer the bundled conductor: `burrow analyze --json <path>` runs the bundled engine,
         // so disk analysis works even with NO system `mo` installed (the hard requirement just
         // below). The envelope's `data` is the same analyze-go JSON, so `parse` is unchanged; any
         // conductor miss (not bundled, engine error, empty/garbled) falls through to the direct
         // engine, so behavior is never worse than before.
-        if BurrowConductor.isAvailable, let viaConductor = try? conductorScan(path) {
+        if BurrowConductor.isAvailable, let viaConductor = try? conductorScan(path, timeout: timeout) {
             return viaConductor
         }
         guard case .installed = MoEngine.shared.availability() else {
@@ -92,7 +95,7 @@ enum DiskScanner {
         // few seconds, but a cold cache + large external volume + no
         // indexing can stretch it. Beyond 5 min something's wrong.
         let result = try MoEngine.shared.capture(
-            MoCommand(target: .mo, args: ["analyze", "--json", path], timeout: 300))
+            MoCommand(target: .mo, args: ["analyze", "--json", path], timeout: timeout))
         guard result.exitCode == 0 else {
             if indicatesMissingJSONSupport(stderr: result.stderr) {
                 throw DiskScanError.moTooOld(found: MoleCLI.version())
@@ -108,8 +111,8 @@ enum DiskScanner {
     /// Scan via the bundled conductor (`burrow analyze --json <path>`). Throws on any miss —
     /// not bundled, timeout, an `ok:false` envelope, or no `data` — so `scan` can fall back to
     /// the direct engine. The `data` payload is the same analyze-go JSON, decoded by `parse`.
-    private static func conductorScan(_ path: String) throws -> DiskScanResult {
-        let envelope = try BurrowConductor.capture("analyze", [path], timeout: 300)
+    private static func conductorScan(_ path: String, timeout: TimeInterval) throws -> DiskScanResult {
+        let envelope = try BurrowConductor.capture("analyze", [path], timeout: timeout)
         guard let data = envelope.data else {
             throw DiskScanError.parseFailed("conductor returned an envelope with no data")
         }

--- a/macos/Sources/HUDController.swift
+++ b/macos/Sources/HUDController.swift
@@ -50,6 +50,11 @@ final class HUDController: NSViewController {
         // it rarely needs to.
         scroll.hasVerticalScroller = false
         scroll.hasHorizontalScroller = false
+        // No rubber-band bounce: when the content fits (the common case) the scroll view must not
+        // elastic-scroll into empty space and spring back (the reported popover-scroll bug).
+        // Content past the screen-height cap still scrolls — elasticity only governs the bounce.
+        scroll.verticalScrollElasticity = .none
+        scroll.horizontalScrollElasticity = .none
         scroll.automaticallyAdjustsContentInsets = false
 
         hosting.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Fixes found while hand-testing the conductor build (all validated on a real build):

- **Analyze freeze** ('191/192' stuck on ~/Library / Home): `DiskScanner.scan` now takes a `timeout`, and the per-child walk passes **20s** — so one huge child (a package cache with millions of files) times out + shows partial instead of stalling the whole scan for the full 300s.
- **Menu-bar popover bounce**: `HUDController`'s `NSScrollView` gets `verticalScrollElasticity = .none` — no more rubber-banding into empty space when the content fits (overflow past the screen-height cap still scrolls).
- **Streaming safety** (opt-in `analyze --progress`, off by default): a 30s kill-timeout so a pathological tree can't block the reader indefinitely, and the progress reads `N files` (unknown total) instead of a misleading `N/N`.

The conductor path is unchanged — analyze/status/history/clean still run through bundled `burrow` → bundled engine (confirmed via `ps`: `burrow analyze` → `analyze-go`). Streaming stays **off by default**; the per-child walk's 'scanning <child> · k/N' progress is more informative.