### PR TITLE
feat(gui): Duplicates view — first conductor-tool surface (Phase 6.2)

### DIFF
--- a/macos/Sources/DupesModel.swift
+++ b/macos/Sources/DupesModel.swift
@@ -1,0 +1,70 @@
+//
+//  DupesModel.swift
+//  Burrow
+//
+//  Typed shape + pure parser for `burrow dupes <dir> --json`: the conductor
+//  forwards fclones' group report verbatim in the envelope's `data`, and the
+//  GUI reads only the spine — `header.stats.redundant_file_size`,
+//  `groups[].file_len`, `groups[].files[]` — so any other fclones field can
+//  drift upstream without breaking us.
+//
+//  Parsed with JSONSerialization (like DiskScanner / BurrowEnvelope), not
+//  Codable: byte counts must stay integer-exact — a 5 GB group is
+//  5_000_000_123 B, not 5.000000123e9.
+//
+
+import Foundation
+
+/// One duplicate group: N identical files of `fileLen` bytes each.
+struct DupeGroup: Identifiable, Equatable {
+    /// Size of ONE copy, in bytes (fclones `file_len`).
+    let fileLen: Int64
+    /// Absolute paths of every identical copy (fclones `files`), ≥ 2 in
+    /// any group fclones emits.
+    let files: [String]
+
+    /// Stable identity for SwiftUI lists — the first path is unique per group.
+    var id: String { files.first ?? "\(fileLen)" }
+
+    /// Bytes reclaimable from this group if all but one copy went away.
+    var redundantBytes: Int64 { fileLen * Int64(max(0, files.count - 1)) }
+}
+
+/// A whole dupes scan: groups largest-reclaim first, plus the report's
+/// redundant-byte total.
+struct DupesReport: Equatable {
+    let groups: [DupeGroup]
+    /// Total reclaimable bytes (fclones `header.stats.redundant_file_size`;
+    /// computed from the groups when the header doesn't carry it).
+    let redundantBytes: Int64
+
+    /// Decode fclones' group-report JSON. Loose everywhere except the spine:
+    /// a group missing `file_len` or `files` is dropped, a payload that isn't
+    /// a JSON object is nil (never a crash on garbled conductor output).
+    static func parse(_ data: Data) -> DupesReport? {
+        guard let raw = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return nil
+        }
+
+        var groups: [DupeGroup] = []
+        let groupsRaw = raw["groups"] as? [[String: Any]] ?? []
+        groups.reserveCapacity(groupsRaw.count)
+        for g in groupsRaw {
+            let fileLen = (g["file_len"] as? Int64) ?? Int64(g["file_len"] as? Int ?? -1)
+            guard fileLen >= 0,
+                  let files = g["files"] as? [String], !files.isEmpty else { continue }
+            groups.append(DupeGroup(fileLen: fileLen, files: files))
+        }
+        // Largest reclaim first — the group worth acting on leads the list.
+        groups.sort { $0.redundantBytes > $1.redundantBytes }
+
+        // Prefer the header's authoritative total; fall back to the sum of
+        // per-group waste when stats are absent (or drifted).
+        let stats = (raw["header"] as? [String: Any])?["stats"] as? [String: Any]
+        let headerTotal = (stats?["redundant_file_size"] as? Int64)
+            ?? (stats?["redundant_file_size"] as? Int).map(Int64.init)
+        let total = headerTotal ?? groups.reduce(Int64(0)) { $0 + $1.redundantBytes }
+
+        return DupesReport(groups: groups, redundantBytes: total)
+    }
+}

