### PR TITLE
release(windows): 0.10.0 — version bump + conductor-safe release pipeline

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -63,10 +63,12 @@ jobs:
           try {
             $sha = (git ls-tree HEAD windows/vendor/burrow-cli).Split()[2]
             $dest = Join-Path $env:RUNNER_TEMP 'burrow-cli'
-            if ($env:ENGINE_PAT) {
+            # burrow-cli is PUBLIC: clone unauthenticated FIRST. ENGINE_PAT is scoped to
+            # burrow-engine only, and an authenticated clone with an unauthorized token 403s
+            # (the bug that dropped the conductor from the first macOS 0.10.0 artifact).
+            git clone --quiet https://github.com/caezium/burrow-cli.git $dest
+            if (-not (Test-Path $dest) -and $env:ENGINE_PAT) {
               git -c "url.https://x-access-token:$($env:ENGINE_PAT)@github.com/.insteadOf=https://github.com/" clone --quiet https://github.com/caezium/burrow-cli.git $dest
-            } else {
-              git clone --quiet https://github.com/caezium/burrow-cli.git $dest
             }
             git -C $dest -c advice.detachedHead=false checkout --quiet $sha
             cargo build --release --manifest-path (Join-Path $dest 'Cargo.toml')
@@ -94,6 +96,21 @@ jobs:
 
       - name: Publish (telemetry keys baked from secrets)
         run: dotnet publish .\BurrowWin.csproj -c ${{ github.event.inputs.configuration }} -p:Platform=x64 -r win-x64 --self-contained false -o .\artifacts\release-publish -v:minimal
+
+      # A release artifact without the conductor ships with dead features while the run
+      # stays green (the macOS 0.10.0 lesson) — hard-assert the publish output.
+      - name: Verify the bundled conductor + engine made it into the publish
+        shell: pwsh
+        run: |
+          if (-not (Test-Path ".\artifacts\release-publish\Assets\burrow.exe")) {
+            Write-Host "::error::Assets\burrow.exe missing - the conductor did not bundle. Failing the release."
+            exit 1
+          }
+          if (-not (Test-Path ".\artifacts\release-publish\Assets\Mole\mole.ps1")) {
+            Write-Host "::error::Assets\Mole engine missing. Failing the release."
+            exit 1
+          }
+          Write-Host "conductor: present / engine: present"
 
       - name: Upload published app
         uses: actions/upload-artifact@v4

--- a/windows/BurrowWin.csproj
+++ b/windows/BurrowWin.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>BurrowWin</RootNamespace>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/windows/Package.appxmanifest
+++ b/windows/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="DA9687FB-09FD-4C4D-B67F-C35B87E6974E"
     Publisher="CN=Caezium"
-    Version="0.9.0.0" />
+    Version="0.10.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="DA9687FB-09FD-4C4D-B67F-C35B87E6974E" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
Windows side of the 0.10.0 ship: version bump (csproj + appxmanifest, was 0.9.0) + the same two release-pipeline fixes the macOS side just got — **unauthenticated-first** burrow-cli clone (ENGINE_PAT is engine-scoped → authenticated clone 403s) and a **hard assert** that the publish output contains `Assets\burrow.exe` + the bundled engine. `windows-release.yml` gets dispatched after merge.