### PR TITLE
site: add 0.10.0 to the landing site

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,6 +50,19 @@ Tune-Up display bugs you reported.
   sentinel, app-slim check, similar photos — 21 read-only tools total.
   ([#258](https://github.com/caezium/Burrow/pull/258))
 
+## Windows preview
+- **Downloadable at last**: this release ships `BurrowWin-0.10.0-win-x64.zip` —
+  the unpackaged Windows app with the `burrow.exe` conductor and the engine
+  bundled (unzip and run `BurrowWin.exe`; Windows 10/11, .NET 8 runtime).
+- **The conductor, on Windows too**: agent-triggered clean/optimize route
+  through `burrow.exe` with the same envelope contract the macOS app speaks.
+  ([#252](https://github.com/caezium/Burrow/pull/252))
+- **`burrow.exe` grew real Windows powers** this cycle: Recycle-Bin safe
+  delete (never hard-deletes), guarded Bulk Crap Uninstaller uninstalls,
+  czkawka-backed duplicate + similar-photo discovery, provider-aware
+  OneDrive/Cloud Files eviction, and per-app network attribution via the
+  native IP Helper API.
+
 ## Also
 - Per-metric menu-bar text sizing with stable widths, and flipped net in/out
   ordering. ([#245](https://github.com/caezium/Burrow/pull/245))

--- a/docs/index.html
+++ b/docs/index.html
@@ -323,7 +323,7 @@
 
   <!-- ===== HERO ===== -->
   <header class="hero">
-    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.9.2</span>
+    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.10.0</span>
     <h1>Burrow
       <svg class="mark" viewBox="0 0 100 100" aria-hidden="true"><path d="M14 74 a36 36 0 0 1 72 0 Z" fill="#F3ECDD"/><rect x="38" y="74" width="24" height="7" rx="3.5" fill="#121217"/></svg>
     </h1>
@@ -389,38 +389,37 @@
     <div class="sec-head wn-head">
       <div>
         <span class="sec-num">What's new · July 2026</span>
-        <h2 class="sec-title">New in 0.9.2</h2>
+        <h2 class="sec-title">New in 0.10.0</h2>
       </div>
       <a class="btn btn-out btn-sm" href="releases.html">All releases</a>
     </div>
 
     <div class="grid3 wn-grid">
-      <article class="tcard" style="--c: var(--coral)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16M9 7V5h6v2M6 7l1 13h10l1-13"/><path d="M10 11v5M14 11v5"/></svg></div><div class="nm">Purge fixed</div></div>
-        <p class="ds">Cleanup's project-artifacts purge was refusing every removal (“Couldn't confirm the selection safely”) — it now applies exactly the items you pick.</p>
+      <article class="tcard" style="--c: var(--lilac)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8l-9-5-9 5v8l9 5 9-5z"/><path d="M3 8l9 5 9-5M12 13v8"/></svg></div><div class="nm">New: Duplicates</div></div>
+        <p class="ds">Scan any folder for byte-identical copies, review them checklist-style (every group keeps at least one), then move extras to the Trash — or reclaim the space with APFS clones, deleting nothing.</p>
       </article>
-      <article class="tcard" style="--c: var(--green)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19C5 9 13 4 20 4c0 7-3 15-13 15"/><path d="M5 19c2-5 6-9 11-11"/></svg></div><div class="nm">Lighter while idle</div></div>
-        <p class="ds">The metrics engine no longer reads the temperature, fan, and GPU sensors every second when no window is open — a real battery win.</p>
+      <article class="tcard" style="--c: var(--accent)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg></div><div class="nm">The conductor</div></div>
+        <p class="ds">Burrow now bundles <code>burrow</code>, a universal CLI that drives the bundled engine — analysis, status, history, clean, and optimize all speak one stable contract, and the app works out of the box with no Homebrew install.</p>
       </article>
-      <article class="tcard" style="--c: var(--azure)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20v-6M9 20V8M14 20v-9M19 20V5"/></svg></div><div class="nm">Calmer Analyze</div></div>
-        <p class="ds">Disk Analyze no longer spawns a pile of engine processes; superseded scans are cancelled and concurrency is capped, so it won't peg your CPU.</p>
+      <article class="tcard" style="--c: var(--gold)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="15" r="4"/><path d="M10.8 12.2L20 3l1 1-2 2M16 8l2 2"/></svg></div><div class="nm">Sudo dialog fixed</div></div>
+        <p class="ds">Uninstalling root-owned apps (Zoom et al.) shows the proper admin password prompt again instead of failing with “Admin access denied”.</p>
       </article>
-      <article class="tcard" style="--c: var(--violet)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Honest mic/cam dot</div></div>
-        <p class="ds">The camera and microphone in-use indicator no longer false-lights from virtual audio or video devices, and clears reliably when capture ends.</p>
+      <article class="tcard" style="--c: var(--mint)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9l3 3-3 3M13 15h4"/></svg></div><div class="nm">7 new agent tools</div></div>
+        <p class="ds">Duplicates, orphaned files, per-app network usage, rule previews, trash sentinel, app-slim check, and similar photos — 21 read-only MCP tools total.</p>
       </article>
     </div>
 
-    <div class="extra-label mono">// also tightened in 0.9.2</div>
+    <div class="extra-label mono">// also tightened in 0.10.0</div>
     <div class="wn-chips">
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Menu-bar popover stays put and sizes to its own display on multi-monitor setups</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Doctor, disk SMART, and Time Machine probes are timeout-guarded; Doctor results cached</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Bounded Analyze memory, faster live sparklines</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Network-usage views share one sample instead of each running a 1-second scan</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Fewer spurious “App Hang” reports</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Homebrew cask no longer depends on a system <code>mo</code> — the engine is bundled</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Failed uninstalls keep your selection and show the engine's actual error</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Tune-Up sizes render clean — no more raw color codes</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Analyze can't stall on cache-heavy folders; the menu-bar popover no longer bounces</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Per-metric menu-bar text sizing with stable widths</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Windows preview bundles burrow.exe and the same envelope contract</span>
     </div>
     <!-- WN:END -->
   </section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -419,7 +419,7 @@
       <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Tune-Up sizes render clean — no more raw color codes</span>
       <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Analyze can't stall on cache-heavy folders; the menu-bar popover no longer bounces</span>
       <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Per-metric menu-bar text sizing with stable widths</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Windows preview bundles burrow.exe and the same envelope contract</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Windows preview is downloadable — BurrowWin zip with burrow.exe + engine bundled</span>
     </div>
     <!-- WN:END -->
   </section>
@@ -508,7 +508,7 @@
       <a class="btn btn-fill" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" style="padding:15px 40px; font-size:16px;">Get Burrow</a>
       <div class="price-lines">All five tools, the menu-bar HUD, history, and the MCP server included.<br>
         <span style="color:var(--ink-3)">or <a class="u" href="#build">build it from source</a></span></div>
-      <div class="price-meta">unlimited Macs<span class="dot">·</span>no account<span class="dot">·</span>unsigned, pre-1.0<span class="dot">·</span>requires brew install mole</div>
+      <div class="price-meta">unlimited Macs<span class="dot">·</span>no account<span class="dot">·</span>unsigned, pre-1.0<span class="dot">·</span>engine + conductor bundled — nothing else to install</div>
     </div>
 
     <div class="installs" id="build">
@@ -537,7 +537,7 @@ cd Burrow/macos && xcodegen generate</div>
     </div>
 
     <div class="price-meta" style="margin-top:22px; text-align:center;">
-      <b style="color:var(--accent)">Windows&nbsp;10/11 (beta)</b><span class="dot">·</span>build from source under <code class="k">windows/</code> (installer coming)<span class="dot">·</span><a class="u" href="https://github.com/caezium/Burrow/tree/main/windows" target="_blank" rel="noopener">windows/ on GitHub</a>
+      <b style="color:var(--accent)">Windows&nbsp;10/11 (beta)</b><span class="dot">·</span>downloadable preview — <a class="u" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener">BurrowWin zip</a> with the <code class="k">burrow.exe</code> conductor + engine bundled (installer coming)
     </div>
   </section>
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -159,7 +159,14 @@
           <ul class="slist">
             <li>Per-metric menu-bar text sizing, stable widths, flipped net in/out ordering</li>
             <li>HUD popover re-pins when the menu bar auto-hides</li>
-            <li>Windows preview: burrow.exe bundled + BurrowEnvelope contract parser</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">windows</div>
+          <ul class="slist">
+            <li>Downloadable at last: BurrowWin-0.10.0-win-x64.zip ships on this release — the unpackaged app with burrow.exe and the engine bundled (unzip, run BurrowWin.exe; Windows 10/11)</li>
+            <li>Agent-triggered clean/optimize route through burrow.exe with the same envelope contract as macOS</li>
+            <li>burrow.exe grew real Windows powers: Recycle-Bin safe delete, guarded BCU uninstalls, czkawka duplicates + similar photos, provider-aware OneDrive eviction, IP Helper network attribution</li>
           </ul>
         </div>
       </div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -123,13 +123,51 @@
 <header class="hero page">
   <h1>Changelog</h1>
   <p>Every version at a glance — what it added, changed, and fixed. Full notes for each live on GitHub.</p>
-  <p class="count">16 releases · latest 0.9.2 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
+  <p class="count">17 releases · latest 0.10.0 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
 </header>
 
 <main class="page">
+    <article class="entry" id="v0.10.0">
+      <div class="ver-col">
+        <h2 class="ver">0.10.0<span class="latest">latest</span></h2>
+        <span class="date mono">Jul 12, 2026</span>
+        <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.10.0" target="_blank" rel="noopener">full notes ↗</a>
+      </div>
+      <div class="sbody">
+        <p class="lead">The conductor release — Burrow ships its own command layer, a brand-new Duplicates pane, and the sudo, uninstall, and Tune-Up fixes you reported.</p>
+        <div class="sblock">
+          <div class="slabel mono">New</div>
+          <ul class="slist">
+            <li>Duplicates pane: scan, review checklist-style with a keep-one guard, move extras to the Trash or reclaim via APFS clones</li>
+            <li>Bundled <code>burrow</code> conductor (universal): analysis, status, history, clean, and optimize route through one stable JSON contract with direct-engine fallback</li>
+            <li>7 read-only MCP tools through the conductor — 21 total for agents</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">Fixes</div>
+          <ul class="slist">
+            <li>Admin password dialog appears again for root-owned app uninstalls (the engine now opens /dev/tty instead of permission-testing it)</li>
+            <li>Failed uninstalls keep the list and selection and surface the engine's error</li>
+            <li>Tune-Up reclaim sizes no longer show raw ANSI color codes</li>
+            <li>Analyze bounds per-child scans so a huge cache folder can't freeze the scan</li>
+            <li>Menu-bar popover no longer rubber-bands into empty space</li>
+            <li>Self-update refreshes Homebrew before upgrading</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">Also</div>
+          <ul class="slist">
+            <li>Per-metric menu-bar text sizing, stable widths, flipped net in/out ordering</li>
+            <li>HUD popover re-pins when the menu bar auto-hides</li>
+            <li>Windows preview: burrow.exe bundled + BurrowEnvelope contract parser</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
     <article class="entry" id="v0.9.2">
       <div class="ver-col">
-        <h2 class="ver">0.9.2<span class="latest">latest</span></h2>
+        <h2 class="ver">0.9.2</h2>
         <span class="date mono">Jul 8, 2026</span>
         <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.9.2" target="_blank" rel="noopener">full notes ↗</a>
       </div>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -37,7 +37,7 @@
         "Tune-Up sizes render clean \u2014 no more raw color codes",
         "Analyze can't stall on cache-heavy folders; the menu-bar popover no longer bounces",
         "Per-metric menu-bar text sizing with stable widths",
-        "Windows preview bundles burrow.exe and the same envelope contract"
+        "Windows preview is downloadable \u2014 BurrowWin zip with burrow.exe + engine bundled"
       ],
       "sections": [
         {
@@ -63,8 +63,15 @@
           "label": "Also",
           "items": [
             "Per-metric menu-bar text sizing, stable widths, flipped net in/out ordering",
-            "HUD popover re-pins when the menu bar auto-hides",
-            "Windows preview: burrow.exe bundled + BurrowEnvelope contract parser"
+            "HUD popover re-pins when the menu bar auto-hides"
+          ]
+        },
+        {
+          "label": "windows",
+          "items": [
+            "Downloadable at last: BurrowWin-0.10.0-win-x64.zip ships on this release \u2014 the unpackaged app with burrow.exe and the engine bundled (unzip, run BurrowWin.exe; Windows 10/11)",
+            "Agent-triggered clean/optimize route through burrow.exe with the same envelope contract as macOS",
+            "burrow.exe grew real Windows powers: Recycle-Bin safe delete, guarded BCU uninstalls, czkawka duplicates + similar photos, provider-aware OneDrive eviction, IP Helper network attribution"
           ]
         }
       ]

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -2,6 +2,74 @@
   "_comment": "Source of truth for the site's release history. Newest first. Edit this, then run `python3 scripts/site-release.py` to regenerate the homepage 'New in X' section and releases.html. Icons/colors: run `python3 scripts/site-release.py --list-icons`.",
   "releases": [
     {
+      "version": "0.10.0",
+      "date": "2026-07-12",
+      "tag": "v0.10.0",
+      "tagline": "The conductor release \u2014 Burrow ships its own command layer, a brand-new Duplicates pane, and the sudo, uninstall, and Tune-Up fixes you reported.",
+      "highlights": [
+        {
+          "icon": "package",
+          "color": "lilac",
+          "title": "New: Duplicates",
+          "line": "Scan any folder for byte-identical copies, review them checklist-style (every group keeps at least one), then move extras to the Trash \u2014 or reclaim the space with APFS clones, deleting nothing."
+        },
+        {
+          "icon": "wrench",
+          "color": "accent",
+          "title": "The conductor",
+          "line": "Burrow now bundles `burrow`, a universal CLI that drives the bundled engine \u2014 analysis, status, history, clean, and optimize all speak one stable contract, and the app works out of the box with no Homebrew install."
+        },
+        {
+          "icon": "key",
+          "color": "gold",
+          "title": "Sudo dialog fixed",
+          "line": "Uninstalling root-owned apps (Zoom et al.) shows the proper admin password prompt again instead of failing with \u201cAdmin access denied\u201d."
+        },
+        {
+          "icon": "robot",
+          "color": "mint",
+          "title": "7 new agent tools",
+          "line": "Duplicates, orphaned files, per-app network usage, rule previews, trash sentinel, app-slim check, and similar photos \u2014 21 read-only MCP tools total."
+        }
+      ],
+      "chips": [
+        "Failed uninstalls keep your selection and show the engine's actual error",
+        "Tune-Up sizes render clean \u2014 no more raw color codes",
+        "Analyze can't stall on cache-heavy folders; the menu-bar popover no longer bounces",
+        "Per-metric menu-bar text sizing with stable widths",
+        "Windows preview bundles burrow.exe and the same envelope contract"
+      ],
+      "sections": [
+        {
+          "label": "New",
+          "items": [
+            "Duplicates pane: scan, review checklist-style with a keep-one guard, move extras to the Trash or reclaim via APFS clones",
+            "Bundled `burrow` conductor (universal): analysis, status, history, clean, and optimize route through one stable JSON contract with direct-engine fallback",
+            "7 read-only MCP tools through the conductor \u2014 21 total for agents"
+          ]
+        },
+        {
+          "label": "Fixes",
+          "items": [
+            "Admin password dialog appears again for root-owned app uninstalls (the engine now opens /dev/tty instead of permission-testing it)",
+            "Failed uninstalls keep the list and selection and surface the engine's error",
+            "Tune-Up reclaim sizes no longer show raw ANSI color codes",
+            "Analyze bounds per-child scans so a huge cache folder can't freeze the scan",
+            "Menu-bar popover no longer rubber-bands into empty space",
+            "Self-update refreshes Homebrew before upgrading"
+          ]
+        },
+        {
+          "label": "Also",
+          "items": [
+            "Per-metric menu-bar text sizing, stable widths, flipped net in/out ordering",
+            "HUD popover re-pins when the menu bar auto-hides",
+            "Windows preview: burrow.exe bundled + BurrowEnvelope contract parser"
+          ]
+        }
+      ]
+    },
+    {
       "version": "0.9.2",
       "date": "2026-07-08",
       "tag": "v0.9.2",

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.2</string>
+	<string>0.9.2</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>17</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSDesktopFolderUsageDescription</key>


### PR DESCRIPTION
Homepage 'New in 0.10.0' (Duplicates / conductor / sudo-dialog fix / 7 agent tools) + chips + the sections changelog on releases.html, regenerated via `scripts/site-release.py`. Info.plist rides along (xcodegen sync of the 0.10.0 bump).

**Merging this deploys the site** (deploy-site.yml on main) — it's the review gate.