### PR TITLE
fix(macos): actionable uninstall failures (#254) + ANSI-free task reports (#257)

### DIFF
--- a/macos/Sources/SoftwareView.swift
+++ b/macos/Sources/SoftwareView.swift
@@ -851,6 +851,36 @@ final class SoftwareModel: ObservableObject {
                 MoCommand(target: .mo, args: ticket.command.args, stdin: ticket.command.stdin,
                           timeout: ticket.command.timeout ?? 600))
             let ok = (res?.exitCode ?? 1) == 0
+
+            // FAILURE (#254): the apps are still installed, so there's nothing to re-scan —
+            // keep the list AND the selection so the user can retry, and surface the
+            // engine's actual error in an alert (the HUD alone can be invisible when the
+            // menu-bar icon is off).
+            guard ok else {
+                let engineError = [res?.stderr, res?.stdout]
+                    .compactMap { $0 }
+                    .joined(separator: "\n")
+                    .components(separatedBy: "\n")
+                    .map { Ansi.strip($0).trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
+                    .suffix(6)
+                    .joined(separator: "\n")
+                Task { @MainActor in
+                    self.loading = false
+                    OperationCenter.shared.end(opId, success: false,
+                                               detail: NSLocalizedString("uninstall failed", comment: ""))
+                    let alert = NSAlert()
+                    alert.messageText = NSLocalizedString("Uninstall failed", comment: "")
+                    alert.informativeText = engineError.isEmpty
+                        ? NSLocalizedString("The engine reported a failure with no error output. Nothing was removed.", comment: "")
+                        : engineError
+                    alert.alertStyle = .warning
+                    alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
+                    alert.runModalQuiet()
+                }
+                return
+            }
+
             let parsed = Self.fetch()
             Task { @MainActor in
                 self.apps = parsed
@@ -861,9 +891,8 @@ final class SoftwareModel: ObservableObject {
                 // would silently collapse after an uninstall.
                 self.recentLoaded = false
                 if self.sort == .recent { self.ensureRecentDates() }
-                OperationCenter.shared.end(opId, success: ok,
-                                           detail: ok ? "\(targets.count) moved to Trash"
-                                                      : NSLocalizedString("uninstall failed", comment: ""))
+                OperationCenter.shared.end(opId, success: true,
+                                           detail: "\(targets.count) moved to Trash")
             }
         }
     }

--- a/macos/Sources/TaskReport.swift
+++ b/macos/Sources/TaskReport.swift
@@ -168,7 +168,9 @@ func parseTaskReport(_ lines: [String]) -> (groups: [TaskGroup], summary: TaskSu
     var sawSummary = false
 
     for raw in lines {
-        let t = raw.trimmingCharacters(in: .whitespaces)
+        // The engine styles its report (sizes in red, headers bold); strip ANSI here — the
+        // single parse chokepoint — so no consumer ever renders literal "[0;31m…" (#257).
+        let t = Ansi.strip(raw).trimmingCharacters(in: .whitespaces)
         if t.isEmpty || t.hasPrefix("↳") { continue }
 
         if t.hasPrefix("➤") {

--- a/macos/Tests/TaskReportTests.swift
+++ b/macos/Tests/TaskReportTests.swift
@@ -51,6 +51,22 @@ final class TaskReportTests: XCTestCase {
         XCTAssertEqual(result.groups.count, 1)
     }
 
+    func testStripsAnsiColorCodes_issue257() throws {
+        // The engine colors its dry-run sizes; unstripped escapes leaked into Tune-Up as
+        // literal "[0;31m1.9GB[0m" (#257). Every consumer of parseTaskReport must see
+        // clean text regardless of styling.
+        let lines = [
+            "➤ \u{1B}[1mDeveloper tools\u{1B}[0m",
+            "  → npm cache, \u{1B}[0;31m191.8MB\u{1B}[0m",
+            "Potential space: \u{1B}[0;31m1.9GB\u{1B}[0m | Items: 372 | Categories: 20",
+        ]
+        let result = parseTaskReport(lines)
+        let summary = try XCTUnwrap(result.summary)
+        XCTAssertEqual(summary.space, "1.9GB", "no escape bytes or bracket codes may survive")
+        XCTAssertEqual(result.groups.first?.title, "Developer tools")
+        XCTAssertEqual(result.groups.first?.items.first?.text, "npm cache, 191.8MB")
+    }
+
     // The one-line result shared by the Clean done-banner and the
     // completion notification: real freed-space numbers when present,
     // the tracked size otherwise.


### PR DESCRIPTION
Fixes #254 and #257 (two of the three new issues; #253's root cause is the ENGINE's /dev/tty detection — fixed in caezium/burrow-engine#6, re-pin to follow).

- **#254**: `SoftwareModel.engineUninstall` failure no longer rescans + clears the selection with only a transient HUD ping. The apps are still installed — so the list/selection stay for a retry, and an **alert shows the engine's actual error tail** (ANSI-stripped). Success path unchanged.
- **#257**: `parseTaskReport` strips ANSI at the single parse chokepoint — Tune-Up's 'Clean caches & junk' size (and every other TaskReport consumer) never renders literal `[0;31m…[0m` again. Test-first (`testStripsAnsiColorCodes_issue257`).

CI runs the suite; the #254 alert path is hand-testable by reproducing #253 (root-owned app, cold sudo cache) until the engine fix ships.