### PR TITLE
feat(mcp): conductor-parity tools — dupes, orphans, net, rules, sentinel, slim-check, photos

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -11,7 +11,7 @@ samples continuously, and every actuating call is **dry-run by default**.
 
 ## The two kinds of tools
 
-- **Read-only (14)** — observe and diagnose. Always safe; call these proactively whenever a
+- **Read-only (21)** — observe and diagnose. Always safe; call these proactively whenever a
   question is about *this machine's* state, history, or health.
 - **Actuating, gated (5)** — clean / optimize / uninstall / purge / installer. **Preview by
   default** (`--dry-run`); a real run needs `confirm: true` **and** the user's Settings
@@ -54,6 +54,22 @@ samples continuously, and every actuating call is **dry-run by default**.
 | **burrow_analyze** | "What's taking up space in <folder>?" Size-ranked directory tree (the data behind the treemap). Read-only. | `path` |
 | **burrow_list_apps** | Before any uninstall, **always call this first** to get the exact app name `burrow_uninstall` accepts. Also answers "what apps are installed?" | — |
 
+## Discovery (read-only, via the bundled conductor)
+
+These route through the bundled `burrow` conductor and pass its JSON through verbatim. They
+find *reclaim candidates* but never delete anything — reporting only. On a build without the
+bundled conductor they return a JSON error object saying so (never a crash).
+
+| Tool | Use it proactively when… | Key params |
+|---|---|---|
+| **burrow_dupes** | "Do I have duplicate files in <folder>?" Duplicate-file groups (fclones group report) across one or more directories. Report-only — deletes nothing. | `paths` (required) |
+| **burrow_orphans** | "What leftovers did uninstalled apps leave behind?" Files under a directory that belong to no installed app. `installed` (csv of bundle ids) overrides auto-detection. | `path` (required), `installed` |
+| **burrow_net** | "Which app is using my network right now?" Per-app network attribution. | — |
+| **burrow_photos** | "Do I have near-duplicate photos in <folder>?" Visually-similar PNG/JPEG groups (dHash). Report-only. | `path` (required) |
+| **burrow_rules_dryrun** | Previewing what a community cleanup-rules directory would target: per-rule paths with risk + existence, nothing deleted. `dir` is required — no rules ship with the app. | `dir` (required), `app` |
+| **burrow_sentinel** | "Did I trash any apps whose leftovers I should sweep?" `.app` bundles currently in the Trash. | `trashdir` |
+| **burrow_slim_check** | "How much space would thinning <binary> reclaim?" Mach-O fat-slice analysis — estimate only, never rewrites the binary. | `binary` (required) |
+
 ---
 
 ## Act & maintain (actuating — gated, dry-run by default)
@@ -80,6 +96,7 @@ Every actuating call is recorded to Burrow's audit log, so the user can see what
   `burrow_process_usage` (over time) → name the culprit; offer `burrow_clean`/`optimize`
   preview only if relevant.
 - **"I'm low on disk"** → `burrow_disk_forecast` → `burrow_analyze <folder>` →
+  `burrow_dupes`/`burrow_photos`/`burrow_orphans`/`burrow_sentinel` for reclaim candidates →
   `burrow_purge`/`burrow_installer` previews → `burrow_clean` preview.
 - **"Is anything insecure / what's listening?"** → `burrow_doctor` (SIP/Gatekeeper/FileVault/
   firewall) + `burrow_ports`.

