### PR TITLE
fix(macos): Duplicates pane speaks the app's design language — selectable copies, Trash flow

### DIFF
--- a/macos/Sources/DupesModel.swift
+++ b/macos/Sources/DupesModel.swift
@@ -69,6 +69,81 @@ struct DupesReport: Equatable {
     }
 }
 
+/// Which copies the user has ticked for removal — the same shape as CleanSelection so the
+/// Duplicates pane reads like the Clean review checklist. Pure + tested. THE invariant:
+/// every group always keeps at least one unticked copy (removing all copies of a file is
+/// data loss, not deduplication) — a toggle that would violate it is refused.
+struct DupesSelection: Equatable {
+    private(set) var ticked: Set<String>
+
+    /// Default selection: every copy EXCEPT each group's first (fclones lists its keep
+    /// choice first) — the standard "keep one of each" starting point.
+    init(report: DupesReport) {
+        var t = Set<String>()
+        for g in report.groups {
+            for f in g.files.dropFirst() {
+                t.insert(f)
+            }
+        }
+        ticked = t
+    }
+
+    func isTicked(_ path: String) -> Bool { ticked.contains(path) }
+
+    /// Toggle one copy. Ticking is refused (no-op) when it would select EVERY copy of the
+    /// path's group — the keep-one guard.
+    mutating func toggle(_ path: String, in report: DupesReport) {
+        if ticked.contains(path) {
+            ticked.remove(path)
+            return
+        }
+        guard let group = report.groups.first(where: { $0.files.contains(path) }) else { return }
+        let wouldBeTicked = group.files.filter { ticked.contains($0) || $0 == path }
+        if wouldBeTicked.count >= group.files.count { return } // keep-one guard
+        ticked.insert(path)
+    }
+
+    /// Is `path` the group's LAST unticked copy (the one the guard is protecting)?
+    func isKeptCopy(_ path: String, in group: DupeGroup) -> Bool {
+        !ticked.contains(path) && selectedCount(in: group) == group.files.count - 1
+    }
+
+    enum GroupState { case all, mixed, none }
+
+    /// Tri-state over the group's selectable maximum (all copies minus the kept one).
+    func groupState(_ group: DupeGroup) -> GroupState {
+        let n = selectedCount(in: group)
+        if n == 0 { return .none }
+        return n >= group.files.count - 1 ? .all : .mixed
+    }
+
+    /// Group checkbox: at-max -> none; anything else -> the default all-but-first.
+    mutating func toggleGroup(_ group: DupeGroup) {
+        if groupState(group) == .all {
+            for f in group.files { ticked.remove(f) }
+        } else {
+            for f in group.files { ticked.remove(f) }
+            for f in group.files.dropFirst() { ticked.insert(f) }
+        }
+    }
+
+    func selectedCount(in group: DupeGroup) -> Int {
+        group.files.filter { ticked.contains($0) }.count
+    }
+
+    func selectedBytes(in report: DupesReport) -> Int64 {
+        report.groups.reduce(Int64(0)) { sum, g in
+            sum + g.fileLen * Int64(selectedCount(in: g))
+        }
+    }
+
+    func selectedPaths(in report: DupesReport) -> [String] {
+        report.groups.flatMap { g in g.files.filter { ticked.contains($0) } }
+    }
+
+    var isEmpty: Bool { ticked.isEmpty }
+}
+
 /// The conductor's dedupe PREVIEW (`burrow dupes dedupe <dir>`, no --apply): either
 /// fclones' own dry-run plan (`cp -c <src> <dst>` per clone — exactly what --apply
 /// executes) or a skip (nothing actionable). Parsed loose, like DupesReport.

--- a/macos/Sources/DupesView.swift
+++ b/macos/Sources/DupesView.swift
@@ -2,16 +2,21 @@
 //  DupesView.swift
 //  Burrow
 //
-//  The Duplicates tab (Phase 6.2) — the first conductor-tool surface. Pick a
-//  folder, run `burrow dupes <dir> --json` off the main thread, and read the
-//  fclones group report through the pure DupesModel parser: a summary line
-//  ("N groups · X reclaimable") over a list of groups, each showing every
-//  identical copy. READ-ONLY v1 — no delete/dedupe from the GUI yet; the
-//  footnote points at the CLI command that acts.
+//  The Duplicates tab — a conductor-tool surface that reads like the rest of the app:
+//  Analyze's toolbar idiom (up arrow + breadcrumbs + icon buttons), the Clean review
+//  checklist idiom (tri-state group cards + ticked item rows), and Clean's Trash flow
+//  (alert -> FileManager.trashItem -> DoneBanner). Scanning runs `burrow dupes <dir>
+//  --json` off the main thread through the pure DupesModel parser.
 //
