### PR TITLE
chore: point at the renamed engine fork (burrow-engine → burrow-digger)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           DEST="$RUNNER_TEMP/burrow-engine"
           AUTH=()
           [ -n "$ENGINE_PAT" ] && AUTH=(-c "url.https://x-access-token:${ENGINE_PAT}@github.com/.insteadOf=https://github.com/")
-          if git "${AUTH[@]}" clone --quiet https://github.com/caezium/burrow-engine.git "$DEST" \
+          if git "${AUTH[@]}" clone --quiet https://github.com/caezium/burrow-digger.git "$DEST" \
              && git -C "$DEST" -c advice.detachedHead=false checkout --quiet "$SHA"; then
             echo "BURROW_ENGINE_SRC=$DEST" >> "$GITHUB_ENV"
             echo "engine: cloned to $DEST @ ${SHA:0:7}"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "macos/vendor/burrow-engine"]
 	path = macos/vendor/burrow-engine
-	url = https://github.com/caezium/burrow-engine.git
+	url = https://github.com/caezium/burrow-digger.git
 [submodule "macos/vendor/burrow-cli"]
 	path = macos/vendor/burrow-cli
 	url = https://github.com/caezium/burrow-cli.git

--- a/macos/Sources/MoleCLI.swift
+++ b/macos/Sources/MoleCLI.swift
@@ -143,7 +143,7 @@ enum MoleCLI {
     static let installCommand = "brew install --cask caezium/tap/burrow"
     /// The engine fork (the MIT engine is bundled with the app, pinned at mo's last MIT
     /// release before upstream relicensed to GPL-3.0).
-    static let repoURL = URL(string: "https://github.com/caezium/burrow-engine")!
+    static let repoURL = URL(string: "https://github.com/caezium/burrow-digger")!
 
     /// Current `mo` version, or nil if not installed / unparsable.
     static func version() -> String? {


### PR DESCRIPTION
Repo-architecture refactor step 1 (per Henry's direction): the mo-fork snapshot repo is renamed **caezium/burrow-digger**, freeing `burrow-engine` for the new Rust core that will power burrow-cli and both GUIs.

Only **repo URLs** change (.gitmodules, release.yml clone, MoleCLI repoURL). The runtime contract — `Resources/engine`, `BURROW_ENGINE_DIR`, the `mole`/`burrow-engine` entrypoint filenames — is untouched, so shipped apps, bundle scripts, and the release asserts are unaffected.

⚠️ Must merge **before** the new `caezium/burrow-engine` repo is created — creating it kills GitHub's rename redirect that currently keeps the old URLs working.