### PR TITLE
fix(sentry-issues): align the dispatch input default with the 168h lookback

### DIFF
--- a/.github/workflows/sentry-issues.yml
+++ b/.github/workflows/sentry-issues.yml
@@ -38,7 +38,7 @@ on:
         default: "is:unresolved"
       lookback_hours:
         description: "Only file issues first seen within this many hours"
-        default: "24"
+        default: "168"
 
 permissions:
   contents: read


### PR DESCRIPTION
The validation run showed `fetched 50` + dozens of real June-26+ issues still dropped as 'outside the **24h** lookback' — the `workflow_dispatch` input's own `default: 24` overrides the env fallback on manual runs. Aligned to 168. With MAX_PER_RUN=25 the backlog drains over a couple of scheduled runs (ANR skips + seen-list still apply).