-//  Degrade: dev/CI builds without the vendor/burrow-cli submodule have no
-//  bundled conductor (`BurrowConductor.isAvailable == false`) — the pane
-//  shows an explanatory empty state instead of a dead Scan button.
+//  Acting, two ways — both explain-before-act:
+//    * "Move to Trash · X" removes the TICKED copies (default: all but one per group,
+//      keep-one guarded by DupesSelection) via the native Trash — recoverable, exactly
+//      like Clean's trash mode.
+//    * "Reclaim via clones…" keeps every path and converts whole-scan duplicates to APFS
+//      clones (`burrow dupes dedupe`), confirmed with fclones' own dry-run plan.
+//
+//  Degrade: dev/CI builds without the vendor/burrow-cli submodule have no bundled
+//  conductor — the pane explains instead of dead-ending.
 //
 
 import SwiftUI
@@ -19,6 +24,7 @@ import AppKit
 
 struct DupesView: View {
     @StateObject private var model = DupesModel()
+    @State private var trashResult: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,93 +45,63 @@ struct DupesView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .overlay(alignment: .bottom) {
+            if let result = trashResult {
+                DoneBanner(accent: Tool.dupes.accent, title: NSLocalizedString("Moved to Trash", comment: ""), detail: result)
+                    .padding(.horizontal, 18).padding(.bottom, 10)
+                    .onTapGesture { trashResult = nil }
+            }
+        }
     }
 
