### PR TITLE
feat(gui): Leftovers, Similar Photos, and Network panes (conductor discovery follow-ups)

### DIFF
--- a/macos/Sources/NetModel.swift
+++ b/macos/Sources/NetModel.swift
@@ -1,0 +1,82 @@
+//
+//  NetModel.swift
+//  Burrow
+//
+//  Typed shape + pure parser for `burrow net --json`: the conductor emits
+//  {count, by_total_bytes:[{name, pid, bytes_in, bytes_out, total,
+//  metric_source, metric_note?}]}. On macOS the rows are nettop BYTE
+//  counters (metric_source "macos_nettop_bytes"); other platforms may
+//  degrade to connection counts and say so in metric_note — the pane
+//  surfaces that caveat instead of mislabeling counts as bytes.
+//
+//  Parsed with JSONSerialization (like DupesModel / DiskScanner), not
+//  Codable: byte counts must stay integer-exact, and garbled conductor
+//  output parses to nil, never a crash.
+//
+
+import Foundation
+
+/// One process's network attribution for the sample window.
+struct NetRow: Identifiable, Equatable {
+    let name: String
+    let pid: Int
+    let bytesIn: Int64
+    let bytesOut: Int64
+    /// bytes_in + bytes_out on macOS; a connection count on degraded sources.
+    let total: Int64
+    /// Where the numbers came from (e.g. "macos_nettop_bytes").
+    let metricSource: String
+    /// Caveat when the source isn't byte counters (Windows fallbacks).
+    let metricNote: String?
+
+    /// Stable identity for SwiftUI lists — name+pid is unique per sample.
+    var id: String { "\(name).\(pid)" }
+}
+
+/// A whole net sample: rows ranked by total descending.
+struct NetReport: Equatable {
+    let rows: [NetRow]
+
+    /// The first metric caveat across the rows (nil on healthy macOS
+    /// byte-counter samples) — shown once under the table, not per row.
+    var note: String? { rows.lazy.compactMap(\.metricNote).first }
+
+    /// Decode the net JSON. Loose everywhere except the spine: a row missing
+    /// `name` is dropped, absent byte fields degrade to 0 (total recomputed
+    /// from in+out when missing), and a payload that isn't a JSON object is
+    /// nil (never a crash).
+    static func parse(_ data: Data) -> NetReport? {
+        guard let raw = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return nil
+        }
+
+        func int64(_ v: Any?) -> Int64? {
+            (v as? Int64) ?? (v as? Int).map(Int64.init)
+        }
+
+        var rows: [NetRow] = []
+        let rowsRaw = raw["by_total_bytes"] as? [[String: Any]] ?? []
+        rows.reserveCapacity(rowsRaw.count)
+        for r in rowsRaw {
+            guard let name = r["name"] as? String, !name.isEmpty else { continue }
+            let bytesIn = int64(r["bytes_in"]) ?? 0
+            let bytesOut = int64(r["bytes_out"]) ?? 0
+            rows.append(NetRow(
+                name: name,
+                pid: (r["pid"] as? Int) ?? 0,
+                bytesIn: bytesIn,
+                bytesOut: bytesOut,
+                total: int64(r["total"]) ?? (bytesIn + bytesOut),
+                metricSource: (r["metric_source"] as? String) ?? "",
+                metricNote: r["metric_note"] as? String))
+        }
+        // The CLI ranks by total already — re-sort defensively (stable on
+        // ties so the CLI's name/pid tiebreak survives).
+        let ranked = rows.enumerated().sorted {
+            let (l, r) = ($0.element.total, $1.element.total)
+            return l != r ? l > r : $0.offset < $1.offset
+        }.map(\.element)
+
+        return NetReport(rows: ranked)
+    }
+}