--- a/macos/Sources/MCP.swift
+++ b/macos/Sources/MCP.swift
@@ -379,6 +379,88 @@ struct ToolCatalog {
                 ] as [String: Any],
             ],
             [
+                "name": "burrow_dupes",
+                "description": "Duplicate-file groups under one or more directories via `burrow dupes` (fclones group report). Read-only — reports groups, deletes nothing.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "paths": ["type": "array", "items": ["type": "string"], "description": "Absolute directories to scan for duplicate files."],
+                    ],
+                    "required": ["paths"],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_net",
+                "description": "Per-app network attribution via `burrow net`: which apps are moving bytes right now. Read-only.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [String: Any](),
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_orphans",
+                "description": "Leftover files under a directory that belong to no installed app, via `burrow orphans`. Read-only. `installed` (comma-separated bundle ids) overrides the auto-detected app inventory.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "path": ["type": "string", "description": "Absolute directory to scan, e.g. \"~/Library/Application Support\" expanded."],
+                        "installed": ["type": "string", "description": "Optional comma-separated bundle ids to treat as installed (overrides auto-detection)."],
+                    ],
+                    "required": ["path"],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_photos",
+                "description": "Near-duplicate photos (visually similar PNG/JPEG, dHash) under a directory via `burrow photos`. Read-only — reports groups, deletes nothing.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "path": ["type": "string", "description": "Absolute directory to scan for similar images."],
+                    ],
+                    "required": ["path"],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_rules_dryrun",
+                "description": "Preview what a community rules directory would clean via `burrow rules dryrun <dir>` — per-rule paths with risk and existence, nothing deleted. Read-only. `dir` is required (no rules ship with the app); `app` filters to one bundle id.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "dir": ["type": "string", "description": "Absolute path to a rules directory (one YAML file per app)."],
+                        "app": ["type": "string", "description": "Optional bundle id to filter to a single app's rules."],
+                    ],
+                    "required": ["dir"],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_sentinel",
+                "description": ".app bundles currently sitting in the Trash (uninstall-leftover candidates) via `burrow sentinel`. Read-only. `trashdir` overrides the default ~/.Trash.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "trashdir": ["type": "string", "description": "Optional Trash directory to scan instead of ~/.Trash."],
+                    ],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
+                "name": "burrow_slim_check",
+                "description": "Mach-O fat-binary analysis via `burrow slim-check <binary>`: arch slices + bytes a thin-to-host-arch would reclaim. Read-only — estimate only, never rewrites the binary.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "binary": ["type": "string", "description": "Absolute path to a Mach-O binary (e.g. an app's main executable)."],
+                    ],
+                    "required": ["binary"],
+                    "additionalProperties": false,
+                ] as [String: Any],
+            ],
+            [
                 "name": "burrow_clean",
                 "description": "Clean caches, logs, temp files and leftovers via `mo clean`. SAFE BY DEFAULT: with no `confirm` (or confirm:false) it runs `--dry-run` and only PREVIEWS what would be freed — nothing is deleted. A real deletion needs confirm:true AND the user's opt-in ('Let agents run cleanups' in Burrow Settings); without the opt-in, confirm:true is refused and reported as blocked. Real runs are not elevated (user-level caches only).",
                 "inputSchema": [
@@ -507,6 +589,20 @@ struct ToolCatalog {
             return self.callAnalyze(arguments)
         case "burrow_list_apps":
             return self.callListApps()
+        case "burrow_dupes":
+            return try self.callDupes(arguments)
+        case "burrow_net":
+            return self.callConductor("net", [])
+        case "burrow_orphans":
+            return try self.callOrphans(arguments)
+        case "burrow_photos":
+            return try self.callPhotos(arguments)
+        case "burrow_rules_dryrun":
+            return try self.callRulesDryrun(arguments)
+        case "burrow_sentinel":
+            return self.callSentinel(arguments)
+        case "burrow_slim_check":
+            return try self.callSlimCheck(arguments)
         case "burrow_clean":
             return self.runAction(.clean, confirm: (arguments["confirm"] as? Bool) ?? false)
         case "burrow_optimize":
@@ -929,6 +1025,111 @@ struct ToolCatalog {
         }
         let out = Self.stripANSI(res.stdout).trimmingCharacters(in: .whitespacesAndNewlines)
         return out.isEmpty ? "{\"apps\":[]}" : out
+    }
+
+    // MARK: - Conductor discovery tools (Phase 6.3 parity, read-only)
+    //
+    // These expose burrow-cli's discovery commands through the bundled
+    // conductor (`burrow <cmd> --json`, BurrowConductor.capture) and pass
+    // the envelope's `data` payload through VERBATIM — the contract tracks
+    // burrow-cli's, not ours, exactly like burrow_analyze tracks Mole's.
+    // All seven are read-only: no audit rows, no confirm gates, and the
+    // mutating siblings (dupes apply/dedupe, slim, evict) stay out of MCP.
+
+    /// One shape for all seven: availability check, capture, pass `data`
+    /// through. Degrades to a JSON error object — never a throw — so an
+    /// agent on a build without the bundled conductor sees why instead of
+    /// a -32603 (same posture as the exit-127 `mo` degrade above).
+    private func callConductor(_ command: String, _ args: [String],
+                               timeout: TimeInterval = 300) -> String {
+        guard BurrowConductor.isAvailable else {
+            return Self.jsonString([
+                "error": "the burrow conductor is not bundled in this build; \(command) is unavailable",
+                "command": command])
+        }
+        do {
+            let envelope = try BurrowConductor.capture(command, args, timeout: timeout)
+            guard let data = envelope.data,
+                  let out = String(data: data, encoding: .utf8),
+                  !out.isEmpty else {
+                return Self.jsonString(["error": "burrow \(command) returned no data",
+                                        "command": command])
+            }
+            return out
+        } catch let BurrowConductorError.engine(kind, message) {
+            return Self.jsonString(["error": message, "kind": kind, "command": command])
+        } catch {
+            return Self.jsonString(["error": error.localizedDescription, "command": command])
+        }
+    }
+
+    /// `burrow dupes <paths…>` — duplicate-file groups (fclones group
+    /// report; the mutating dedupe/remove/link subcommands are not exposed).
+    private func callDupes(_ args: [String: Any]) throws -> String {
+        let paths = (args["paths"] as? [String])?
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty } ?? []
+        guard !paths.isEmpty else {
+            throw MCPToolError.badArguments("dupes needs `paths`: one or more directories to scan")
+        }
+        return self.callConductor("dupes", paths)
+    }
+
+    /// `burrow orphans <dir> [--installed id1,id2,…]` — leftover files
+    /// belonging to no installed app.
+    private func callOrphans(_ args: [String: Any]) throws -> String {
+        guard let path = (args["path"] as? String)?.trimmingCharacters(in: .whitespaces),
+              !path.isEmpty else {
+            throw MCPToolError.badArguments("orphans needs `path`: a directory to scan")
+        }
+        var argv = [path]
+        if let installed = (args["installed"] as? String)?.trimmingCharacters(in: .whitespaces),
+           !installed.isEmpty {
+            argv += ["--installed", installed]
+        }
+        return self.callConductor("orphans", argv)
+    }
+
+    /// `burrow photos <dir>` — visually-similar image groups (dHash).
+    private func callPhotos(_ args: [String: Any]) throws -> String {
+        guard let path = (args["path"] as? String)?.trimmingCharacters(in: .whitespaces),
+              !path.isEmpty else {
+            throw MCPToolError.badArguments("photos needs `path`: a directory to scan")
+        }
+        return self.callConductor("photos", [path])
+    }
+
+    /// `burrow rules dryrun <dir> [--app id]` — preview a rules directory.
+    /// The CLI defaults its dir to `rules/` relative to CWD, which is
+    /// meaningless from a GUI-spawned process (and the app bundle ships no
+    /// rules), so the tool requires an explicit `dir` — honest > broken.
+    private func callRulesDryrun(_ args: [String: Any]) throws -> String {
+        guard let dir = (args["dir"] as? String)?.trimmingCharacters(in: .whitespaces),
+              !dir.isEmpty else {
+            throw MCPToolError.badArguments("rules_dryrun needs `dir`: a rules directory (none ships with the app)")
+        }
+        var argv = ["dryrun", dir]
+        if let app = (args["app"] as? String)?.trimmingCharacters(in: .whitespaces),
+           !app.isEmpty {
+            argv += ["--app", app]
+        }
+        return self.callConductor("rules", argv)
+    }
+
+    /// `burrow sentinel [trashdir]` — .app bundles sitting in the Trash.
+    private func callSentinel(_ args: [String: Any]) -> String {
+        let trashdir = (args["trashdir"] as? String)?.trimmingCharacters(in: .whitespaces)
+        let argv = trashdir.flatMap { $0.isEmpty ? nil : [$0] } ?? []
+        return self.callConductor("sentinel", argv)
+    }
+
+    /// `burrow slim-check <binary>` — Mach-O fat-slice reclaim estimate.
+    private func callSlimCheck(_ args: [String: Any]) throws -> String {
+        guard let binary = (args["binary"] as? String)?.trimmingCharacters(in: .whitespaces),
+              !binary.isEmpty else {
+            throw MCPToolError.badArguments("slim_check needs `binary`: a path to a Mach-O binary")
+        }
+        return self.callConductor("slim-check", [binary])
     }
 
     // MARK: Action helpers

--- a/macos/Tests/MCPConductorToolsTests.swift
+++ b/macos/Tests/MCPConductorToolsTests.swift
@@ -1,0 +1,191 @@
+//
+//  MCPConductorToolsTests.swift
+//  BurrowTests
+//
+//  The Phase-6.3 conductor-parity tools (dupes, orphans, net, rules
+//  dryrun, sentinel, slim-check, photos) route through the bundled
+//  `burrow` conductor. These pin the tool CONTRACT — catalog listing,
+//  required-argument validation, the no-audit rule, and the degrade-
+//  to-JSON-error path when no conductor is bundled (the test bundle
+//  never ships one, so that branch is exercised without spawning).
+//
+
+import XCTest
+@testable import Burrow
+
+final class MCPConductorToolsTests: XCTestCase {
+    private var tempDir: URL!
+    private var db: DB!
+    private var catalog: ToolCatalog!
+    private var server: MCPServer!
+
+    /// The seven read-only discovery tools this phase adds.
+    private static let conductorTools: Set<String> = [
+        "burrow_dupes", "burrow_net", "burrow_orphans", "burrow_photos",
+        "burrow_rules_dryrun", "burrow_sentinel", "burrow_slim_check",
+    ]
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-conductor-mcp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        db = try DB(at: tempDir.appendingPathComponent("burrow.db"))
+        catalog = ToolCatalog(db: db)
+        server = MCPServer(db: db)
+    }
+
+    override func tearDown() {
+        server = nil
+        db = nil
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Catalog listing
+
+    func testDescriptors_listAllSevenConductorTools() {
+        let names = Set(catalog.descriptors().compactMap { $0["name"] as? String })
+        for tool in Self.conductorTools {
+            XCTAssertTrue(names.contains(tool), "tools/list must include \(tool)")
+        }
+    }
+
+    /// Every conductor tool carries a description that says it is read-only,
+    /// and a schema of the same shape the rest of the catalog uses.
+    func testDescriptors_conductorToolsHaveSchemaAndReadOnlyDescription() throws {
+        for d in catalog.descriptors() where Self.conductorTools.contains((d["name"] as? String) ?? "") {
+            let name = try XCTUnwrap(d["name"] as? String)
+            let desc = try XCTUnwrap(d["description"] as? String, "\(name) needs a description")
+            XCTAssertTrue(desc.localizedCaseInsensitiveContains("read-only"),
+                          "\(name) description must say read-only")
+            let schema = try XCTUnwrap(d["inputSchema"] as? [String: Any], "\(name) needs an inputSchema")
+            XCTAssertEqual(schema["type"] as? String, "object")
+            XCTAssertNotNil(schema["properties"], "\(name) schema needs properties")
+        }
+    }
+
+    /// The required arguments must be declared in the schema so agents
+    /// discover them from tools/list instead of by trial and error.
+    func testDescriptors_requiredArgumentsAreDeclared() throws {
+        let expected: [String: [String]] = [
+            "burrow_dupes": ["paths"],
+            "burrow_net": [],
+            "burrow_orphans": ["path"],
+            "burrow_photos": ["path"],
+            "burrow_rules_dryrun": ["dir"],
+            "burrow_sentinel": [],
+            "burrow_slim_check": ["binary"],
+        ]
+        for d in catalog.descriptors() {
+            guard let name = d["name"] as? String, let want = expected[name] else { continue }
+            let schema = try XCTUnwrap(d["inputSchema"] as? [String: Any])
+            let required = (schema["required"] as? [String]) ?? []
+            XCTAssertEqual(Set(required), Set(want), "\(name) required args drifted")
+            // Every required arg must also exist as a property.
+            let properties = try XCTUnwrap(schema["properties"] as? [String: Any])
+            for arg in want {
+                XCTAssertNotNil(properties[arg], "\(name) required arg `\(arg)` missing from properties")
+            }
+        }
+    }
+
+    // MARK: - Required-argument validation (before any conductor spawn)
+
+    func testDupes_withoutPaths_throwsBadArguments() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_dupes", arguments: [:])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    func testDupes_withEmptyPaths_throwsBadArguments() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_dupes",
+                                              arguments: ["paths": ["", "  "]])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    func testOrphans_withoutPath_throwsBadArguments() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_orphans", arguments: [:])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    func testRulesDryrun_withoutDir_throwsBadArguments() {
+        // The bundled conductor ships no rules/ directory and its CLI default
+        // (`rules/` relative to CWD) is meaningless from a GUI-spawned
+        // process — so `dir` is required. Honest > broken.
+        XCTAssertThrowsError(try catalog.call(name: "burrow_rules_dryrun", arguments: [:])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    func testSlimCheck_withoutBinary_throwsBadArguments() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_slim_check", arguments: [:])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    func testPhotos_withoutPath_throwsBadArguments() {
+        XCTAssertThrowsError(try catalog.call(name: "burrow_photos", arguments: [:])) { err in
+            guard case MCPToolError.badArguments = err else {
+                return XCTFail("expected .badArguments, got \(err)")
+            }
+        }
+    }
+
+    /// Over the JSON-RPC envelope the same validation must surface as the
+    /// standard -32602 invalid-arguments error.
+    func testSlimCheck_withoutBinary_is32602OverTheEnvelope() {
+        let r = server.response(toLine: Data(
+            #"{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"burrow_slim_check","arguments":{}}}"#.utf8))
+        XCTAssertEqual((r?["error"] as? [String: Any])?["code"] as? Int, -32602)
+    }
+
+    // MARK: - Read-only: never audited, never confirm-gated
+
+    func testConductorTools_areNotAudited() {
+        for tool in Self.conductorTools {
+            XCTAssertFalse(ToolCatalog.auditedTools.contains(tool),
+                           "\(tool) is read-only and must not be in auditedTools")
+        }
+    }
+
+    // MARK: - Degrade, never throw (no conductor in the test bundle)
+
+    /// The test bundle ships no Resources/burrow, so `isAvailable` is false
+    /// and the call must come back as a JSON error object naming the
+    /// conductor — never a throw, never a crash, and no process spawned.
+    func testNet_withoutBundledConductor_returnsJSONErrorMentioningConductor() throws {
+        XCTAssertFalse(BurrowConductor.isAvailable,
+                       "test bundles must not ship a conductor; this test depends on that")
+        let json = try catalog.call(name: "burrow_net", arguments: [:])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let error = try XCTUnwrap(obj["error"] as? String)
+        XCTAssertTrue(error.localizedCaseInsensitiveContains("conductor")
+                        || error.localizedCaseInsensitiveContains("burrow"),
+                      "the error must tell the agent the conductor is missing, got: \(error)")
+    }
+
+    func testSentinel_withoutBundledConductor_returnsJSONErrorNotThrow() throws {
+        let json = try catalog.call(name: "burrow_sentinel", arguments: [:])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        XCTAssertNotNil(obj["error"])
+    }
+
+    /// Valid arguments + missing conductor must still degrade (the
+    /// argument check passes, then the availability check reports).
+    func testSlimCheck_withBinaryButNoConductor_returnsJSONError() throws {
+        let json = try catalog.call(name: "burrow_slim_check", arguments: ["binary": "/usr/bin/true"])
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        XCTAssertNotNil(obj["error"])
+    }
+}

--- a/macos/Tests/MCPTests.swift
+++ b/macos/Tests/MCPTests.swift
@@ -101,7 +101,10 @@ final class MCPTests: XCTestCase {
                         "burrow_process_usage", "burrow_disk_forecast", "burrow_diff",
                         "burrow_report", "burrow_doctor", "burrow_ports", "burrow_info",
                         "burrow_cleanup_history", "burrow_deleted_files",
-                        "burrow_analyze", "burrow_list_apps", "burrow_clean",
+                        "burrow_analyze", "burrow_list_apps",
+                        "burrow_dupes", "burrow_net", "burrow_orphans",
+                        "burrow_photos", "burrow_rules_dryrun", "burrow_sentinel",
+                        "burrow_slim_check", "burrow_clean",
                         "burrow_optimize", "burrow_uninstall", "burrow_purge",
                         "burrow_installer"])
         // Every tool must carry an inputSchema and a description.


### PR DESCRIPTION
## What

Phase 6.3 "MCP parity" of the master plan: exposes burrow-cli's discovery capabilities as **7 new read-only MCP tools** in the macOS GUI, each routed through the **bundled conductor** (`BurrowConductor.capture("<cmd>", args)`) with the envelope's `data` payload passed through **verbatim** — the tool contract tracks burrow-cli's JSON, exactly like `burrow_analyze` tracks Mole's.

| Tool | Conductor command | Required args |
|---|---|---|
| `burrow_dupes` | `dupes <paths…>` (fclones group report) | `paths` |
| `burrow_net` | `net` (per-app network attribution) | — |
| `burrow_orphans` | `orphans <path> [--installed csv]` | `path` |
| `burrow_photos` | `photos <path>` (dHash near-duplicates) | `path` |
| `burrow_rules_dryrun` | `rules dryrun <dir> [--app id]` | `dir` |
| `burrow_sentinel` | `sentinel [trashdir]` (.apps in the Trash) | — |
| `burrow_slim_check` | `slim-check <binary>` (Mach-O fat-slice estimate) | `binary` |

Also updates `docs/agent-tools.md` with a new "Discovery (read-only, via the bundled conductor)" section and the corrected read-only tool count.

## Why

The GUI's MCP surface stopped at the Mole-backed tools; the conductor's discovery commands (dupes, orphans, net, rules, sentinel, slim-check, photos) had no agent-facing entry point even though the binary already ships in the app bundle. This closes that gap without adding any mutating surface.

## Guarantees

- **Read-only, by construction.** None of the 7 are in `auditedTools` and none take a `confirm` gate. The mutating siblings (`dupes apply/dedupe/remove/link`, `slim`, evict) are deliberately **not** exposed in this PR.
- **Degrade, never throw.** Mirrors the existing exit-127 missing-engine posture: no bundled conductor → `{error: "...not bundled...", command}`; capture timeout / `ok:false` envelope → `{error, kind, command}` with the conductor's classified kind. An agent never sees a -32603 just because the conductor is missing.
- **Honest `rules dryrun`.** burrow-cli defaults the rules dir to `rules/` relative to CWD — meaningless from a GUI-spawned process, and the app bundle ships no rules directory. So `dir` is a **required** argument instead of a silently-broken default.
- **Required args validated first.** Missing `paths`/`path`/`dir`/`binary` surface as the standard `-32602` invalid-arguments error via the existing `MCPToolError.badArguments` path, before any availability check or spawn.

## Verification

Tests were written first (`macos/Tests/MCPConductorToolsTests.swift`) and are the spec: catalog listing for all 7, `inputSchema`/`required` shape, -32602 on missing required args (catalog + JSON-RPC envelope level), the no-audit rule, and the missing-conductor degrade path (the test bundle ships no `Resources/burrow`, so that branch runs without spawning anything). The existing catalog-equality test in `MCPTests.swift` is updated to include the new names.

**CI is the runner** — this sandbox has no PTY for `xcodebuild test`; the suite runs on CI.