-    // MARK: Toolbar
+    // MARK: Toolbar (Analyze's idiom: up + crumbs + info + icon buttons)
 
     private var toolbar: some View {
-        HStack(spacing: 10) {
-            Button { pickFolder() } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "folder").font(.system(size: 11, weight: .semibold))
-                    Text(model.folder.map { ($0 as NSString).abbreviatingWithTildeInPath }
-                         ?? NSLocalizedString("Choose a folder…", comment: ""))
-                        .font(Brand.mono(11)).lineLimit(1).truncationMode(.middle)
-                        .frame(maxWidth: 340, alignment: .leading)
+        HStack(spacing: 8) {
+            Button { model.goUp() } label: {
+                Image(systemName: "arrow.up").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(model.canGoUp ? Brand.textSecondary : Brand.textTertiary.opacity(0.35))
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain).disabled(!model.canGoUp)
+            .help(NSLocalizedString("Scan the parent folder", comment: ""))
+
+            if model.crumbs.isEmpty {
+                Text(NSLocalizedString("Choose a folder to scan", comment: ""))
+                    .font(Brand.mono(12)).foregroundStyle(Brand.textTertiary)
+            }
+            ForEach(Array(model.crumbs.enumerated()), id: \.offset) { idx, crumb in
+                if idx > 0 {
+                    Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Brand.textTertiary)
                 }
-                .foregroundStyle(Brand.textSecondary)
-                .padding(.horizontal, 12).padding(.vertical, 6)
-                .background(Capsule().fill(Color.black.opacity(0.22)))
-                .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
-                .contentShape(Capsule())
-            }
-            .buttonStyle(.plain)
-            .disabled(!BurrowConductor.isAvailable)
-            .help(NSLocalizedString("Choose the folder to scan for duplicates", comment: ""))
-
-            Button { model.rescan() } label: {
-                Text(NSLocalizedString("Scan", comment: ""))
-                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
-                    .padding(.horizontal, 14).padding(.vertical, 6)
-                    .background(Capsule().fill(.white))
-            }
-            .buttonStyle(.plain)
-            .disabled(!BurrowConductor.isAvailable || model.folder == nil || model.scanning)
-
-            // Act: clone-dedupe the scanned folder. Explain-before-act — this runs the
-            // conductor's PREVIEW first and confirms with fclones' own plan; only the
-            // confirm dialog triggers --apply. Enabled only when a scan found waste.
-            if let report = model.report, !report.groups.isEmpty {
-                Button { startDedupe(report) } label: {
-                    Text(String(format: NSLocalizedString("Reclaim %@…", comment: ""),
-                                Fmt.bytes(report.redundantBytes)))
-                        .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
-                        .padding(.horizontal, 14).padding(.vertical, 6)
-                        .background(Capsule().fill(Tool.dupes.accent))
+                Button { model.goToCrumb(idx) } label: {
+                    Text(crumb.name)
+                        .font(Brand.mono(12, idx == model.crumbs.count - 1 ? .semibold : .regular))
+                        .foregroundStyle(idx == model.crumbs.count - 1 ? Brand.textPrimary : Brand.textSecondary)
                 }
                 .buttonStyle(.plain)
-                .disabled(model.scanning || model.deduping)
-                .help(NSLocalizedString("Deduplicate with APFS clones — every path stays, the copies share storage. Nothing is deleted.", comment: ""))
             }
-
-            if model.scanning || model.deduping { ProgressView().controlSize(.small) }
             Spacer()
             if let report = model.report {
                 Text(summaryLine(report))
                     .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
             }
-        }
-    }
-
-    /// Preview -> confirm -> apply. The dialog shows fclones' own dry-run plan (the exact
-    /// `cp -c` clones --apply will make) so consent is informed, and repeats the safety
-    /// property: paths stay, bytes get shared, nothing is deleted.
-    private func startDedupe(_ report: DupesReport) {
-        model.dedupePreview { preview in
-            guard let preview else { return } // model.error carries the reason
-            let alert = NSAlert()
-            if preview.skipped || preview.plan.isEmpty {
-                alert.messageText = NSLocalizedString("Nothing to deduplicate", comment: "")
-                alert.informativeText = NSLocalizedString("Every duplicate here is protected, cross-volume, or already a clone — there is nothing safe to reclaim.", comment: "")
-                alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
-                alert.runModalQuiet()
-                return
+            Button { pickFolder() } label: {
+                Image(systemName: "folder").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Brand.textSecondary)
             }
-            alert.messageText = String(
-                format: NSLocalizedString("Reclaim %@ by clone-deduplicating?", comment: ""),
-                Fmt.bytes(report.redundantBytes))
-            let shown = preview.plan.prefix(6).map { "  " + $0 }.joined(separator: "\n")
-            let more = preview.plan.count > 6
-                ? "\n" + String(format: NSLocalizedString("  …and %d more", comment: ""), preview.plan.count - 6)
-                : ""
-            alert.informativeText = String(
-                format: NSLocalizedString("%d groups become APFS clones — every file keeps its path and contents; the copies share storage. Nothing is deleted, and edits to one copy no longer affect the others.\n\nPlanned clones:\n%@%@", comment: ""),
-                preview.groups, shown, more)
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: NSLocalizedString("Reclaim", comment: ""))
-            alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
-            guard alert.runModalQuiet() == .alertFirstButtonReturn else { return }
-            model.dedupeApply()
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable)
+            .help(NSLocalizedString("Choose a folder…", comment: ""))
+            Button { model.rescan() } label: {
+                Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(model.folder == nil ? Brand.textTertiary.opacity(0.35) : Brand.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable || model.folder == nil || model.scanning)
+            .help(NSLocalizedString("Rescan", comment: ""))
         }
     }
 