--- a/macos/Sources/DupesView.swift
+++ b/macos/Sources/DupesView.swift
@@ -1,0 +1,304 @@
+//
+//  DupesView.swift
+//  Burrow
+//
+//  The Duplicates tab (Phase 6.2) — the first conductor-tool surface. Pick a
+//  folder, run `burrow dupes <dir> --json` off the main thread, and read the
+//  fclones group report through the pure DupesModel parser: a summary line
+//  ("N groups · X reclaimable") over a list of groups, each showing every
+//  identical copy. READ-ONLY v1 — no delete/dedupe from the GUI yet; the
+//  footnote points at the CLI command that acts.
+//
+//  Degrade: dev/CI builds without the vendor/burrow-cli submodule have no
+//  bundled conductor (`BurrowConductor.isAvailable == false`) — the pane
+//  shows an explanatory empty state instead of a dead Scan button.
+//
+
+import SwiftUI
+import AppKit
+
+struct DupesView: View {
+    @StateObject private var model = DupesModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            ZStack {
+                if !BurrowConductor.isAvailable {
+                    conductorMissing
+                } else if model.scanning {
+                    scanningProgress
+                } else if let err = model.error {
+                    errorState(err)
+                } else if let report = model.report {
+                    if report.groups.isEmpty { cleanState } else { results(report) }
+                } else {
+                    idleState
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: Toolbar
+
+    private var toolbar: some View {
+        HStack(spacing: 10) {
+            Button { pickFolder() } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "folder").font(.system(size: 11, weight: .semibold))
+                    Text(model.folder.map { ($0 as NSString).abbreviatingWithTildeInPath }
+                         ?? NSLocalizedString("Choose a folder…", comment: ""))
+                        .font(Brand.mono(11)).lineLimit(1).truncationMode(.middle)
+                        .frame(maxWidth: 340, alignment: .leading)
+                }
+                .foregroundStyle(Brand.textSecondary)
+                .padding(.horizontal, 12).padding(.vertical, 6)
+                .background(Capsule().fill(Color.black.opacity(0.22)))
+                .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
+                .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable)
+            .help(NSLocalizedString("Choose the folder to scan for duplicates", comment: ""))
+
+            Button { model.rescan() } label: {
+                Text(NSLocalizedString("Scan", comment: ""))
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .background(Capsule().fill(.white))
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable || model.folder == nil || model.scanning)
+
+            if model.scanning { ProgressView().controlSize(.small) }
+            Spacer()
+            if let report = model.report {
+                Text(summaryLine(report))
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+        }
+    }
+
+    /// "N groups · X reclaimable" — the one number this pane exists for.
+    private func summaryLine(_ report: DupesReport) -> String {
+        String(format: NSLocalizedString("%d groups · %@ reclaimable", comment: ""),
+               report.groups.count, Fmt.bytes(report.redundantBytes))
+    }
+
+    private func pickFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = NSLocalizedString("Scan", comment: "")
+        if let folder = model.folder {
+            panel.directoryURL = URL(fileURLWithPath: folder)
+        }
+        guard CrashReporter.withoutAppHangTracking({ panel.runModal() }) == .OK,
+              let url = panel.url else { return }
+        model.scan(url.path)
+    }
+
+    // MARK: States
+
+    /// Dev/CI build without the bundled conductor — explain rather than dead-end.
+    private var conductorMissing: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "shippingbox").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
+            Text(NSLocalizedString("The bundled burrow conductor is missing", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Duplicate scanning runs through the bundled `burrow` CLI. This build shipped without it — a dev build without the vendor/burrow-cli submodule. Release builds include it.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 420)
+        }
+    }
+
+    private var idleState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "doc.on.doc").font(.system(size: 26)).foregroundStyle(Tool.dupes.accent)
+            Text(NSLocalizedString("Find what you've stashed twice", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Choose a folder and Burrow finds byte-identical copies — downloads saved twice, exports duplicated across projects — and totals what one-of-each would reclaim.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 420)
+            Button { pickFolder() } label: {
+                Text(NSLocalizedString("Choose a folder…", comment: ""))
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .background(Capsule().fill(.white))
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 4)
+        }
+    }
+
+    private var scanningProgress: some View {
+        VStack(spacing: 12) {
+            Text(NSLocalizedString("Hunting duplicates", comment: ""))
+                .font(Brand.serif(18, .medium)).foregroundStyle(Brand.textPrimary)
+            HStack(spacing: 8) {
+                PulsingDot(color: Tool.dupes.accent)
+                Text((model.folder.map { ($0 as NSString).abbreviatingWithTildeInPath }) ?? "")
+                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                    .lineLimit(1).truncationMode(.middle)
+                    .frame(maxWidth: 380)
+            }
+            Text(NSLocalizedString("Hashing candidate files — large folders can take a minute.", comment: ""))
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(NSLocalizedString("Scanning for duplicates", comment: ""))
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle").font(.system(size: 22)).foregroundStyle(Brand.orange)
+            Text(message).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 340)
+        }
+    }
+
+    private var cleanState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle").font(.system(size: 24)).foregroundStyle(Tool.dupes.accent)
+            Text(NSLocalizedString("No duplicates here", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Every file in this folder is one of a kind.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+        }
+    }
+
+    // MARK: Results
+
+    private func results(_ report: DupesReport) -> some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    // Cap the rendered groups; a pathological folder can carry
+                    // thousands and the biggest wins are already sorted first.
+                    ForEach(report.groups.prefix(200)) { groupCard($0) }
+                    if report.groups.count > 200 {
+                        Text(String(format: NSLocalizedString("…and %d smaller groups. Narrow the folder to see them.", comment: ""),
+                                    report.groups.count - 200))
+                            .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                            .padding(.vertical, 8)
+                    }
+                }
+                .padding(.horizontal, 18).padding(.vertical, 14)
+            }
+            .scrollIndicators(.hidden)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            footnote
+        }
+    }
+
+    private func groupCard(_ group: DupeGroup) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(Fmt.bytes(group.fileLen))
+                    .font(Brand.mono(12, .bold)).foregroundStyle(Brand.textPrimary)
+                Text(String(format: NSLocalizedString("× %d copies", comment: ""), group.files.count))
+                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                Spacer()
+                Text(String(format: NSLocalizedString("%@ reclaimable", comment: ""), Fmt.bytes(group.redundantBytes)))
+                    .font(Brand.mono(10, .semibold)).foregroundStyle(Tool.dupes.accent)
+            }
+            ForEach(group.files, id: \.self) { path in
+                HStack(spacing: 6) {
+                    Image(systemName: "doc").font(.system(size: 9)).foregroundStyle(Brand.textTertiary)
+                    Text((path as NSString).abbreviatingWithTildeInPath)
+                        .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
+                        .lineLimit(1).truncationMode(.middle)
+                    Spacer(minLength: 0)
+                }
+                .contextMenu {
+                    Button(NSLocalizedString("Reveal in Finder", comment: "")) { AnalyzeIcons.reveal(path) }
+                }
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Brand.cardFill))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
+    }
+
+    /// v1 is report-only. Removing copies from the GUI ships later; until
+    /// then the CLI can act, keep-one and preview-first.
+    private var footnote: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "info.circle").font(.system(size: 10)).foregroundStyle(Brand.textTertiary)
+            (Text(NSLocalizedString("Read-only for now — deduplicating from here ships later. To act from the CLI: ", comment: ""))
+                + Text(verbatim: "burrow dupes dedupe <dir> --keep <ref> --apply").bold())
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            Spacer()
+        }
+        .padding(.horizontal, 18).padding(.vertical, 10)
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class DupesModel: ObservableObject {
+    /// The chosen folder (absolute path). Scans re-run against this.
+    @Published var folder: String?
+    @Published var scanning = false
+    @Published var report: DupesReport?
+    @Published var error: String?
+
+    private let opId = UUID()
+    /// Monotonic token (same pattern as AnalyzeModel.scanGen): only the
+    /// newest scan's result may land — a slow walk of a huge folder must
+    /// not clobber a scan the user has since restarted elsewhere.
+    private var scanGen = 0
+
+    /// Re-run against the current folder (the toolbar's Scan button).
+    func rescan() {
+        guard let folder else { return }
+        scan(folder)
+    }
+
+    /// Scan `path` via the bundled conductor, off the main thread. The
+    /// envelope's `data` is fclones' group report, decoded by the pure
+    /// DupesReport.parse.
+    func scan(_ path: String) {
+        folder = path
+        scanGen += 1
+        let gen = scanGen
+        scanning = true
+        error = nil
+        report = nil
+        let name = (path as NSString).lastPathComponent
+        OperationCenter.shared.begin(opId, label: String(format: NSLocalizedString("Finding duplicates in %@", comment: ""), name))
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome: Result<DupesReport, Error>
+            do {
+                let envelope = try BurrowConductor.capture("dupes", [path], timeout: 300)
+                guard let data = envelope.data, let parsed = DupesReport.parse(data) else {
+                    throw BurrowConductorError.engine(
+                        kind: "error",
+                        message: NSLocalizedString("burrow dupes returned an unreadable report", comment: ""))
+                }
+                outcome = .success(parsed)
+            } catch {
+                outcome = .failure(error)
+            }
+            Task { @MainActor in
+                guard gen == self.scanGen else { return }
+                self.scanning = false
+                switch outcome {
+                case .success(let r):
+                    self.report = r
+                    OperationCenter.shared.end(self.opId, success: true,
+                                               detail: String(format: NSLocalizedString("%d groups · %@", comment: ""),
+                                                              r.groups.count, Fmt.bytes(r.redundantBytes)))
+                case .failure(let e):
+                    self.error = e.localizedDescription
+                    OperationCenter.shared.end(self.opId, success: false,
+                                               detail: NSLocalizedString("scan failed", comment: ""))
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/RootView.swift
+++ b/macos/Sources/RootView.swift
@@ -155,6 +155,7 @@ struct RootView: View {
     private var content: some View {
         ZStack {
             AnalyzeView(isActive: pane == .tool(.analyze)).tabVisible(pane == .tool(.analyze))
+            DupesView().tabVisible(pane == .tool(.dupes))
             SoftwareView(isActive: pane == .tool(.apps)).tabVisible(pane == .tool(.apps))
             CleanHub().tabVisible(pane == .tool(.clean))
             OptimizeView().tabVisible(pane == .tool(.optimize))

--- a/macos/Sources/Tool.swift
+++ b/macos/Sources/Tool.swift
@@ -12,7 +12,7 @@
 import SwiftUI
 
 enum Tool: String, CaseIterable, Identifiable {
-    case clean, purge, installer, apps, optimize, analyze, status, ports, connectivity, tuneup
+    case clean, purge, installer, apps, optimize, analyze, dupes, status, ports, connectivity, tuneup
 
     var id: String { rawValue }
 
@@ -21,7 +21,7 @@ enum Tool: String, CaseIterable, Identifiable {
     /// optimize, then apps / analyze. The .purge/.installer cases live on for
     /// the hub cards, MCP actions, and Explain deep-links. The live dashboard
     /// isn't a tool anymore — it's Home, reached by the Burrow mark.
-    static let navOrder: [Tool] = [.clean, .optimize, .apps, .analyze, .ports, .connectivity]
+    static let navOrder: [Tool] = [.clean, .optimize, .apps, .analyze, .dupes, .ports, .connectivity]
 
     /// Lowercase tab label (matches the instrument-panel voice).
     var label: String { NSLocalizedString(rawValue, comment: "") }
@@ -35,6 +35,7 @@ enum Tool: String, CaseIterable, Identifiable {
         case .apps:      return NSLocalizedString("Apps", comment: "")
         case .optimize:  return NSLocalizedString("Optimize", comment: "")
         case .analyze:   return NSLocalizedString("Analyze", comment: "")
+        case .dupes:     return NSLocalizedString("Duplicates", comment: "")
         case .status:    return NSLocalizedString("Status", comment: "")
         case .ports:     return NSLocalizedString("Ports", comment: "")
         case .connectivity: return NSLocalizedString("Get Online", comment: "")
@@ -50,6 +51,7 @@ enum Tool: String, CaseIterable, Identifiable {
         case .apps:      return "shippingbox"
         case .optimize:  return "wand.and.stars"
         case .analyze:   return "square.grid.2x2"
+        case .dupes:     return "doc.on.doc"
         case .status:    return "waveform.path.ecg"
         case .ports:     return "network"
         case .connectivity: return "wifi"
@@ -66,6 +68,7 @@ enum Tool: String, CaseIterable, Identifiable {
         case .apps:      return Color(hex: 0xF0714E) // coral
         case .optimize:  return Color(hex: 0x8E84F0) // violet
         case .analyze:   return Color(hex: 0x4FA3E3) // azure
+        case .dupes:     return Color(hex: 0xDB7E9C) // rose
         case .status:    return Color(hex: 0xE6A93C) // gold
         case .ports:     return Color(hex: 0xB58BD6) // lilac
         case .connectivity: return Color(hex: 0x4FC3D9) // cyan
@@ -83,6 +86,7 @@ enum Tool: String, CaseIterable, Identifiable {
         case .apps:      return Color(hex: 0x2B1611)
         case .optimize:  return Color(hex: 0x1A1730)
         case .analyze:   return Color(hex: 0x0E1F2E)
+        case .dupes:     return Color(hex: 0x2A141C)
         case .status:    return Color(hex: 0x241D11)
         case .ports:     return Color(hex: 0x1B1426)
         case .connectivity: return Color(hex: 0x0E2630)
@@ -105,6 +109,7 @@ enum Tool: String, CaseIterable, Identifiable {
         case .apps:      return NSLocalizedString("Shed what you've outgrown.", comment: "")
         case .optimize:  return NSLocalizedString("Small turns, a smoother run.", comment: "")
         case .analyze:   return NSLocalizedString("Map every chamber below.", comment: "")
+        case .dupes:     return NSLocalizedString("Find what you've stashed twice.", comment: "")
         case .status:    return NSLocalizedString("Every pulse of the den.", comment: "")
         case .ports:     return NSLocalizedString("See who's listening.", comment: "")
         case .connectivity: return NSLocalizedString("Find your way back to the surface.", comment: "")

--- a/macos/Tests/DupesModelTests.swift
+++ b/macos/Tests/DupesModelTests.swift
@@ -1,0 +1,124 @@
+//
+//  DupesModelTests.swift
+//  BurrowTests
+//
+//  The pure fclones-report parser behind the Duplicates pane (Phase 6.2):
+//  `burrow dupes <dir> --json` returns an envelope whose `data` is fclones'
+//  group report. The GUI only reads the spine — `header.stats.
+//  redundant_file_size`, `groups[].file_len`, `groups[].files[]` — and must
+//  keep byte counts integer-exact (JSONSerialization, not a Codable Double
+//  bridge). Garbage or a non-object payload parses to nil, never a crash.
+//
+
+import XCTest
+@testable import Burrow
+
+final class DupesModelTests: XCTestCase {
+
+    /// A canned fclones group report, shaped like burrow-cli's testdata:
+    /// two groups, header stats carrying the redundant byte total.
+    private let canned = """
+    {
+      "header": {
+        "version": "0.34.0",
+        "timestamp": "2026-07-11T10:00:00.000000000+00:00",
+        "command": ["fclones", "group", "."],
+        "base_dir": "/Users/dev/Downloads",
+        "stats": {
+          "group_count": 2,
+          "total_file_count": 5,
+          "total_file_size": 7168,
+          "redundant_file_count": 3,
+          "redundant_file_size": 5120
+        }
+      },
+      "groups": [
+        {
+          "file_len": 1024,
+          "file_hash": "aabbccdd",
+          "files": ["/Users/dev/Downloads/a.zip", "/Users/dev/Downloads/copy of a.zip"]
+        },
+        {
+          "file_len": 2048,
+          "file_hash": "eeff0011",
+          "files": ["/Users/dev/Downloads/b.dmg", "/Users/dev/Downloads/b (1).dmg", "/Users/dev/Downloads/b (2).dmg"]
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    func testParse_readsGroupsAndStats() throws {
+        let report = try XCTUnwrap(DupesReport.parse(canned))
+        XCTAssertEqual(report.groups.count, 2)
+        XCTAssertEqual(report.redundantBytes, 5120)
+
+        // Groups come back largest-reclaim first: the 3-copy 2048 B group
+        // wastes 4096 B, ahead of the 2-copy 1024 B group's 1024 B.
+        XCTAssertEqual(report.groups[0].fileLen, 2048)
+        XCTAssertEqual(report.groups[0].files.count, 3)
+        XCTAssertEqual(report.groups[0].files.first, "/Users/dev/Downloads/b.dmg")
+        XCTAssertEqual(report.groups[0].redundantBytes, 4096)
+        XCTAssertEqual(report.groups[1].fileLen, 1024)
+        XCTAssertEqual(report.groups[1].files,
+                       ["/Users/dev/Downloads/a.zip", "/Users/dev/Downloads/copy of a.zip"])
+        XCTAssertEqual(report.groups[1].redundantBytes, 1024)
+    }
+
+    func testParse_emptyGroupsIsAValidCleanReport() throws {
+        let data = """
+        {"header": {"stats": {"group_count": 0, "redundant_file_size": 0}}, "groups": []}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(DupesReport.parse(data))
+        XCTAssertTrue(report.groups.isEmpty)
+        XCTAssertEqual(report.redundantBytes, 0)
+    }
+
+    func testParse_missingHeaderStatsFallsBackToComputedTotal() throws {
+        // A stats-less report (or a drifted header) still yields an honest
+        // total: sum of (copies − 1) × file_len over the groups.
+        let data = """
+        {"groups": [
+          {"file_len": 100, "files": ["/tmp/x", "/tmp/y", "/tmp/z"]},
+          {"file_len": 7,   "files": ["/tmp/p", "/tmp/q"]}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(DupesReport.parse(data))
+        XCTAssertEqual(report.groups.count, 2)
+        XCTAssertEqual(report.redundantBytes, 207)   // 2×100 + 1×7
+    }
+
+    func testParse_garbageIsNilNotACrash() {
+        XCTAssertNil(DupesReport.parse(Data("not json".utf8)))
+        XCTAssertNil(DupesReport.parse(Data()))
+        // Valid JSON but not an object — fclones reports are objects.
+        XCTAssertNil(DupesReport.parse(Data("[1, 2, 3]".utf8)))
+    }
+
+    func testParse_skipsMalformedGroupsKeepsGoodOnes() throws {
+        // A group missing its spine (no files / no file_len) is dropped;
+        // the rest of the report still parses.
+        let data = """
+        {"header": {"stats": {"redundant_file_size": 50}},
+         "groups": [
+           {"file_hash": "deadbeef"},
+           {"file_len": 50, "files": ["/tmp/a", "/tmp/b"]}
+         ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(DupesReport.parse(data))
+        XCTAssertEqual(report.groups.count, 1)
+        XCTAssertEqual(report.groups[0].fileLen, 50)
+    }
+
+    func testParse_keepsInt64PrecisionAboveInt32() throws {
+        // 5 GB-scale byte counts must survive exactly — the reason the
+        // parser is JSONSerialization, matching DiskScanner.parse.
+        let data = """
+        {"header": {"stats": {"redundant_file_size": 5000000123}},
+         "groups": [{"file_len": 5000000123, "files": ["/tmp/big1", "/tmp/big2"]}]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(DupesReport.parse(data))
+        XCTAssertEqual(report.redundantBytes, 5_000_000_123)
+        XCTAssertEqual(report.groups[0].fileLen, 5_000_000_123)
+        XCTAssertEqual(report.groups[0].redundantBytes, 5_000_000_123)
+    }
+}


### PR DESCRIPTION
## What

Phase 6.2 of the master plan: surface the conductor discovery tools as GUI views. This is the first slice — **one** new tool pane, **Duplicates** (`burrow dupes`), kept deliberately small and reviewable.

- **Tool.swift** — new `dupes` case: SF Symbol `doc.on.doc`, title "Duplicates", rose accent (`0xDB7E9C`) + dark tint + tagline, placed in `navOrder` right after Analyze. The floating rail picks it up automatically.
- **DupesModel.swift** (new, pure) — `DupeGroup { fileLen, files }` / `DupesReport { groups, redundantBytes }` with `parse(_ data:) -> DupesReport?` reading fclones' group report (`header.stats.redundant_file_size`, `groups[].file_len`, `groups[].files[]`). JSONSerialization like `DiskScanner.parse` so byte counts stay integer-exact; loose everywhere except the spine; groups sorted largest-reclaim first; header total falls back to a computed sum.
- **DupesView.swift** (new) — NSOpenPanel folder pick (SettingsView's `withoutAppHangTracking` pattern), then `BurrowConductor.capture("dupes", [path], timeout: 300)` on a background queue with AnalyzeModel's `scanGen` supersede token. Summary line ("N groups · X reclaimable" via `Fmt.bytes`), group cards listing every copy with Reveal-in-Finder, groups capped at 200 rendered.
- **RootView.swift** — dispatch case for the new pane.

## Read-only v1

No delete/dedupe from the GUI yet — a footnote says actions ship later and names the CLI path: `burrow dupes dedupe <dir> --keep <ref> --apply`.

## Degrade

`BurrowConductor.isAvailable == false` (dev/CI build without the `vendor/burrow-cli` submodule) → explanatory empty state instead of a dead Scan button; the toolbar disables itself.

## Tests (written first)

`macos/Tests/DupesModelTests.swift`, mirroring DiskScannerTests style:
- canned fclones report → groups + stats + largest-reclaim-first ordering
- empty `groups` → valid clean report
- missing header stats → computed fallback total
- garbage / empty / non-object JSON → `nil`, never a crash
- malformed group dropped, good ones kept
- `Int64` precision above Int32 (5 GB-scale byte counts stay exact)

Sandbox has no PTY for `xcodebuild test`, so CI is the runner for the suite; sources were syntax-checked locally.

## Follow-ups (deliberately not in this PR)

- Orphans / Photos / Net panes (same conductor pattern, one slice each)
- GUI dedupe actions (gated, preview-first) once the envelope's action contract lands
- zh-Hans / zh-Hant strings for the new keys (siblings like Ports are also pending)