--- a/macos/Sources/NetView.swift
+++ b/macos/Sources/NetView.swift
@@ -1,0 +1,270 @@
+//
+//  NetView.swift
+//  Burrow
+//
+//  The Network tab — a conductor-tool surface copying the Duplicates pane's
+//  idiom, minus the folder machinery (there is no folder: the sample is
+//  machine-wide). A Refresh-driven table over `burrow net --json`: per-process
+//  bytes in / out / total from nettop's counters, ranked by total, decoded by
+//  the pure NetModel parser off the main thread.
+//
+//  The sample is cheap (~a second), so the pane auto-samples the first time
+//  it becomes active (PortsView's isActive idiom) and refreshes manually
+//  after — no polling, no timers.
+//
+//  READ-ONLY v1: it names the talkers, it doesn't quiet them. Degrade:
+//  dev/CI builds without the vendor/burrow-cli submodule have no bundled
+//  conductor — the pane explains instead of dead-ending.
+//
+
+import SwiftUI
+import AppKit
+
+struct NetView: View {
+    var isActive: Bool = true
+    @StateObject private var model = NetModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            ZStack {
+                if !BurrowConductor.isAvailable {
+                    conductorMissing
+                } else if model.scanning {
+                    scanningProgress
+                } else if let err = model.error {
+                    errorState(err)
+                } else if let report = model.report {
+                    if report.rows.isEmpty { quietState } else { results(report) }
+                } else {
+                    idleState
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        // The first activation samples automatically (it's cheap); after
+        // that the refresh button owns the cadence.
+        .onAppear { if isActive { model.scanIfNeeded() } }
+        .onChange(of: isActive) { _, now in if now { model.scanIfNeeded() } }
+    }
+
+    // MARK: Toolbar (Analyze's idiom, folderless: label + summary + refresh)
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Text(NSLocalizedString("Per-app network, one sample", comment: ""))
+                .font(Brand.mono(12)).foregroundStyle(Brand.textTertiary)
+            Spacer()
+            if let report = model.report {
+                Text(summaryLine(report))
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+            Button { model.scan() } label: {
+                Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Brand.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable || model.scanning)
+            .help(NSLocalizedString("Sample again", comment: ""))
+        }
+    }
+
+    /// "N processes · X total" — the sample's one-line truth.
+    private func summaryLine(_ report: NetReport) -> String {
+        String(format: NSLocalizedString("%d processes · %@ total", comment: ""),
+               report.rows.count, Fmt.bytes(report.rows.reduce(Int64(0)) { $0 + $1.total }))
+    }
+
+    // MARK: States
+
+    private var conductorMissing: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "shippingbox").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
+            Text(NSLocalizedString("The bundled burrow conductor is missing", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Network sampling runs through the bundled `burrow` CLI. This build shipped without it — a dev build without the vendor/burrow-cli submodule. Release builds include it.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 420)
+        }
+    }
+
+    private var idleState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "arrow.up.arrow.down").font(.system(size: 26)).foregroundStyle(Tool.net.accent)
+            Text(NSLocalizedString("Watch what travels the tunnels", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("One nettop sample of every process's bytes in and out, biggest talkers first. Read-only — it names the talkers, it doesn't quiet them.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 440)
+            Button { model.scan() } label: {
+                Text(NSLocalizedString("Sample now", comment: ""))
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .background(Capsule().fill(.white))
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 4)
+        }
+    }
+
+    private var scanningProgress: some View {
+        VStack(spacing: 12) {
+            Text(NSLocalizedString("Sampling the network", comment: ""))
+                .font(Brand.serif(18, .medium)).foregroundStyle(Brand.textPrimary)
+            HStack(spacing: 8) {
+                PulsingDot(color: Tool.net.accent)
+                Text(NSLocalizedString("Reading nettop's per-process byte counters…", comment: ""))
+                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(NSLocalizedString("Sampling network usage", comment: ""))
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle").font(.system(size: 22)).foregroundStyle(Brand.orange)
+            Text(message).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 340)
+        }
+    }
+
+    private var quietState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle").font(.system(size: 24)).foregroundStyle(Tool.net.accent)
+            Text(NSLocalizedString("All quiet", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("No process moved bytes during the sample window.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+        }
+    }
+
+    // MARK: Results (a plain ranked table — name · pid · in · out · total)
+
+    private func results(_ report: NetReport) -> some View {
+        VStack(spacing: 0) {
+            columnHeader.padding(.horizontal, 31).padding(.vertical, 7)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(report.rows) { row($0) }
+                    if let note = report.note {
+                        Text(note)
+                            .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                            .multilineTextAlignment(.center)
+                            .padding(.vertical, 10).padding(.horizontal, 18)
+                    }
+                    Color.clear.frame(height: 16)
+                }
+                .padding(.horizontal, 18)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: 10) {
+            Text(NSLocalizedString("process", comment: "net column"))
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(NSLocalizedString("pid", comment: "net column"))
+                .frame(width: 52, alignment: .trailing)
+            Text(NSLocalizedString("in", comment: "net column"))
+                .frame(width: 72, alignment: .trailing)
+            Text(NSLocalizedString("out", comment: "net column"))
+                .frame(width: 72, alignment: .trailing)
+            Text(NSLocalizedString("total", comment: "net column"))
+                .frame(width: 76, alignment: .trailing)
+        }
+        .font(Brand.mono(9, .medium)).foregroundStyle(Brand.textTertiary)
+    }
+
+    private func row(_ r: NetRow) -> some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 8) {
+                Circle().fill(Tool.net.accent.opacity(0.8)).frame(width: 5, height: 5)
+                    .accessibilityHidden(true)
+                Text(r.name)
+                    .font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Text(verbatim: r.pid > 0 ? "\(r.pid)" : "—")
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                .frame(width: 52, alignment: .trailing)
+            Text(Fmt.bytes(r.bytesIn))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .frame(width: 72, alignment: .trailing)
+            Text(Fmt.bytes(r.bytesOut))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .frame(width: 72, alignment: .trailing)
+            Text(Fmt.bytes(r.total))
+                .font(Brand.mono(11, .medium)).foregroundStyle(Tool.net.accent)
+                .frame(width: 76, alignment: .trailing)
+        }
+        .padding(.horizontal, 13).padding(.vertical, 6)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(format: NSLocalizedString("%@, %@ in, %@ out", comment: ""),
+                                   r.name, Fmt.bytes(r.bytesIn), Fmt.bytes(r.bytesOut)))
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class NetModel: ObservableObject {
+    @Published var scanning = false
+    @Published var report: NetReport?
+    @Published var error: String?
+
+    private let opId = UUID()
+    /// Monotonic token (same pattern as DupesModel.scanGen): only the newest
+    /// sample's result may land.
+    private var scanGen = 0
+
+    /// First-activation sample: only when nothing has been sampled yet, so
+    /// switching back to the tab never stomps a result the user is reading.
+    func scanIfNeeded() {
+        guard BurrowConductor.isAvailable, report == nil, error == nil, !scanning else { return }
+        scan()
+    }
+
+    /// Sample via the bundled conductor, off the main thread. The envelope's
+    /// `data` is the net report, decoded by the pure NetReport.parse.
+    func scan() {
+        scanGen += 1
+        let gen = scanGen
+        scanning = true
+        error = nil
+        OperationCenter.shared.begin(opId, label: NSLocalizedString("Sampling per-app network", comment: ""))
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome: Result<NetReport, Error>
+            do {
+                let envelope = try BurrowConductor.capture("net", [], timeout: 60)
+                guard let data = envelope.data, let parsed = NetReport.parse(data) else {
+                    throw BurrowConductorError.engine(
+                        kind: "error",
+                        message: NSLocalizedString("burrow net returned an unreadable report", comment: ""))
+                }
+                outcome = .success(parsed)
+            } catch {
+                outcome = .failure(error)
+            }
+            Task { @MainActor in
+                guard gen == self.scanGen else { return }
+                self.scanning = false
+                switch outcome {
+                case .success(let r):
+                    self.report = r
+                    OperationCenter.shared.end(self.opId, success: true,
+                                               detail: String(format: NSLocalizedString("%d processes", comment: ""),
+                                                              r.rows.count))
+                case .failure(let e):
+                    self.error = e.localizedDescription
+                    OperationCenter.shared.end(self.opId, success: false,
+                                               detail: NSLocalizedString("sample failed", comment: ""))
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/OrphansModel.swift
+++ b/macos/Sources/OrphansModel.swift
@@ -1,0 +1,92 @@
+//
+//  OrphansModel.swift
+//  Burrow
+//
+//  Typed shape + pure parser for `burrow orphans <dir> --json`: the conductor
+//  emits {roots, installed_count, count, orphans:[{name, path, confidence,
+//  evidence[], default_selected}]} and the GUI reads only that spine — extra
+//  fields (inventory_sources, future evidence kinds) can drift upstream
+//  without breaking us.
+//
+//  Parsed with JSONSerialization (like DupesModel / DiskScanner), not
+//  Codable: loose everywhere except the spine, nil (never a crash) on
+//  garbled conductor output.
+//
+
+import Foundation
+
+/// One leftover candidate: an app-artifact-shaped file or folder that matches
+/// no installed app.
+struct OrphanHit: Identifiable, Equatable {
+    let name: String
+    /// Absolute path of the candidate.
+    let path: String
+    /// burrow-cli's confidence grade — "medium" (bundle-id-shaped, vendor
+    /// signature) above "weak" (loose name); Windows also emits "low".
+    let confidence: String
+    /// Why it was flagged (e.g. "app-artifact-shaped",
+    /// "not-matched-to-installed-inventory").
+    let evidence: [String]
+    /// Always false today (the scanner never preselects) — carried so a
+    /// future acting pane inherits the CLI's judgement, not its own.
+    let defaultSelected: Bool
+
+    /// Stable identity for SwiftUI lists — paths are unique per scan.
+    var id: String { path }
+}
+
+/// A whole leftover scan: hits strongest-confidence first, plus the scan's
+/// roots and inventory size (the denominator that makes "orphan" meaningful).
+struct OrphansReport: Equatable {
+    let roots: [String]
+    /// How many installed apps the scan matched against (0 = unknown).
+    let installedCount: Int
+    /// The CLI's own hit count (falls back to the parsed rows when absent).
+    let count: Int
+    let orphans: [OrphanHit]
+
+    /// Rank a confidence tier for sorting: medium > low > weak > anything new.
+    static func tierRank(_ confidence: String) -> Int {
+        switch confidence {
+        case "medium": return 0
+        case "low":    return 1
+        case "weak":   return 2
+        default:       return 3
+        }
+    }
+
+    /// Decode the orphans JSON. Loose everywhere except the spine: a hit
+    /// missing `name` or `path` is dropped, missing confidence degrades to
+    /// "weak", and a payload that isn't a JSON object is nil (never a crash).
+    static func parse(_ data: Data) -> OrphansReport? {
+        guard let raw = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return nil
+        }
+
+        var hits: [OrphanHit] = []
+        let hitsRaw = raw["orphans"] as? [[String: Any]] ?? []
+        hits.reserveCapacity(hitsRaw.count)
+        for h in hitsRaw {
+            guard let name = h["name"] as? String, !name.isEmpty,
+                  let path = h["path"] as? String, !path.isEmpty else { continue }
+            hits.append(OrphanHit(
+                name: name,
+                path: path,
+                confidence: (h["confidence"] as? String) ?? "weak",
+                evidence: (h["evidence"] as? [String]) ?? [],
+                defaultSelected: (h["default_selected"] as? Bool) ?? false))
+        }
+        // Strongest evidence first; stable within a tier so the CLI's
+        // name-sorted order survives.
+        let ranked = hits.enumerated().sorted {
+            let (l, r) = (tierRank($0.element.confidence), tierRank($1.element.confidence))
+            return l != r ? l < r : $0.offset < $1.offset
+        }.map(\.element)
+
+        return OrphansReport(
+            roots: (raw["roots"] as? [String]) ?? [],
+            installedCount: (raw["installed_count"] as? Int) ?? 0,
+            count: (raw["count"] as? Int) ?? ranked.count,
+            orphans: ranked)
+    }
+}

--- a/macos/Sources/OrphansView.swift
+++ b/macos/Sources/OrphansView.swift
@@ -1,0 +1,417 @@
+//
+//  OrphansView.swift
+//  Burrow
+//
+//  The Leftovers tab — a conductor-tool surface copying the Duplicates pane's
+//  idiom: Analyze's toolbar (up arrow + breadcrumbs + mono summary + icon
+//  buttons), the same state ladder (conductorMissing / idle / scanning /
+//  error / clean / results), and card-list results. Scanning runs
+//  `burrow orphans <dir> --json` off the main thread through the pure
+//  OrphansModel parser.
+//
+//  READ-ONLY v1: rows reveal in Finder, nothing is deleted. The scanner's
+//  own volatile-roots policy (never flag Preferences / Keychains / Mail /
+//  Containers) plus this pane's no-action stance keep it safe by
+//  construction; a review-checklist + Trash flow is the follow-up.
+//
+//  Degrade: dev/CI builds without the vendor/burrow-cli submodule have no
+//  bundled conductor — the pane explains instead of dead-ending.
+//
+
+import SwiftUI
+import AppKit
+
+struct OrphansView: View {
+    @StateObject private var model = OrphansModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            ZStack {
+                if !BurrowConductor.isAvailable {
+                    conductorMissing
+                } else if model.scanning {
+                    scanningProgress
+                } else if let err = model.error {
+                    errorState(err)
+                } else if let report = model.report {
+                    if report.orphans.isEmpty { cleanState } else { results(report) }
+                } else {
+                    idleState
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: Toolbar (Analyze's idiom: up + crumbs + info + icon buttons)
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Button { model.goUp() } label: {
+                Image(systemName: "arrow.up").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(model.canGoUp ? Brand.textSecondary : Brand.textTertiary.opacity(0.35))
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain).disabled(!model.canGoUp)
+            .help(NSLocalizedString("Scan the parent folder", comment: ""))
+
+            if model.crumbs.isEmpty {
+                Text(NSLocalizedString("Choose a folder to scan", comment: ""))
+                    .font(Brand.mono(12)).foregroundStyle(Brand.textTertiary)
+            }
+            ForEach(Array(model.crumbs.enumerated()), id: \.offset) { idx, crumb in
+                if idx > 0 {
+                    Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Brand.textTertiary)
+                }
+                Button { model.goToCrumb(idx) } label: {
+                    Text(crumb.name)
+                        .font(Brand.mono(12, idx == model.crumbs.count - 1 ? .semibold : .regular))
+                        .foregroundStyle(idx == model.crumbs.count - 1 ? Brand.textPrimary : Brand.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer()
+            if let report = model.report {
+                Text(summaryLine(report))
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+            Button { pickFolder() } label: {
+                Image(systemName: "folder").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Brand.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable)
+            .help(NSLocalizedString("Choose a folder…", comment: ""))
+            Button { model.rescan() } label: {
+                Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(model.folder == nil ? Brand.textTertiary.opacity(0.35) : Brand.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable || model.folder == nil || model.scanning)
+            .help(NSLocalizedString("Rescan", comment: ""))
+        }
+    }
+
+    /// "N leftovers · matched against M apps" — the scan's one-line truth.
+    private func summaryLine(_ report: OrphansReport) -> String {
+        String(format: NSLocalizedString("%d leftovers · matched against %d apps", comment: ""),
+               report.orphans.count, report.installedCount)
+    }
+
+    private func pickFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = NSLocalizedString("Scan", comment: "")
+        if let folder = model.folder {
+            panel.directoryURL = URL(fileURLWithPath: folder)
+        }
+        guard CrashReporter.withoutAppHangTracking({ panel.runModal() }) == .OK,
+              let url = panel.url else { return }
+        model.scan(url.path)
+    }
+
+    // MARK: States
+
+    private var conductorMissing: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "shippingbox").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
+            Text(NSLocalizedString("The bundled burrow conductor is missing", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Leftover scanning runs through the bundled `burrow` CLI. This build shipped without it — a dev build without the vendor/burrow-cli submodule. Release builds include it.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 420)
+        }
+    }
+
+    private var idleState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "externaldrive.badge.questionmark").font(.system(size: 26)).foregroundStyle(Tool.orphans.accent)
+            Text(NSLocalizedString("Find what uninstalled apps left behind", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Choose a folder and Burrow flags app-shaped caches and logs that match nothing installed. Read-only — nothing is deleted; review the evidence and reveal anything in Finder.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 440)
+            HStack(spacing: 8) {
+                quickChip(NSLocalizedString("Caches", comment: ""),
+                          path: NSHomeDirectory() + "/Library/Caches")
+                quickChip(NSLocalizedString("Logs", comment: ""),
+                          path: NSHomeDirectory() + "/Library/Logs")
+                Button { pickFolder() } label: {
+                    Text(NSLocalizedString("Choose a folder…", comment: ""))
+                        .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                        .padding(.horizontal, 14).padding(.vertical, 6)
+                        .background(Capsule().fill(.white))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    /// One-tap scan target for the usual leftover haunts.
+    private func quickChip(_ label: String, path: String) -> some View {
+        Button { model.scan(path) } label: {
+            Text(label)
+                .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.textPrimary)
+                .padding(.horizontal, 14).padding(.vertical, 6)
+                .background(Capsule().fill(Color.white.opacity(0.08)))
+                .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .help((path as NSString).abbreviatingWithTildeInPath)
+    }
+
+    private var scanningProgress: some View {
+        VStack(spacing: 12) {
+            Text(NSLocalizedString("Hunting leftovers", comment: ""))
+                .font(Brand.serif(18, .medium)).foregroundStyle(Brand.textPrimary)
+            HStack(spacing: 8) {
+                PulsingDot(color: Tool.orphans.accent)
+                Text((model.folder.map { ($0 as NSString).abbreviatingWithTildeInPath }) ?? "")
+                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                    .lineLimit(1).truncationMode(.middle)
+                    .frame(maxWidth: 380)
+            }
+            Text(NSLocalizedString("Matching folder contents against your installed apps.", comment: ""))
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(NSLocalizedString("Scanning for leftovers", comment: ""))
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle").font(.system(size: 22)).foregroundStyle(Brand.orange)
+            Text(message).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 340)
+        }
+    }
+
+    private var cleanState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle").font(.system(size: 24)).foregroundStyle(Tool.orphans.accent)
+            Text(NSLocalizedString("No leftovers here", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Everything in this folder matches an installed app.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+        }
+    }
+
+    // MARK: Results (confidence-tiered card list, strongest first)
+
+    private func results(_ report: OrphansReport) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 14) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(NSLocalizedString("Review leftovers", comment: ""))
+                        .font(Brand.serif(22, .medium)).foregroundStyle(Brand.textPrimary)
+                    Text(NSLocalizedString("App-shaped files that match nothing installed. Read-only — hover a badge for the evidence, reveal anything in Finder before you act on it.", comment: ""))
+                        .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 18).padding(.top, 14).padding(.bottom, 10)
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(tiers(report), id: \.name) { tier in
+                        tierCard(tier.name, hits: tier.hits)
+                    }
+                    Color.clear.frame(height: 16)
+                }
+                .padding(.horizontal, 18).padding(.bottom, 6)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+
+    /// Group the (already rank-sorted) hits into contiguous confidence tiers.
+    private func tiers(_ report: OrphansReport) -> [(name: String, hits: [OrphanHit])] {
+        var out: [(name: String, hits: [OrphanHit])] = []
+        for hit in report.orphans {
+            if let last = out.indices.last, out[last].name == hit.confidence {
+                out[last].hits.append(hit)
+            } else {
+                out.append((name: hit.confidence, hits: [hit]))
+            }
+        }
+        return out
+    }
+
+    private func tierTitle(_ confidence: String) -> String {
+        switch confidence {
+        case "medium": return NSLocalizedString("Likely leftovers", comment: "orphan tier")
+        case "low":    return NSLocalizedString("Possible leftovers", comment: "orphan tier")
+        case "weak":   return NSLocalizedString("Faint traces", comment: "orphan tier")
+        default:       return confidence
+        }
+    }
+
+    private func tierCard(_ confidence: String, hits: [OrphanHit]) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Text(tierTitle(confidence))
+                    .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                confidenceBadge(confidence)
+                Spacer()
+                Text(String(format: NSLocalizedString("%d items", comment: ""), hits.count))
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+            .padding(13)
+            Rectangle().fill(Brand.hairline).frame(height: 1).padding(.horizontal, 13)
+            VStack(spacing: 0) {
+                ForEach(hits) { hitRow($0) }
+            }
+            .padding(.vertical, 4)
+        }
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Brand.cardFill))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
+    }
+
+    private func confidenceBadge(_ confidence: String) -> some View {
+        Text(confidence)
+            .font(Brand.mono(9, .medium)).foregroundStyle(Tool.orphans.accent)
+            .padding(.horizontal, 5).padding(.vertical, 1.5)
+            .background(Capsule().fill(Tool.orphans.accent.opacity(0.16)))
+    }
+
+    private func hitRow(_ hit: OrphanHit) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "questionmark.folder")
+                .font(.system(size: 13)).foregroundStyle(Tool.orphans.accent)
+                .frame(width: 20)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(hit.name)
+                    .font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
+                    .lineLimit(1)
+                Text((hit.path as NSString).abbreviatingWithTildeInPath)
+                    .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+            Spacer()
+            if !hit.evidence.isEmpty {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 11)).foregroundStyle(Brand.textTertiary)
+                    .help(String(format: NSLocalizedString("Why it's flagged: %@", comment: ""),
+                                 hit.evidence.joined(separator: " · ")))
+            }
+            Button { AnalyzeIcons.reveal(hit.path) } label: {
+                Image(systemName: "magnifyingglass.circle")
+                    .font(.system(size: 12)).foregroundStyle(Brand.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .help(NSLocalizedString("Reveal in Finder", comment: ""))
+        }
+        .padding(.horizontal, 13).padding(.vertical, 5)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(format: NSLocalizedString("%@, %@ confidence", comment: ""),
+                                   hit.name, hit.confidence))
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class OrphansModel: ObservableObject {
+    /// The chosen folder (absolute path). Scans re-run against this.
+    @Published var folder: String?
+    @Published var scanning = false
+    @Published var report: OrphansReport?
+    @Published var error: String?
+
+    private let opId = UUID()
+    /// Monotonic token (same pattern as DupesModel.scanGen): only the newest
+    /// scan's result may land.
+    private var scanGen = 0
+
+    // MARK: Breadcrumbs (Analyze's idiom over the scanned folder)
+
+    var crumbs: [(name: String, path: String)] {
+        guard let folder else { return [] }
+        let ns = folder as NSString
+        var paths: [String] = []
+        var current = ns as String
+        while current != "/" && !current.isEmpty {
+            paths.append(current)
+            current = (current as NSString).deletingLastPathComponent
+            if paths.count > 6 { break } // keep the bar sane on deep paths
+        }
+        return paths.reversed().map { p in
+            let abbrev = (p as NSString).abbreviatingWithTildeInPath
+            let name = abbrev == "~" ? "~" : (p as NSString).lastPathComponent
+            return (name: name, path: p)
+        }
+    }
+
+    var canGoUp: Bool {
+        guard let folder else { return false }
+        return (folder as NSString).deletingLastPathComponent != folder
+            && folder != NSHomeDirectory() && folder != "/"
+    }
+
+    func goUp() {
+        guard let folder, canGoUp else { return }
+        scan((folder as NSString).deletingLastPathComponent)
+    }
+
+    func goToCrumb(_ idx: Int) {
+        let c = crumbs
+        guard idx < c.count, c[idx].path != folder else { return }
+        scan(c[idx].path)
+    }
+
+    /// Re-run against the current folder (the toolbar's rescan button).
+    func rescan() {
+        guard let folder else { return }
+        scan(folder)
+    }
+
+    /// Scan `path` via the bundled conductor, off the main thread. The
+    /// envelope's `data` is the orphans report, decoded by the pure
+    /// OrphansReport.parse.
+    func scan(_ path: String) {
+        folder = path
+        scanGen += 1
+        let gen = scanGen
+        scanning = true
+        error = nil
+        report = nil
+        let name = (path as NSString).lastPathComponent
+        OperationCenter.shared.begin(opId, label: String(format: NSLocalizedString("Finding leftovers in %@", comment: ""), name))
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome: Result<OrphansReport, Error>
+            do {
+                let envelope = try BurrowConductor.capture("orphans", [path], timeout: 300)
+                guard let data = envelope.data, let parsed = OrphansReport.parse(data) else {
+                    throw BurrowConductorError.engine(
+                        kind: "error",
+                        message: NSLocalizedString("burrow orphans returned an unreadable report", comment: ""))
+                }
+                outcome = .success(parsed)
+            } catch {
+                outcome = .failure(error)
+            }
+            Task { @MainActor in
+                guard gen == self.scanGen else { return }
+                self.scanning = false
+                switch outcome {
+                case .success(let r):
+                    self.report = r
+                    OperationCenter.shared.end(self.opId, success: true,
+                                               detail: String(format: NSLocalizedString("%d leftovers", comment: ""),
+                                                              r.orphans.count))
+                case .failure(let e):
+                    self.error = e.localizedDescription
+                    OperationCenter.shared.end(self.opId, success: false,
+                                               detail: NSLocalizedString("scan failed", comment: ""))
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/PhotosModel.swift
+++ b/macos/Sources/PhotosModel.swift
@@ -1,0 +1,62 @@
+//
+//  PhotosModel.swift
+//  Burrow
+//
+//  Typed shape + pure parser for `burrow photos <dir> --json`: the conductor
+//  emits {dir, threshold, similar_groups:[{paths:[String]}]} — each group is
+//  burrow-cli's photos::Group, an OBJECT with a `paths` key (not a bare
+//  array). The GUI reads only that spine.
+//
+//  Parsed with JSONSerialization (like DupesModel / DiskScanner), not
+//  Codable: loose everywhere except the spine, nil (never a crash) on
+//  garbled conductor output.
+//
+
+import Foundation
+
+/// One cluster of visually-similar images (dHash within the scan threshold).
+struct PhotoGroup: Identifiable, Equatable {
+    /// Absolute paths of every member — ≥ 2 in any group the CLI emits.
+    let paths: [String]
+
+    /// Stable identity for SwiftUI lists — greedy clustering never puts one
+    /// path in two groups, so the first member is unique per group.
+    var id: String { paths.first ?? "" }
+}
+
+/// A whole similar-photos scan: groups largest first, plus the scanned dir
+/// and the hamming threshold that produced them.
+struct PhotosReport: Equatable {
+    let dir: String
+    /// dHash hamming-distance threshold (CLI default 10; 0 when absent).
+    let threshold: Int
+    let groups: [PhotoGroup]
+
+    /// Decode the photos JSON. Loose everywhere except the spine: a group
+    /// that isn't {paths:[...]} — or holds fewer than two paths — is dropped,
+    /// and a payload that isn't a JSON object is nil (never a crash).
+    static func parse(_ data: Data) -> PhotosReport? {
+        guard let raw = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+            return nil
+        }
+
+        var groups: [PhotoGroup] = []
+        let groupsRaw = raw["similar_groups"] as? [[String: Any]] ?? []
+        groups.reserveCapacity(groupsRaw.count)
+        for g in groupsRaw {
+            guard let paths = g["paths"] as? [String], paths.count >= 2 else { continue }
+            groups.append(PhotoGroup(paths: paths))
+        }
+        // Largest cluster first — the set with the most near-copies leads.
+        // Stable within a size so the CLI's path-sorted order survives.
+        let ranked = groups.enumerated().sorted {
+            let (l, r) = ($0.element.paths.count, $1.element.paths.count)
+            return l != r ? l > r : $0.offset < $1.offset
+        }.map(\.element)
+
+        return PhotosReport(
+            dir: (raw["dir"] as? String) ?? "",
+            threshold: (raw["threshold"] as? Int) ?? 0,
+            groups: ranked)
+    }
+}

--- a/macos/Sources/PhotosView.swift
+++ b/macos/Sources/PhotosView.swift
@@ -1,0 +1,440 @@
+//
+//  PhotosView.swift
+//  Burrow
+//
+//  The Similar Photos tab — a conductor-tool surface copying the Duplicates
+//  pane's idiom: Analyze's toolbar (up arrow + breadcrumbs + mono summary +
+//  icon buttons), the same state ladder, and results as one card per
+//  similar-cluster. Scanning runs `burrow photos <dir> --json` (dHash
+//  perceptual hashing — slow on big folders, so the long 600 s timeout) off
+//  the main thread through the pure PhotosModel parser.
+//
+//  READ-ONLY v1: rows reveal in Finder, nothing is deleted. Member
+//  thumbnails decode OFF the main thread via ImageIO at thumbnail size
+//  (a full NSImage(contentsOfFile:) of a 48 MP photo on main is a hang),
+//  cached in a bounded NSCache; rendered groups cap at 100.
+//
+//  Degrade: dev/CI builds without the vendor/burrow-cli submodule have no
+//  bundled conductor — the pane explains instead of dead-ending.
+//
+
+import SwiftUI
+import AppKit
+import ImageIO
+
+struct PhotosView: View {
+    @StateObject private var model = PhotosModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            toolbar.padding(.horizontal, 18).padding(.top, 4).padding(.bottom, 12)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            ZStack {
+                if !BurrowConductor.isAvailable {
+                    conductorMissing
+                } else if model.scanning {
+                    scanningProgress
+                } else if let err = model.error {
+                    errorState(err)
+                } else if let report = model.report {
+                    if report.groups.isEmpty { cleanState } else { results(report) }
+                } else {
+                    idleState
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    // MARK: Toolbar (Analyze's idiom: up + crumbs + info + icon buttons)
+
+    private var toolbar: some View {
+        HStack(spacing: 8) {
+            Button { model.goUp() } label: {
+                Image(systemName: "arrow.up").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(model.canGoUp ? Brand.textSecondary : Brand.textTertiary.opacity(0.35))
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain).disabled(!model.canGoUp)
+            .help(NSLocalizedString("Scan the parent folder", comment: ""))
+
+            if model.crumbs.isEmpty {
+                Text(NSLocalizedString("Choose a folder to scan", comment: ""))
+                    .font(Brand.mono(12)).foregroundStyle(Brand.textTertiary)
+            }
+            ForEach(Array(model.crumbs.enumerated()), id: \.offset) { idx, crumb in
+                if idx > 0 {
+                    Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Brand.textTertiary)
+                }
+                Button { model.goToCrumb(idx) } label: {
+                    Text(crumb.name)
+                        .font(Brand.mono(12, idx == model.crumbs.count - 1 ? .semibold : .regular))
+                        .foregroundStyle(idx == model.crumbs.count - 1 ? Brand.textPrimary : Brand.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer()
+            if let report = model.report {
+                Text(summaryLine(report))
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            }
+            Button { pickFolder() } label: {
+                Image(systemName: "folder").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(Brand.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable)
+            .help(NSLocalizedString("Choose a folder…", comment: ""))
+            Button { model.rescan() } label: {
+                Image(systemName: "arrow.clockwise").font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(model.folder == nil ? Brand.textTertiary.opacity(0.35) : Brand.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!BurrowConductor.isAvailable || model.folder == nil || model.scanning)
+            .help(NSLocalizedString("Rescan", comment: ""))
+        }
+    }
+
+    /// "N similar sets · M photos" — the scan's one-line truth.
+    private func summaryLine(_ report: PhotosReport) -> String {
+        String(format: NSLocalizedString("%d similar sets · %d photos", comment: ""),
+               report.groups.count, report.groups.reduce(0) { $0 + $1.paths.count })
+    }
+
+    private func pickFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = NSLocalizedString("Scan", comment: "")
+        if let folder = model.folder {
+            panel.directoryURL = URL(fileURLWithPath: folder)
+        }
+        guard CrashReporter.withoutAppHangTracking({ panel.runModal() }) == .OK,
+              let url = panel.url else { return }
+        model.scan(url.path)
+    }
+
+    // MARK: States
+
+    private var conductorMissing: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "shippingbox").font(.system(size: 26)).foregroundStyle(Brand.textTertiary)
+            Text(NSLocalizedString("The bundled burrow conductor is missing", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Similar-photo scanning runs through the bundled `burrow` CLI. This build shipped without it — a dev build without the vendor/burrow-cli submodule. Release builds include it.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 420)
+        }
+    }
+
+    private var idleState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "photo.on.rectangle.angled").font(.system(size: 26)).foregroundStyle(Tool.photos.accent)
+            Text(NSLocalizedString("Spot the shots that echo", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Choose a folder and Burrow clusters visually-similar PNG and JPEG images by perceptual hash — near-duplicate screenshots, burst shots, re-exports. Read-only: review the sets, reveal anything in Finder.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 440)
+            Button { pickFolder() } label: {
+                Text(NSLocalizedString("Choose a folder…", comment: ""))
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .background(Capsule().fill(.white))
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 4)
+        }
+    }
+
+    private var scanningProgress: some View {
+        VStack(spacing: 12) {
+            Text(NSLocalizedString("Comparing photos", comment: ""))
+                .font(Brand.serif(18, .medium)).foregroundStyle(Brand.textPrimary)
+            HStack(spacing: 8) {
+                PulsingDot(color: Tool.photos.accent)
+                Text((model.folder.map { ($0 as NSString).abbreviatingWithTildeInPath }) ?? "")
+                    .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                    .lineLimit(1).truncationMode(.middle)
+                    .frame(maxWidth: 380)
+            }
+            Text(NSLocalizedString("Hashing every image — folders with many photos can take a few minutes.", comment: ""))
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(NSLocalizedString("Scanning for similar photos", comment: ""))
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle").font(.system(size: 22)).foregroundStyle(Brand.orange)
+            Text(message).font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 340)
+        }
+    }
+
+    private var cleanState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle").font(.system(size: 24)).foregroundStyle(Tool.photos.accent)
+            Text(NSLocalizedString("No look-alikes here", comment: ""))
+                .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
+            Text(NSLocalizedString("Every PNG and JPEG in this folder looks one of a kind.", comment: ""))
+                .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+        }
+    }
+
+    // MARK: Results (one card per similar cluster, largest first)
+
+    private func results(_ report: PhotosReport) -> some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .firstTextBaseline, spacing: 14) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(NSLocalizedString("Review similar sets", comment: ""))
+                        .font(Brand.serif(22, .medium)).foregroundStyle(Brand.textPrimary)
+                    Text(NSLocalizedString("Images in a set look alike to a perceptual hash — not byte-identical, so judge with your eyes. Read-only: reveal anything in Finder.", comment: ""))
+                        .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 18).padding(.top, 14).padding(.bottom, 10)
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(report.groups.prefix(100)) { group in
+                        groupCard(group)
+                    }
+                    if report.groups.count > 100 {
+                        Text(String(format: NSLocalizedString("…and %d smaller sets. Narrow the folder to see them.", comment: ""),
+                                    report.groups.count - 100))
+                            .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                            .padding(.vertical, 8)
+                    }
+                    Color.clear.frame(height: 16)
+                }
+                .padding(.horizontal, 18).padding(.bottom, 6)
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+
+    private func groupCard(_ group: PhotoGroup) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "photo.stack")
+                    .font(.system(size: 13)).foregroundStyle(Tool.photos.accent)
+                    .frame(width: 20)
+                    .accessibilityHidden(true)
+                Text(String(format: NSLocalizedString("%d look-alike photos", comment: ""), group.paths.count))
+                    .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.textPrimary)
+                Spacer()
+                Text((group.paths.first.map { (($0 as NSString).deletingLastPathComponent as NSString).abbreviatingWithTildeInPath }) ?? "")
+                    .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+            .padding(13)
+            Rectangle().fill(Brand.hairline).frame(height: 1).padding(.horizontal, 13)
+            VStack(spacing: 0) {
+                ForEach(group.paths, id: \.self) { memberRow($0) }
+            }
+            .padding(.vertical, 4)
+        }
+        .background(RoundedRectangle(cornerRadius: 14, style: .continuous).fill(Brand.cardFill))
+        .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String(format: NSLocalizedString("Set of %d similar photos", comment: ""), group.paths.count))
+    }
+
+    private func memberRow(_ path: String) -> some View {
+        HStack(spacing: 10) {
+            PhotoThumbView(path: path)
+            VStack(alignment: .leading, spacing: 1) {
+                Text((path as NSString).lastPathComponent)
+                    .font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
+                    .lineLimit(1)
+                Text((path as NSString).abbreviatingWithTildeInPath)
+                    .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+            Spacer()
+            Button { AnalyzeIcons.reveal(path) } label: {
+                Image(systemName: "magnifyingglass.circle")
+                    .font(.system(size: 12)).foregroundStyle(Brand.textTertiary)
+            }
+            .buttonStyle(.plain)
+            .help(NSLocalizedString("Reveal in Finder", comment: ""))
+        }
+        .padding(.horizontal, 13).padding(.vertical, 5)
+    }
+}
+
+// MARK: - Thumbnails (async, bounded cache, never a main-thread decode)
+
+/// A small square thumbnail that decodes off-main via ImageIO's thumbnail
+/// API (bounded pixel size — never a full-resolution decode) and caches the
+/// result. Shows a neutral placeholder until the pixels land.
+private struct PhotoThumbView: View {
+    let path: String
+    @State private var image: NSImage?
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .fill(Color.white.opacity(0.06))
+            if let image {
+                Image(nsImage: image)
+                    .resizable().aspectRatio(contentMode: .fill)
+                    .frame(width: 22, height: 22)
+                    .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+            } else {
+                Image(systemName: "photo")
+                    .font(.system(size: 9)).foregroundStyle(Brand.textTertiary)
+            }
+        }
+        .frame(width: 22, height: 22)
+        .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Brand.hairline, lineWidth: 1))
+        .accessibilityHidden(true)
+        .task(id: path) {
+            image = await PhotoThumbs.shared.thumbnail(for: path)
+        }
+    }
+}
+
+/// Off-main thumbnail loader with a bounded NSCache. ImageIO's
+/// CGImageSourceCreateThumbnailAtIndex decodes at most `maxPixel` pixels —
+/// cheap even for 48 MP originals.
+final class PhotoThumbs: @unchecked Sendable {
+    static let shared = PhotoThumbs()
+    private let cache = NSCache<NSString, NSImage>()
+    private let queue = DispatchQueue(label: "dev.caezium.Burrow.photo-thumbs", qos: .utility)
+    private let maxPixel = 64
+
+    private init() {
+        cache.countLimit = 600 // ~100 groups × a handful of members
+    }
+
+    func thumbnail(for path: String) async -> NSImage? {
+        if let hit = cache.object(forKey: path as NSString) { return hit }
+        let maxPixel = self.maxPixel
+        return await withCheckedContinuation { cont in
+            queue.async { [cache] in
+                let url = URL(fileURLWithPath: path) as CFURL
+                let opts: [CFString: Any] = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                    kCGImageSourceThumbnailMaxPixelSize: maxPixel,
+                    kCGImageSourceShouldCache: false,
+                ]
+                guard let src = CGImageSourceCreateWithURL(url, nil),
+                      let cg = CGImageSourceCreateThumbnailAtIndex(src, 0, opts as CFDictionary) else {
+                    cont.resume(returning: nil)
+                    return
+                }
+                let img = NSImage(cgImage: cg, size: NSSize(width: cg.width, height: cg.height))
+                cache.setObject(img, forKey: path as NSString)
+                cont.resume(returning: img)
+            }
+        }
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class PhotosModel: ObservableObject {
+    /// The chosen folder (absolute path). Scans re-run against this.
+    @Published var folder: String?
+    @Published var scanning = false
+    @Published var report: PhotosReport?
+    @Published var error: String?
+
+    private let opId = UUID()
+    /// Monotonic token (same pattern as DupesModel.scanGen): only the newest
+    /// scan's result may land.
+    private var scanGen = 0
+
+    // MARK: Breadcrumbs (Analyze's idiom over the scanned folder)
+
+    var crumbs: [(name: String, path: String)] {
+        guard let folder else { return [] }
+        let ns = folder as NSString
+        var paths: [String] = []
+        var current = ns as String
+        while current != "/" && !current.isEmpty {
+            paths.append(current)
+            current = (current as NSString).deletingLastPathComponent
+            if paths.count > 6 { break } // keep the bar sane on deep paths
+        }
+        return paths.reversed().map { p in
+            let abbrev = (p as NSString).abbreviatingWithTildeInPath
+            let name = abbrev == "~" ? "~" : (p as NSString).lastPathComponent
+            return (name: name, path: p)
+        }
+    }
+
+    var canGoUp: Bool {
+        guard let folder else { return false }
+        return (folder as NSString).deletingLastPathComponent != folder
+            && folder != NSHomeDirectory() && folder != "/"
+    }
+
+    func goUp() {
+        guard let folder, canGoUp else { return }
+        scan((folder as NSString).deletingLastPathComponent)
+    }
+
+    func goToCrumb(_ idx: Int) {
+        let c = crumbs
+        guard idx < c.count, c[idx].path != folder else { return }
+        scan(c[idx].path)
+    }
+
+    /// Re-run against the current folder (the toolbar's rescan button).
+    func rescan() {
+        guard let folder else { return }
+        scan(folder)
+    }
+
+    /// Scan `path` via the bundled conductor, off the main thread. Perceptual
+    /// hashing is the slow part — hence the 600 s timeout (double the dupes
+    /// pane's). The envelope's `data` is decoded by the pure PhotosReport.parse.
+    func scan(_ path: String) {
+        folder = path
+        scanGen += 1
+        let gen = scanGen
+        scanning = true
+        error = nil
+        report = nil
+        let name = (path as NSString).lastPathComponent
+        OperationCenter.shared.begin(opId, label: String(format: NSLocalizedString("Comparing photos in %@", comment: ""), name))
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome: Result<PhotosReport, Error>
+            do {
+                let envelope = try BurrowConductor.capture("photos", [path], timeout: 600)
+                guard let data = envelope.data, let parsed = PhotosReport.parse(data) else {
+                    throw BurrowConductorError.engine(
+                        kind: "error",
+                        message: NSLocalizedString("burrow photos returned an unreadable report", comment: ""))
+                }
+                outcome = .success(parsed)
+            } catch {
+                outcome = .failure(error)
+            }
+            Task { @MainActor in
+                guard gen == self.scanGen else { return }
+                self.scanning = false
+                switch outcome {
+                case .success(let r):
+                    self.report = r
+                    OperationCenter.shared.end(self.opId, success: true,
+                                               detail: String(format: NSLocalizedString("%d similar sets", comment: ""),
+                                                              r.groups.count))
+                case .failure(let e):
+                    self.error = e.localizedDescription
+                    OperationCenter.shared.end(self.opId, success: false,
+                                               detail: NSLocalizedString("scan failed", comment: ""))
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/RootView.swift
+++ b/macos/Sources/RootView.swift
@@ -156,6 +156,9 @@ struct RootView: View {
         ZStack {
             AnalyzeView(isActive: pane == .tool(.analyze)).tabVisible(pane == .tool(.analyze))
             DupesView().tabVisible(pane == .tool(.dupes))
+            OrphansView().tabVisible(pane == .tool(.orphans))
+            PhotosView().tabVisible(pane == .tool(.photos))
+            NetView(isActive: pane == .tool(.net)).tabVisible(pane == .tool(.net))
             SoftwareView(isActive: pane == .tool(.apps)).tabVisible(pane == .tool(.apps))
             CleanHub().tabVisible(pane == .tool(.clean))
             OptimizeView().tabVisible(pane == .tool(.optimize))

--- a/macos/Sources/Tool.swift
+++ b/macos/Sources/Tool.swift
@@ -12,7 +12,7 @@
 import SwiftUI
 
 enum Tool: String, CaseIterable, Identifiable {
-    case clean, purge, installer, apps, optimize, analyze, dupes, status, ports, connectivity, tuneup
+    case clean, purge, installer, apps, optimize, analyze, dupes, orphans, photos, status, ports, net, connectivity, tuneup
 
     var id: String { rawValue }
 
@@ -21,7 +21,7 @@ enum Tool: String, CaseIterable, Identifiable {
     /// optimize, then apps / analyze. The .purge/.installer cases live on for
     /// the hub cards, MCP actions, and Explain deep-links. The live dashboard
     /// isn't a tool anymore — it's Home, reached by the Burrow mark.
-    static let navOrder: [Tool] = [.clean, .optimize, .apps, .analyze, .dupes, .ports, .connectivity]
+    static let navOrder: [Tool] = [.clean, .optimize, .apps, .analyze, .dupes, .orphans, .photos, .ports, .net, .connectivity]
 
     /// Lowercase tab label (matches the instrument-panel voice).
     var label: String { NSLocalizedString(rawValue, comment: "") }
@@ -36,8 +36,11 @@ enum Tool: String, CaseIterable, Identifiable {
         case .optimize:  return NSLocalizedString("Optimize", comment: "")
         case .analyze:   return NSLocalizedString("Analyze", comment: "")
         case .dupes:     return NSLocalizedString("Duplicates", comment: "")
+        case .orphans:   return NSLocalizedString("Leftovers", comment: "")
+        case .photos:    return NSLocalizedString("Similar Photos", comment: "")
         case .status:    return NSLocalizedString("Status", comment: "")
         case .ports:     return NSLocalizedString("Ports", comment: "")
+        case .net:       return NSLocalizedString("Network", comment: "")
         case .connectivity: return NSLocalizedString("Get Online", comment: "")
         case .tuneup:    return NSLocalizedString("Tune-Up", comment: "")
         }
@@ -52,8 +55,11 @@ enum Tool: String, CaseIterable, Identifiable {
         case .optimize:  return "wand.and.stars"
         case .analyze:   return "square.grid.2x2"
         case .dupes:     return "doc.on.doc"
+        case .orphans:   return "externaldrive.badge.questionmark"
+        case .photos:    return "photo.on.rectangle.angled"
         case .status:    return "waveform.path.ecg"
         case .ports:     return "network"
+        case .net:       return "arrow.up.arrow.down"
         case .connectivity: return "wifi"
         case .tuneup:    return "slider.horizontal.3"
         }
@@ -69,8 +75,11 @@ enum Tool: String, CaseIterable, Identifiable {
         case .optimize:  return Color(hex: 0x8E84F0) // violet
         case .analyze:   return Color(hex: 0x4FA3E3) // azure
         case .dupes:     return Color(hex: 0xDB7E9C) // rose
+        case .orphans:   return Color(hex: 0xB7BE5A) // olive
+        case .photos:    return Color(hex: 0xD57BC4) // orchid
         case .status:    return Color(hex: 0xE6A93C) // gold
         case .ports:     return Color(hex: 0xB58BD6) // lilac
+        case .net:       return Color(hex: 0x6E8FE0) // indigo
         case .connectivity: return Color(hex: 0x4FC3D9) // cyan
         case .tuneup:    return Color(hex: 0x5AA98B) // sage
         }
@@ -87,8 +96,11 @@ enum Tool: String, CaseIterable, Identifiable {
         case .optimize:  return Color(hex: 0x1A1730)
         case .analyze:   return Color(hex: 0x0E1F2E)
         case .dupes:     return Color(hex: 0x2A141C)
+        case .orphans:   return Color(hex: 0x232612)
+        case .photos:    return Color(hex: 0x281425)
         case .status:    return Color(hex: 0x241D11)
         case .ports:     return Color(hex: 0x1B1426)
+        case .net:       return Color(hex: 0x131A2C)
         case .connectivity: return Color(hex: 0x0E2630)
         case .tuneup:    return Color(hex: 0x12231D)
         }
@@ -110,8 +122,11 @@ enum Tool: String, CaseIterable, Identifiable {
         case .optimize:  return NSLocalizedString("Small turns, a smoother run.", comment: "")
         case .analyze:   return NSLocalizedString("Map every chamber below.", comment: "")
         case .dupes:     return NSLocalizedString("Find what you've stashed twice.", comment: "")
+        case .orphans:   return NSLocalizedString("Traces of tenants long gone.", comment: "")
+        case .photos:    return NSLocalizedString("Spot the shots that echo.", comment: "")
         case .status:    return NSLocalizedString("Every pulse of the den.", comment: "")
         case .ports:     return NSLocalizedString("See who's listening.", comment: "")
+        case .net:       return NSLocalizedString("Watch what travels the tunnels.", comment: "")
         case .connectivity: return NSLocalizedString("Find your way back to the surface.", comment: "")
         case .tuneup:    return NSLocalizedString("One pass, a tidier den.", comment: "")
         }

--- a/macos/Tests/NetModelTests.swift
+++ b/macos/Tests/NetModelTests.swift
@@ -1,0 +1,122 @@
+//
+//  NetModelTests.swift
+//  BurrowTests
+//
+//  The pure parser behind the Network pane: `burrow net --json` returns an
+//  envelope whose `data` is {count, by_total_bytes: [{name, pid, bytes_in,
+//  bytes_out, total, metric_source, metric_note?}]}. On macOS the rows are
+//  nettop BYTE counters (metric_source "macos_nettop_bytes", no note); on
+//  Windows they degrade to connection counts and carry a metric_note the
+//  pane must surface. Byte counts stay integer-exact (JSONSerialization,
+//  like DupesModel). Garbage parses to nil, never a crash.
+//
+
+import XCTest
+@testable import Burrow
+
+final class NetModelTests: XCTestCase {
+
+    /// A canned net report shaped like burrow-cli's `run_net` output on
+    /// macOS: nettop byte counters, ranked by total descending.
+    private let canned = """
+    {
+      "count": 3,
+      "by_total_bytes": [
+        {"name": "apsd", "pid": 573, "bytes_in": 28142, "bytes_out": 40592, "total": 68734,
+         "metric_source": "macos_nettop_bytes"},
+        {"name": "com.apple.WebKit.Networking", "pid": 123, "bytes_in": 5, "bytes_out": 7, "total": 12,
+         "metric_source": "macos_nettop_bytes"},
+        {"name": "launchd", "pid": 1, "bytes_in": 0, "bytes_out": 0, "total": 0,
+         "metric_source": "macos_nettop_bytes"}
+      ]
+    }
+    """.data(using: .utf8)!
+
+    func testParse_readsRowsRankedByTotal() throws {
+        let report = try XCTUnwrap(NetReport.parse(canned))
+        XCTAssertEqual(report.rows.count, 3)
+        XCTAssertEqual(report.rows[0].name, "apsd")
+        XCTAssertEqual(report.rows[0].pid, 573)
+        XCTAssertEqual(report.rows[0].bytesIn, 28142)
+        XCTAssertEqual(report.rows[0].bytesOut, 40592)
+        XCTAssertEqual(report.rows[0].total, 68734)
+        XCTAssertEqual(report.rows[0].metricSource, "macos_nettop_bytes")
+        XCTAssertNil(report.rows[0].metricNote)
+        // Dotted helper names survive whole.
+        XCTAssertEqual(report.rows[1].name, "com.apple.WebKit.Networking")
+        XCTAssertEqual(report.rows[2].name, "launchd")
+        XCTAssertNil(report.note, "byte-counter rows carry no caveat")
+    }
+
+    func testParse_resortsByTotalWhenTheCliOrderDrifts() throws {
+        // The CLI ranks by total already, but the pane re-sorts defensively.
+        let data = """
+        {"count": 2, "by_total_bytes": [
+          {"name": "small", "pid": 2, "bytes_in": 1, "bytes_out": 1, "total": 2, "metric_source": "macos_nettop_bytes"},
+          {"name": "big",   "pid": 3, "bytes_in": 50, "bytes_out": 50, "total": 100, "metric_source": "macos_nettop_bytes"}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(NetReport.parse(data))
+        XCTAssertEqual(report.rows.map(\.name), ["big", "small"])
+    }
+
+    func testParse_surfacesTheMetricNote() throws {
+        // Windows fallback rows are connection COUNTS, not bytes — the note
+        // explaining that must reach the pane (report.note = first note seen).
+        let data = """
+        {"count": 1, "by_total_bytes": [
+          {"name": "chrome.exe", "pid": 42, "bytes_in": 0, "bytes_out": 0, "total": 3,
+           "metric_source": "windows_netstat_connection_count",
+           "metric_note": "Windows netstat fallback reports per-process connection counts; byte counters are unavailable in this fallback."}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(NetReport.parse(data))
+        XCTAssertEqual(report.rows[0].metricNote?.isEmpty, false)
+        XCTAssertEqual(report.note, report.rows[0].metricNote)
+    }
+
+    func testParse_dropsRowsMissingTheSpineKeepsGoodOnes() throws {
+        // A row without a name is dropped; missing byte fields degrade to 0
+        // (total recomputed from in+out when absent).
+        let data = """
+        {"count": 3, "by_total_bytes": [
+          {"pid": 9, "total": 999},
+          {"name": "quiet", "pid": 7},
+          {"name": "busy", "pid": 8, "bytes_in": 10, "bytes_out": 20}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(NetReport.parse(data))
+        XCTAssertEqual(report.rows.count, 2)
+        XCTAssertEqual(report.rows[0].name, "busy")
+        XCTAssertEqual(report.rows[0].total, 30, "absent total falls back to in+out")
+        XCTAssertEqual(report.rows[1].name, "quiet")
+        XCTAssertEqual(report.rows[1].total, 0)
+    }
+
+    func testParse_keepsInt64PrecisionAboveInt32() throws {
+        // Multi-GB byte counters must survive exactly — the reason the parser
+        // is JSONSerialization, matching DupesModel/DiskScanner.
+        let data = """
+        {"count": 1, "by_total_bytes": [
+          {"name": "backupd", "pid": 4, "bytes_in": 5000000123, "bytes_out": 1,
+           "total": 5000000124, "metric_source": "macos_nettop_bytes"}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(NetReport.parse(data))
+        XCTAssertEqual(report.rows[0].bytesIn, 5_000_000_123)
+        XCTAssertEqual(report.rows[0].total, 5_000_000_124)
+    }
+
+    func testParse_emptyRowsIsAValidQuietReport() throws {
+        let data = #"{"count": 0, "by_total_bytes": []}"#.data(using: .utf8)!
+        let report = try XCTUnwrap(NetReport.parse(data))
+        XCTAssertTrue(report.rows.isEmpty)
+    }
+
+    func testParse_garbageIsNilNotACrash() {
+        XCTAssertNil(NetReport.parse(Data("not json".utf8)))
+        XCTAssertNil(NetReport.parse(Data()))
+        // Valid JSON but not an object — net reports are objects.
+        XCTAssertNil(NetReport.parse(Data("[1, 2, 3]".utf8)))
+    }
+}

--- a/macos/Tests/OrphansModelTests.swift
+++ b/macos/Tests/OrphansModelTests.swift
@@ -1,0 +1,136 @@
+//
+//  OrphansModelTests.swift
+//  BurrowTests
+//
+//  The pure parser behind the Leftovers pane: `burrow orphans <dir> --json`
+//  returns an envelope whose `data` carries the scan — `roots`,
+//  `installed_count`, `count`, and `orphans[]` rows shaped
+//  {name, path, confidence, evidence[], default_selected}. The GUI reads only
+//  that spine; extra fields (e.g. `inventory_sources`) may drift upstream
+//  without breaking us. Garbage or a non-object payload parses to nil,
+//  never a crash.
+//
+
+import XCTest
+@testable import Burrow
+
+final class OrphansModelTests: XCTestCase {
+
+    /// A canned orphans report, shaped like burrow-cli's `run_orphans` output:
+    /// two hits (one medium, one weak), a root, and the inventory count.
+    private let canned = """
+    {
+      "roots": ["/Users/dev/Library/Caches"],
+      "installed_count": 42,
+      "inventory_sources": {"applications_dir": 42},
+      "count": 2,
+      "orphans": [
+        {
+          "name": "OldAppLeftovers",
+          "path": "/Users/dev/Library/Caches/OldAppLeftovers",
+          "confidence": "weak",
+          "evidence": ["app-artifact-shaped", "not-matched-to-installed-inventory"],
+          "default_selected": false
+        },
+        {
+          "name": "com.deadvendor.oldapp",
+          "path": "/Users/dev/Library/Caches/com.deadvendor.oldapp",
+          "confidence": "medium",
+          "evidence": ["app-artifact-shaped", "not-matched-to-installed-inventory"],
+          "default_selected": false
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    func testParse_readsSpineAndSortsMediumFirst() throws {
+        let report = try XCTUnwrap(OrphansReport.parse(canned))
+        XCTAssertEqual(report.roots, ["/Users/dev/Library/Caches"])
+        XCTAssertEqual(report.installedCount, 42)
+        XCTAssertEqual(report.count, 2)
+        XCTAssertEqual(report.orphans.count, 2)
+
+        // Medium-confidence hits lead the list — the CLI emits name-sorted,
+        // the pane wants strongest evidence first.
+        XCTAssertEqual(report.orphans[0].name, "com.deadvendor.oldapp")
+        XCTAssertEqual(report.orphans[0].confidence, "medium")
+        XCTAssertEqual(report.orphans[0].evidence,
+                       ["app-artifact-shaped", "not-matched-to-installed-inventory"])
+        XCTAssertFalse(report.orphans[0].defaultSelected)
+        XCTAssertEqual(report.orphans[1].confidence, "weak")
+        XCTAssertEqual(report.orphans[1].path, "/Users/dev/Library/Caches/OldAppLeftovers")
+    }
+
+    func testParse_emptyOrphansIsAValidCleanReport() throws {
+        let data = """
+        {"roots": ["/tmp"], "installed_count": 10, "count": 0, "orphans": []}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(OrphansReport.parse(data))
+        XCTAssertTrue(report.orphans.isEmpty)
+        XCTAssertEqual(report.count, 0)
+    }
+
+    func testParse_dropsRowsMissingTheSpineKeepsGoodOnes() throws {
+        // A hit missing name or path is dropped; the rest still parses.
+        // Missing confidence/evidence degrade to "weak"/[] (loose everywhere
+        // except the spine).
+        let data = """
+        {"roots": ["/tmp"], "installed_count": 1, "count": 3, "orphans": [
+          {"confidence": "medium"},
+          {"name": "ghost", "path": "/tmp/ghost"},
+          {"name": "x", "confidence": "weak"}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(OrphansReport.parse(data))
+        XCTAssertEqual(report.orphans.count, 1)
+        XCTAssertEqual(report.orphans[0].name, "ghost")
+        XCTAssertEqual(report.orphans[0].confidence, "weak", "missing confidence degrades to weak")
+        XCTAssertTrue(report.orphans[0].evidence.isEmpty)
+    }
+
+    func testParse_windowsLowTierSortsBetweenMediumAndWeak() throws {
+        // burrow-cli's Windows scanner also emits "low" — it must rank below
+        // medium but above weak, and never crash the macOS pane.
+        let data = """
+        {"roots": ["/tmp"], "installed_count": 0, "count": 3, "orphans": [
+          {"name": "a-weak",   "path": "/t/a", "confidence": "weak"},
+          {"name": "b-low",    "path": "/t/b", "confidence": "low"},
+          {"name": "c-medium", "path": "/t/c", "confidence": "medium"}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(OrphansReport.parse(data))
+        XCTAssertEqual(report.orphans.map(\.confidence), ["medium", "low", "weak"])
+    }
+
+    func testParse_sortIsStableWithinATier() throws {
+        // Same tier -> the CLI's (name-sorted) order is preserved.
+        let data = """
+        {"roots": ["/tmp"], "installed_count": 0, "count": 3, "orphans": [
+          {"name": "alpha", "path": "/t/alpha", "confidence": "weak"},
+          {"name": "beta",  "path": "/t/beta",  "confidence": "weak"},
+          {"name": "gamma", "path": "/t/gamma", "confidence": "weak"}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(OrphansReport.parse(data))
+        XCTAssertEqual(report.orphans.map(\.name), ["alpha", "beta", "gamma"])
+    }
+
+    func testParse_missingCountsFallBackToComputed() throws {
+        // No count / installed_count -> count falls back to the parsed rows,
+        // installedCount to 0 (rendered as "unknown inventory", not a crash).
+        let data = """
+        {"orphans": [{"name": "ghost", "path": "/tmp/ghost", "confidence": "medium"}]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(OrphansReport.parse(data))
+        XCTAssertEqual(report.count, 1)
+        XCTAssertEqual(report.installedCount, 0)
+        XCTAssertTrue(report.roots.isEmpty)
+    }
+
+    func testParse_garbageIsNilNotACrash() {
+        XCTAssertNil(OrphansReport.parse(Data("not json".utf8)))
+        XCTAssertNil(OrphansReport.parse(Data()))
+        // Valid JSON but not an object — orphans reports are objects.
+        XCTAssertNil(OrphansReport.parse(Data("[1, 2, 3]".utf8)))
+    }
+}

--- a/macos/Tests/PhotosModelTests.swift
+++ b/macos/Tests/PhotosModelTests.swift
@@ -1,0 +1,94 @@
+//
+//  PhotosModelTests.swift
+//  BurrowTests
+//
+//  The pure parser behind the Similar Photos pane: `burrow photos <dir>
+//  --json` returns an envelope whose `data` is {dir, threshold,
+//  similar_groups: [{paths: [String]}]} — each group serialized by
+//  burrow-cli's photos::Group as an OBJECT with a `paths` key, not a bare
+//  array. The GUI reads only that spine. Garbage or a non-object payload
+//  parses to nil, never a crash.
+//
+
+import XCTest
+@testable import Burrow
+
+final class PhotosModelTests: XCTestCase {
+
+    /// A canned photos report shaped like burrow-cli's `run_photos` output:
+    /// two similar groups at the default hamming threshold.
+    private let canned = """
+    {
+      "dir": "/Users/dev/Pictures/Screenshots",
+      "threshold": 10,
+      "similar_groups": [
+        {"paths": ["/Users/dev/Pictures/Screenshots/a.png", "/Users/dev/Pictures/Screenshots/a copy.png"]},
+        {"paths": ["/Users/dev/Pictures/Screenshots/b.jpg", "/Users/dev/Pictures/Screenshots/b2.jpg", "/Users/dev/Pictures/Screenshots/b3.jpg"]}
+      ]
+    }
+    """.data(using: .utf8)!
+
+    func testParse_readsGroupsAndSortsLargestFirst() throws {
+        let report = try XCTUnwrap(PhotosReport.parse(canned))
+        XCTAssertEqual(report.dir, "/Users/dev/Pictures/Screenshots")
+        XCTAssertEqual(report.threshold, 10)
+        XCTAssertEqual(report.groups.count, 2)
+        // Largest group first — the set with the most near-copies leads.
+        XCTAssertEqual(report.groups[0].paths.count, 3)
+        XCTAssertEqual(report.groups[0].paths.first, "/Users/dev/Pictures/Screenshots/b.jpg")
+        XCTAssertEqual(report.groups[1].paths,
+                       ["/Users/dev/Pictures/Screenshots/a.png",
+                        "/Users/dev/Pictures/Screenshots/a copy.png"])
+    }
+
+    func testParse_emptyGroupsIsAValidCleanReport() throws {
+        let data = """
+        {"dir": "/tmp/pics", "threshold": 10, "similar_groups": []}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(PhotosReport.parse(data))
+        XCTAssertTrue(report.groups.isEmpty)
+        XCTAssertEqual(report.dir, "/tmp/pics")
+    }
+
+    func testParse_dropsMalformedGroupsKeepsGoodOnes() throws {
+        // A group that isn't {paths: [...]} — or holds fewer than two paths
+        // (not "similar" to anything) — is dropped; the rest still parses.
+        let data = """
+        {"dir": "/tmp", "threshold": 5, "similar_groups": [
+          {"hash": 42},
+          {"paths": []},
+          {"paths": ["/tmp/only-one.png"]},
+          {"paths": ["/tmp/x.png", "/tmp/y.png"]}
+        ]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(PhotosReport.parse(data))
+        XCTAssertEqual(report.groups.count, 1)
+        XCTAssertEqual(report.groups[0].paths, ["/tmp/x.png", "/tmp/y.png"])
+    }
+
+    func testParse_missingDirAndThresholdDegradeGently() throws {
+        // Loose everywhere except the spine: absent dir -> "", absent
+        // threshold -> 0. Groups still land.
+        let data = """
+        {"similar_groups": [{"paths": ["/tmp/x.png", "/tmp/y.png"]}]}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(PhotosReport.parse(data))
+        XCTAssertEqual(report.dir, "")
+        XCTAssertEqual(report.threshold, 0)
+        XCTAssertEqual(report.groups.count, 1)
+    }
+
+    func testParse_garbageIsNilNotACrash() {
+        XCTAssertNil(PhotosReport.parse(Data("not json".utf8)))
+        XCTAssertNil(PhotosReport.parse(Data()))
+        // Valid JSON but not an object — photos reports are objects.
+        XCTAssertNil(PhotosReport.parse(Data(#"[["a.png","b.png"]]"#.utf8)))
+    }
+
+    func testGroup_identityIsTheFirstPath() {
+        // Stable SwiftUI identity: the first member path is unique per group
+        // (greedy clustering never puts one path in two groups).
+        let g = PhotoGroup(paths: ["/tmp/x.png", "/tmp/y.png"])
+        XCTAssertEqual(g.id, "/tmp/x.png")
+    }
+}


### PR DESCRIPTION
## What

Three new GUI panes surfacing the conductor's discovery commands, all **read-only v1** (the only action anywhere is Reveal in Finder):

| Pane | Tool case | Command | Accent |
|---|---|---|---|
| Leftovers | `orphans` | `burrow orphans <dir>` | olive `0xB7BE5A` |
| Similar Photos | `photos` | `burrow photos <dir>` (600 s timeout — dHash is slow) | orchid `0xD57BC4` |
| Network | `net` | `burrow net` | indigo `0x6E8FE0` |

## Pattern provenance

Copied from the **post-#266 Duplicates pane** (`DupesView.swift` / `DupesModel.swift`), the canonical conductor-tool surface:

- Analyze-style toolbar: up arrow + breadcrumbs + mono summary + folder/refresh icon buttons (Network drops the folder machinery — the sample is machine-wide).
- The same state ladder: `conductorMissing` / idle / scanning / error / clean / results.
- `BurrowConductor.capture` off the main thread with a monotonic `scanGen` supersede token; `OperationCenter` begin/end around every scan.
- Pure `JSONSerialization` parsers (`OrphansReport.parse`, `PhotosReport.parse`, `NetReport.parse`) — loose everywhere except the spine, Int64-exact byte counts, garbage → nil never a crash.
- `NSLocalizedString` on every user string, `Brand.*` styling, `Tool` accents/tints/taglines.
- Network auto-samples on first activation via PortsView's `isActive` idiom (cheap, no timers); manual refresh after.

`Tool` gains three cases; verified no exhaustive `Tool` switches exist outside `Tool.swift`, so the growth is additive. Nav order: the discovery pair (Leftovers, Similar Photos) follows Duplicates; Network sits beside Ports.

## Tests (written first)

`OrphansModelTests` / `PhotosModelTests` / `NetModelTests`, in the DupesModelTests style: canned CLI-shaped reports, spine reads, ordering (confidence tier / cluster size / total bytes), loose-field degradation, Int64 precision above Int32, garbage-is-nil. Shapes verified against the vendored `burrow-cli` source (`orphan.rs::OrphanHit`, `photos.rs::Group` — note: groups serialize as `{paths: [...]}` objects, `net.rs::ProcNet` under `by_total_bytes`).

Local verification: `macos/scripts/build.sh Debug` **and** `xcodebuild build-for-testing` both green (the suite itself runs in CI — no PTY locally).

## Notes / deviations

- Network's nav glyph is `arrow.up.arrow.down`, not `network` — Ports already owns `network` and two identical rail icons would be indistinguishable.
- Photos thumbnails decode off-main via `CGImageSourceCreateThumbnailAtIndex` (max 64 px, bounded `NSCache`) — deliberately not `NSImage(contentsOfFile:)`, which full-decodes and would hang on large originals.

## Follow-ups (out of scope here)

- **Leftovers**: a CleanReview-style checklist + Move-to-Trash flow honoring `default_selected` and the CLI's volatile-roots policy; surface `inventory_sources`; an "add scan root" multi-root mode.
- **Similar Photos**: a side-by-side compare view; keep-best selection + Trash flow; HEIC support once burrow-cli grows its `heif` feature; recursive scan option.
- **Network**: repeat-sample deltas (rates, not one-shot totals); jump-to-Ports for a process; kill/quiet actions with the Ports pane's confirm gating; a `--limit` control (CLI default caps at 15 rows).