@@ -151,7 +127,6 @@ struct DupesView: View {
 
     // MARK: States
 
-    /// Dev/CI build without the bundled conductor — explain rather than dead-end.
     private var conductorMissing: some View {
         VStack(spacing: 10) {
             Image(systemName: "shippingbox").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
@@ -168,9 +143,9 @@ struct DupesView: View {
             Image(systemName: "doc.on.doc").font(.system(size: 26)).foregroundStyle(Tool.dupes.accent)
             Text(NSLocalizedString("Find what you've stashed twice", comment: ""))
                 .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
-            Text(NSLocalizedString("Choose a folder and Burrow finds byte-identical copies — downloads saved twice, exports duplicated across projects — and totals what one-of-each would reclaim.", comment: ""))
+            Text(NSLocalizedString("Choose a folder and Burrow finds byte-identical copies, preselects all but one of each, and moves the extras to the Trash — or reclaims their space with APFS clones, deleting nothing.", comment: ""))
                 .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
-                .multilineTextAlignment(.center).frame(maxWidth: 420)
+                .multilineTextAlignment(.center).frame(maxWidth: 440)
             Button { pickFolder() } label: {
                 Text(NSLocalizedString("Choose a folder…", comment: ""))
                     .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
@@ -218,70 +193,260 @@ struct DupesView: View {
         }
     }
 
-    // MARK: Results
+    // MARK: Results (Clean review's checklist idiom)
 
     private func results(_ report: DupesReport) -> some View {
         VStack(spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 14) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(NSLocalizedString("Review duplicates", comment: ""))
+                        .font(Brand.serif(22, .medium)).foregroundStyle(Brand.textPrimary)
+                    Text(NSLocalizedString("Ticked copies go to the Trash; every group always keeps at least one. Untick anything you'd rather hold on to.", comment: ""))
+                        .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 18).padding(.top, 14).padding(.bottom, 10)
             ScrollView {
                 LazyVStack(spacing: 10) {
-                    // Cap the rendered groups; a pathological folder can carry
-                    // thousands and the biggest wins are already sorted first.
-                    ForEach(report.groups.prefix(200)) { groupCard($0) }
+                    ForEach(report.groups.prefix(200)) { group in
+                        groupCard(group, report: report)
+                    }
                     if report.groups.count > 200 {
                         Text(String(format: NSLocalizedString("…and %d smaller groups. Narrow the folder to see them.", comment: ""),
                                     report.groups.count - 200))
                             .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
                             .padding(.vertical, 8)
                     }
+                    Color.clear.frame(height: 56) // room for the floating footer pill
                 }
-                .padding(.horizontal, 18).padding(.vertical, 14)
+                .padding(.horizontal, 18).padding(.bottom, 6)
             }
             .scrollIndicators(.hidden)
-            Rectangle().fill(Brand.hairline).frame(height: 1)
-            footnote
         }
+        .overlay(alignment: .bottom) { footer(report) }
     }
 
-    private func groupCard(_ group: DupeGroup) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 8) {
-                Text(Fmt.bytes(group.fileLen))
-                    .font(Brand.mono(12, .bold)).foregroundStyle(Brand.textPrimary)
-                Text(String(format: NSLocalizedString("× %d copies", comment: ""), group.files.count))
-                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
-                Spacer()
-                Text(String(format: NSLocalizedString("%@ reclaimable", comment: ""), Fmt.bytes(group.redundantBytes)))
-                    .font(Brand.mono(10, .semibold)).foregroundStyle(Tool.dupes.accent)
+    private func groupCard(_ group: DupeGroup, report: DupesReport) -> some View {
+        let isOpen = model.openGroups.contains(group.id)
+        return VStack(spacing: 0) {
+            Button {
+                if isOpen { model.openGroups.remove(group.id) } else { model.openGroups.insert(group.id) }
+            } label: {
+                HStack(spacing: 10) {
+                    triStateBox(model.selection.groupState(group)) { model.toggleGroup(group) }
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 13)).foregroundStyle(Tool.dupes.accent)
+                        .frame(width: 20)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 8) {
+                            Text(String(format: NSLocalizedString("%@ × %d copies", comment: ""),
+                                        Fmt.bytes(group.fileLen), group.files.count))
+                                .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                            Text(verbatim: "\(model.selection.selectedCount(in: group))/\(group.files.count) selected")
+                                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                        }
+                        Text((group.files.first.map { ($0 as NSString).abbreviatingWithTildeInPath }) ?? "")
+                            .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                            .lineLimit(1).truncationMode(.middle)
+                    }
+                    Spacer()
+                    Text(verbatim: "\(Fmt.bytes(group.fileLen * Int64(model.selection.selectedCount(in: group)))) / \(Fmt.bytes(group.redundantBytes))")
+                        .font(Brand.mono(11, .medium)).foregroundStyle(Tool.dupes.accent)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold)).foregroundStyle(Brand.textTertiary)
+                        .rotationEffect(.degrees(isOpen ? 90 : 0))
+                }
+                .padding(13)
+                .contentShape(Rectangle())
             }
-            ForEach(group.files, id: \.self) { path in
-                HStack(spacing: 6) {
-                    Image(systemName: "doc").font(.system(size: 9)).foregroundStyle(Brand.textTertiary)
-                    Text((path as NSString).abbreviatingWithTildeInPath)
-                        .font(Brand.mono(10)).foregroundStyle(Brand.textSecondary)
-                        .lineLimit(1).truncationMode(.middle)
-                    Spacer(minLength: 0)
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(String(format: NSLocalizedString("%@ times %d copies, %d selected", comment: ""),
+                                       Fmt.bytes(group.fileLen), group.files.count,
+                                       model.selection.selectedCount(in: group)))
+            .accessibilityAddTraits(.isButton)
+
+            if isOpen {
+                Rectangle().fill(Brand.hairline).frame(height: 1).padding(.horizontal, 13)
+                VStack(spacing: 0) {
+                    ForEach(group.files, id: \.self) { path in
+                        copyRow(path, group: group, report: report)
+                    }
                 }
-                .contextMenu {
-                    Button(NSLocalizedString("Reveal in Finder", comment: "")) { AnalyzeIcons.reveal(path) }
-                }
+                .padding(.vertical, 4)
             }
         }
-        .padding(12)
         .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Brand.cardFill))
         .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
-    /// Reclaim clones in place (non-destructive); DELETING extra copies stays CLI-only,
-    /// where reference folders can be protected explicitly.
-    private var footnote: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "info.circle").font(.system(size: 10)).foregroundStyle(Brand.textTertiary)
-            (Text(NSLocalizedString("Reclaim uses APFS clones — nothing is deleted. To delete extra copies instead (keep-one, preview-first): ", comment: ""))
-                + Text(verbatim: "burrow dupes remove <dir> --keep <ref> --apply").bold())
-                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
-            Spacer()
+    private func triStateBox(_ state: DupesSelection.GroupState, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(state == .none ? Color.white.opacity(0.07) : Tool.dupes.accent.opacity(0.9))
+                    .frame(width: 17, height: 17)
+                switch state {
+                case .all:
+                    Image(systemName: "checkmark").font(.system(size: 9, weight: .bold)).foregroundStyle(.black)
+                case .mixed:
+                    Image(systemName: "minus").font(.system(size: 9, weight: .bold)).foregroundStyle(.black)
+                case .none:
+                    EmptyView()
+                }
+            }
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Brand.hairline, lineWidth: 1))
         }
-        .padding(.horizontal, 18).padding(.vertical, 10)
+        .buttonStyle(.plain)
+        .accessibilityLabel(NSLocalizedString("Toggle group", comment: ""))
+    }
+
+    private func copyRow(_ path: String, group: DupeGroup, report: DupesReport) -> some View {
+        let ticked = model.selection.isTicked(path)
+        let kept = model.selection.isKeptCopy(path, in: group)
+        return HStack(spacing: 10) {
+            Button { model.toggle(path) } label: {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(ticked ? Tool.dupes.accent.opacity(0.9) : Color.white.opacity(0.07))
+                        .frame(width: 15, height: 15)
+                    if ticked {
+                        Image(systemName: "checkmark").font(.system(size: 8, weight: .bold)).foregroundStyle(.black)
+                    }
+                }
+                .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Brand.hairline, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel((path as NSString).lastPathComponent)
+            .accessibilityValue(ticked ? NSLocalizedString("selected", comment: "") : NSLocalizedString("not selected", comment: ""))
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text((path as NSString).lastPathComponent)
+                    .font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
+                    .lineLimit(1)
+                Text((path as NSString).abbreviatingWithTildeInPath)
+                    .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+            Spacer()
+            if kept {
+                Text(NSLocalizedString("kept", comment: ""))
+                    .font(Brand.mono(9, .medium)).foregroundStyle(Tool.dupes.accent)
+                    .padding(.horizontal, 5).padding(.vertical, 1.5)
+                    .background(Capsule().fill(Tool.dupes.accent.opacity(0.16)))
+                    .help(NSLocalizedString("Every group keeps at least one copy — tick a different one to keep instead.", comment: ""))
+            }
+            Text(Fmt.bytes(group.fileLen)).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .frame(minWidth: 56, alignment: .trailing)
+            Button { AnalyzeIcons.reveal(path) } label: {
+                Image(systemName: "magnifyingglass.circle")
+                    .font(.system(size: 12)).foregroundStyle(Brand.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .help(NSLocalizedString("Reveal in Finder", comment: ""))
+        }
+        .padding(.horizontal, 13).padding(.vertical, 5)
+    }
+
+    // MARK: Footer (Clean review's confirm-pill idiom)
+
+    private func footer(_ report: DupesReport) -> some View {
+        HStack(spacing: 10) {
+            Button { startDedupe(report) } label: {
+                Text(NSLocalizedString("Reclaim via clones…", comment: ""))
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.textPrimary)
+                    .padding(.horizontal, 14).padding(.vertical, 8)
+                    .background(Capsule().fill(Color.white.opacity(0.08)))
+                    .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+            .disabled(model.deduping || model.scanning)
+            .help(NSLocalizedString("Keep every file; duplicates share storage via APFS clones. Nothing is deleted.", comment: ""))
+
+            Button { trashTicked(report) } label: {
+                Text(String(format: NSLocalizedString("Move to Trash · %@", comment: "confirm pill"),
+                            Fmt.bytes(model.selection.selectedBytes(in: report))))
+                    .font(Brand.sans(12, .semibold))
+                    .foregroundStyle(model.selection.isEmpty ? Brand.textTertiary : .black)
+                    .padding(.horizontal, 16).padding(.vertical, 8)
+                    .background(Capsule().fill(model.selection.isEmpty ? Color.white.opacity(0.06) : Color.white))
+            }
+            .buttonStyle(.plain)
+            .disabled(model.selection.isEmpty || model.deduping || model.scanning)
+            if model.deduping { ProgressView().controlSize(.small) }
+        }
+        .padding(.horizontal, 18).padding(.bottom, 12)
+    }
+
+    /// Clean's exact trash flow: alert with count+size -> FileManager.trashItem per path
+    /// (recoverable) -> HUD + banner -> rescan for the post-move truth.
+    private func trashTicked(_ report: DupesReport) {
+        let paths = model.selection.selectedPaths(in: report)
+        guard !paths.isEmpty else { return }
+        let total = model.selection.selectedBytes(in: report)
+        let alert = NSAlert()
+        alert.messageText = String(format: NSLocalizedString("Move %d duplicate copies (%@) to the Trash?", comment: ""),
+                                   paths.count, Fmt.bytes(total))
+        alert.informativeText = NSLocalizedString("Every group keeps at least one copy. The moved copies stay recoverable until you empty the Trash.", comment: "")
+        alert.addButton(withTitle: NSLocalizedString("Move to Trash", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
+        guard alert.runModalQuiet() == .alertFirstButtonReturn else { return }
+
+        let opID = UUID()
+        OperationCenter.shared.begin(opID, label: NSLocalizedString("Moving duplicates to Trash", comment: ""),
+                                     notifiesOnEnd: true)
+        DispatchQueue.global(qos: .userInitiated).async {
+            var moved = 0, failed = 0
+            for path in paths {
+                do {
+                    try FileManager.default.trashItem(at: URL(fileURLWithPath: path), resultingItemURL: nil)
+                    moved += 1
+                } catch {
+                    failed += 1
+                }
+            }
+            DispatchQueue.main.async {
+                OperationCenter.shared.end(opID, success: failed == 0,
+                                           detail: String(format: NSLocalizedString("%d moved · %d failed", comment: ""), moved, failed))
+                trashResult = failed == 0
+                    ? String(format: NSLocalizedString("Moved %d copies (%@) to the Trash.", comment: ""), moved, Fmt.bytes(total))
+                    : String(format: NSLocalizedString("Moved %d copies; %d were locked or already gone.", comment: ""), moved, failed)
+                model.rescan()
+            }
+        }
+    }
+
+    /// The non-destructive path: conductor dedupe preview -> confirm with fclones' own
+    /// `cp -c` plan -> --apply -> rescan.
+    private func startDedupe(_ report: DupesReport) {
+        model.dedupePreview { preview in
+            guard let preview else { return } // model.error carries the reason
+            let alert = NSAlert()
+            if preview.skipped || preview.plan.isEmpty {
+                alert.messageText = NSLocalizedString("Nothing to deduplicate", comment: "")
+                alert.informativeText = NSLocalizedString("Every duplicate here is protected, cross-volume, or already a clone — there is nothing safe to reclaim.", comment: "")
+                alert.addButton(withTitle: NSLocalizedString("OK", comment: ""))
+                alert.runModalQuiet()
+                return
+            }
+            alert.messageText = String(
+                format: NSLocalizedString("Reclaim %@ by clone-deduplicating?", comment: ""),
+                Fmt.bytes(report.redundantBytes))
+            let shown = preview.plan.prefix(6).map { "  " + $0 }.joined(separator: "\n")
+            let more = preview.plan.count > 6
+                ? "\n" + String(format: NSLocalizedString("  …and %d more", comment: ""), preview.plan.count - 6)
+                : ""
+            alert.informativeText = String(
+                format: NSLocalizedString("%d groups become APFS clones — every file keeps its path and contents; the copies share storage. Nothing is deleted, and edits to one copy no longer affect the others.\n\nPlanned clones:\n%@%@", comment: ""),
+                preview.groups, shown, more)
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: NSLocalizedString("Reclaim", comment: ""))
+            alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
+            guard alert.runModalQuiet() == .alertFirstButtonReturn else { return }
+            model.dedupeApply()
+        }
     }
 }
 
@@ -295,22 +460,71 @@ final class DupesModel: ObservableObject {
     @Published var deduping = false
     @Published var report: DupesReport?
     @Published var error: String?
+    /// The Clean-review checklist state over the current report.
+    @Published var selection = DupesSelection(report: DupesReport(groups: [], redundantBytes: 0))
+    /// Which group cards are expanded (collapsed by default, like Clean's categories).
+    @Published var openGroups: Set<String> = []
 
     private let opId = UUID()
-    /// Monotonic token (same pattern as AnalyzeModel.scanGen): only the
-    /// newest scan's result may land — a slow walk of a huge folder must
-    /// not clobber a scan the user has since restarted elsewhere.
+    /// Monotonic token (same pattern as AnalyzeModel.scanGen): only the newest scan's
+    /// result may land.
     private var scanGen = 0
 
-    /// Re-run against the current folder (the toolbar's Scan button).
+    // MARK: Breadcrumbs (Analyze's idiom over the scanned folder)
+
+    var crumbs: [(name: String, path: String)] {
+        guard let folder else { return [] }
+        let ns = folder as NSString
+        var paths: [String] = []
+        var current = ns as String
+        while current != "/" && !current.isEmpty {
+            paths.append(current)
+            current = (current as NSString).deletingLastPathComponent
+            if paths.count > 6 { break } // keep the bar sane on deep paths
+        }
+        return paths.reversed().map { p in
+            let abbrev = (p as NSString).abbreviatingWithTildeInPath
+            let name = abbrev == "~" ? "~" : (p as NSString).lastPathComponent
+            return (name: name, path: p)
+        }
+    }
+
+    var canGoUp: Bool {
+        guard let folder else { return false }
+        return (folder as NSString).deletingLastPathComponent != folder
+            && folder != NSHomeDirectory() && folder != "/"
+    }
+
+    func goUp() {
+        guard let folder, canGoUp else { return }
+        scan((folder as NSString).deletingLastPathComponent)
+    }
+
+    func goToCrumb(_ idx: Int) {
+        let c = crumbs
+        guard idx < c.count, c[idx].path != folder else { return }
+        scan(c[idx].path)
+    }
+
+    // MARK: Selection passthroughs (keep the view dumb)
+
+    func toggle(_ path: String) {
+        guard let report else { return }
+        selection.toggle(path, in: report)
+    }
+
+    func toggleGroup(_ group: DupeGroup) {
+        selection.toggleGroup(group)
+    }
+
+    /// Re-run against the current folder (the toolbar's rescan button).
     func rescan() {
         guard let folder else { return }
         scan(folder)
     }
 
-    /// Scan `path` via the bundled conductor, off the main thread. The
-    /// envelope's `data` is fclones' group report, decoded by the pure
-    /// DupesReport.parse.
+    /// Scan `path` via the bundled conductor, off the main thread. The envelope's `data`
+    /// is fclones' group report, decoded by the pure DupesReport.parse.
     func scan(_ path: String) {
         folder = path
         scanGen += 1
@@ -339,6 +553,8 @@ final class DupesModel: ObservableObject {
                 switch outcome {
                 case .success(let r):
                     self.report = r
+                    self.selection = DupesSelection(report: r)
+                    self.openGroups = Set(r.groups.prefix(3).map(\.id)) // biggest wins start open
                     OperationCenter.shared.end(self.opId, success: true,
                                                detail: String(format: NSLocalizedString("%d groups · %@", comment: ""),
                                                               r.groups.count, Fmt.bytes(r.redundantBytes)))
@@ -351,7 +567,7 @@ final class DupesModel: ObservableObject {
         }
     }
 
-    // MARK: Dedupe (act)
+    // MARK: Dedupe (the non-destructive act)
 
     /// Run the conductor's dedupe PREVIEW (`dupes dedupe <dir>`, no --apply) and hand the
     /// parsed plan to the caller on the main actor. nil = the preview itself failed

--- a/macos/Tests/DupesModelTests.swift
+++ b/macos/Tests/DupesModelTests.swift
@@ -109,6 +109,59 @@ final class DupesModelTests: XCTestCase {
         XCTAssertEqual(report.groups[0].fileLen, 50)
     }
 
+    // MARK: DupesSelection (the checklist — keep-one invariant)
+
+    private var twoGroups: DupesReport {
+        DupesReport(
+            groups: [
+                DupeGroup(fileLen: 100, files: ["/a/1", "/a/2", "/a/3"]),
+                DupeGroup(fileLen: 50, files: ["/b/1", "/b/2"]),
+            ],
+            redundantBytes: 250)
+    }
+
+    func testSelection_defaultsToAllButFirstPerGroup() {
+        let sel = DupesSelection(report: twoGroups)
+        XCTAssertFalse(sel.isTicked("/a/1"), "each group's first copy starts kept")
+        XCTAssertTrue(sel.isTicked("/a/2"))
+        XCTAssertTrue(sel.isTicked("/a/3"))
+        XCTAssertFalse(sel.isTicked("/b/1"))
+        XCTAssertTrue(sel.isTicked("/b/2"))
+        XCTAssertEqual(sel.selectedBytes(in: twoGroups), 250, "matches the report's redundant total")
+    }
+
+    func testSelection_keepOneGuardRefusesFullGroup() {
+        var sel = DupesSelection(report: twoGroups)
+        // /a/1 is the last unticked copy of group a — ticking it must be a no-op.
+        sel.toggle("/a/1", in: twoGroups)
+        XCTAssertFalse(sel.isTicked("/a/1"), "the guard must refuse selecting every copy")
+        XCTAssertTrue(sel.isKeptCopy("/a/1", in: twoGroups.groups[0]))
+        // Free a slot, then the first copy becomes selectable (the KEPT one moves).
+        sel.toggle("/a/2", in: twoGroups)
+        sel.toggle("/a/1", in: twoGroups)
+        XCTAssertTrue(sel.isTicked("/a/1"), "keep-one is per-group, not first-copy-sacred")
+        XCTAssertFalse(sel.isTicked("/a/2"))
+    }
+
+    func testSelection_groupTriStateAndToggle() {
+        var sel = DupesSelection(report: twoGroups)
+        let a = twoGroups.groups[0]
+        XCTAssertEqual(sel.groupState(a), .all, "default = at selectable max")
+        sel.toggleGroup(a)
+        XCTAssertEqual(sel.groupState(a), .none)
+        XCTAssertEqual(sel.selectedBytes(in: twoGroups), 50, "only group b remains")
+        sel.toggle("/a/3", in: twoGroups)
+        XCTAssertEqual(sel.groupState(a), .mixed)
+        sel.toggleGroup(a)
+        XCTAssertEqual(sel.groupState(a), .all, "mixed -> back to all-but-first")
+        XCTAssertFalse(sel.isTicked("/a/1"))
+    }
+
+    func testSelection_selectedPathsFollowGroupOrder() {
+        let sel = DupesSelection(report: twoGroups)
+        XCTAssertEqual(sel.selectedPaths(in: twoGroups), ["/a/2", "/a/3", "/b/2"])
+    }
+
     // MARK: DedupePreview (the act-from-GUI flow)
 
     func testDedupePreview_parsesPlanLines() throws {


### PR DESCRIPTION
Addresses the hand-test feedback (no selection; UX inconsistent with the clean/purge/apps choosing pages and Analyze's folder selection). The pane now copies the app's idioms wholesale:

- **Clean-review checklist**: tri-state group cards over checkbox copy rows (same 17px/15px box anatomy, card fill, reveal buttons), biggest 3 groups open by default.
- **Selection with a keep-one invariant** (`DupesSelection`, pure + TDD'd): defaults to all-but-first per group; the last unticked copy of a group can't be ticked and wears a **kept** badge.
- **Clean's Trash flow verbatim**: alert → `FileManager.trashItem` (recoverable) → HUD + DoneBanner → rescan. This is the 'select ones to remove' ask — reversible, unlike fclones' hard `remove` (stays CLI-only).
- **Analyze's toolbar idiom**: up arrow + clickable breadcrumbs + mono summary + folder/refresh icon buttons.
- **Reclaim via clones…** kept as the secondary pill (non-destructive, `cp -c` plan confirm).

4 new `DupesSelection` tests; full local Debug build compiles clean.