### PR TITLE
fix(macos): bundle the fclones sidecar so Duplicates works with zero install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,24 @@ jobs:
           xcodebuild test -project Burrow.xcodeproj -scheme Burrow \
             -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+  # Validate the fclones sidecar cross-compiles universal (the Duplicates dependency). Runs on
+  # the fclones scripts so it proves + caches the build before a release relies on it.
+  fclones-sidecar:
+    runs-on: macos-15
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Cache fclones sidecar
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/burrow-fclones
+          key: fclones-universal-0.35.0
+      - name: Build universal fclones
+        run: bash scripts/build-fclones.sh
+      - name: Assert it is universal
+        run: |
+          F="$HOME/.cache/burrow-fclones/fclones-universal-0.35.0"
+          lipo -archs "$F" | grep -q arm64 && lipo -archs "$F" | grep -q x86_64 \
+            || { echo "::error::fclones not universal: $(lipo -archs "$F")"; exit 1; }
+          "$F" --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,16 @@ jobs:
       - name: Select newest Xcode
         run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)" && xcodebuild -version
 
+      # Cache the built universal fclones across releases so it builds only once (heavy —
+      # two full dep-tree builds). Keyed on the pinned version.
+      - name: Cache fclones sidecar
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: ~/.cache/burrow-fclones
+          key: fclones-universal-0.35.0
+      - name: Build fclones sidecar (MIT, universal)
+        run: bash scripts/build-fclones.sh
+
       - name: Install xcodegen
         run: brew install xcodegen
 
@@ -144,7 +154,11 @@ jobs:
             || { echo "::error::Resources/engine incomplete — the engine did not bundle. Failing the release."; exit 1; }
           lipo -archs "$APP/Contents/Resources/burrow" | grep -q "x86_64" \
             || { echo "::error::bundled burrow is not universal (missing x86_64 slice)."; exit 1; }
-          echo "conductor: $(lipo -archs "$APP/Contents/Resources/burrow") ✓  engine: present ✓"
+          [ -x "$APP/Contents/Resources/fclones" ] \
+            || { echo "::error::Resources/fclones missing — the Duplicates sidecar did not bundle. Failing the release."; exit 1; }
+          lipo -archs "$APP/Contents/Resources/fclones" | grep -q "x86_64" \
+            || { echo "::error::bundled fclones is not universal (missing x86_64 slice)."; exit 1; }
+          echo "conductor: $(lipo -archs "$APP/Contents/Resources/burrow") ✓  engine: present ✓  fclones: $(lipo -archs "$APP/Contents/Resources/fclones") ✓"
 
       - name: Verify the tag matches the app version
         run: |

--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -38,6 +38,16 @@ enum BurrowConductor {
         return (exists && isDir.boolValue) ? dir : nil
     }
 
+    /// The bundled `fclones` sidecar (Resources/fclones, from bundle-fclones.sh), or nil if this
+    /// build didn't ship one. `burrow dupes` shells out to fclones; without a bundled copy it falls
+    /// back to a `$BURROW_FCLONES`/PATH fclones, and if none exists the Duplicates pane shows
+    /// "fclones not found".
+    static func fclonesURL() -> URL? {
+        guard let res = Bundle.main.resourceURL else { return nil }
+        let fclones = res.appendingPathComponent("fclones")
+        return FileManager.default.isExecutableFile(atPath: fclones.path) ? fclones : nil
+    }
+
     /// True when a bundled conductor is present. Call sites branch on this to decide between the
     /// conductor path and the legacy direct-engine path.
     static var isAvailable: Bool { executableURL() != nil }
@@ -58,6 +68,11 @@ enum BurrowConductor {
         // would otherwise shadow Foundation's here.
         var env = Foundation.ProcessInfo.processInfo.environment
         if let dir = engineDir { env["BURROW_ENGINE_DIR"] = dir.path }
+        // Point the conductor at the bundled fclones for `dupes` — but don't OVERRIDE a user's
+        // own $BURROW_FCLONES if they set one (they may prefer a newer/system fclones).
+        if env["BURROW_FCLONES"] == nil, let fclones = fclonesURL() {
+            env["BURROW_FCLONES"] = fclones.path
+        }
         return env
     }
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -132,6 +132,16 @@ targets:
           else
             echo "warning: burrow-cli source or cargo not present at $BURROW_CLI_SRC — Burrow falls back to the direct engine. Set BURROW_CLI_SRC or init the vendor/burrow-cli submodule."
           fi
+      - name: Bundle fclones (MIT sidecar)
+        basedOnDependencyAnalysis: false
+        script: |
+          # COPY the cached universal `fclones` beside the conductor so the Duplicates pane works
+          # with zero install — `burrow dupes` resolves it via $BURROW_FCLONES (set by the app to
+          # this bundled copy). This phase NEVER builds fclones (that heavy step is release-only,
+          # scripts/build-fclones.sh); it copies the cache and otherwise skips gracefully, so a
+          # disk-constrained local build is never at risk. Final seal happens POST-build.
+          "$SRCROOT/scripts/bundle-fclones.sh" "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH" \
+            || echo "warning: fclones bundling skipped — Duplicates falls back to a system/\$BURROW_FCLONES fclones."
 
   BurrowTests:
     type: bundle.unit-test

--- a/macos/scripts/bundle-fclones.sh
+++ b/macos/scripts/bundle-fclones.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# bundle-fclones.sh — stage a cached universal `fclones` (MIT) into the app's Resources.
+#
+# COPY-ONLY BY DESIGN. The Duplicates pane runs `burrow dupes`, whose conductor shells out to
+# the fclones sidecar; the app points $BURROW_FCLONES at this bundled copy so Duplicates works
+# with zero user install. fclones has no macOS prebuilt binary, so it's built from source ONCE
+# by scripts/build-fclones.sh (release-only — it needs GBs of temp space, which disk-constrained
+# dev machines don't have). This script NEVER builds; it only copies the cached universal. If
+# the cache is empty (a plain local build) it warns + skips so the app build stays green and
+# Duplicates falls back to a system/$BURROW_FCLONES fclones.
+#
+# Usage: bundle-fclones.sh <RESOURCES_DIR>
+set -euo pipefail
+
+RESOURCES="${1:?resources dir required}"
+VERSION="${FCLONES_VERSION:-0.35.0}"
+CACHE="${FCLONES_CACHE:-$HOME/.cache/burrow-fclones}"
+OUT="$RESOURCES/fclones"
+UNIVERSAL="$CACHE/fclones-universal-$VERSION"
+
+if [ ! -x "$UNIVERSAL" ]; then
+  echo "note: no cached universal fclones at $UNIVERSAL — Duplicates will use a system/\$BURROW_FCLONES fclones. (The release pipeline builds + caches it via scripts/build-fclones.sh.)"
+  exit 0
+fi
+
+mkdir -p "$RESOURCES"
+cp "$UNIVERSAL" "$OUT"
+chmod +x "$OUT"
+
+# Sign beside the engine/conductor so the app's own signature validates (--deep).
+IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:--}"
+codesign --force --sign "$IDENTITY" --timestamp=none "$OUT" 2>/dev/null \
+  || codesign --force --sign - --timestamp=none "$OUT" || true
+
+echo "bundled fclones -> $OUT ($(lipo -archs "$OUT" 2>/dev/null || echo native); signed with '${IDENTITY}')"

--- a/scripts/build-fclones.sh
+++ b/scripts/build-fclones.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# build-fclones.sh — build a UNIVERSAL `fclones` (MIT) from crates.io into the sidecar cache.
+#
+# fclones ships no macOS prebuilt binary, so the app bundles one we build ourselves. This is the
+# HEAVY, disk-hungry half (two full dependency-tree builds, arm64 + x86_64) — kept OUT of the app
+# build phase so a disk-constrained dev machine never triggers it accidentally. Run it explicitly:
+# the release pipeline calls it (ample runner disk) with actions/cache keyed on the version so it
+# builds only on the first release. bundle-fclones.sh then just COPIES the result.
+#
+# Idempotent: exits immediately if the cached universal already exists.
+set -euo pipefail
+
+VERSION="${FCLONES_VERSION:-0.35.0}"
+CACHE="${FCLONES_CACHE:-$HOME/.cache/burrow-fclones}"
+UNIVERSAL="$CACHE/fclones-universal-$VERSION"
+
+if [ -x "$UNIVERSAL" ]; then
+  echo "fclones $VERSION already cached: $UNIVERSAL ($(lipo -archs "$UNIVERSAL"))"
+  exit 0
+fi
+
+command -v cargo >/dev/null 2>&1 || { echo "error: cargo not found — cannot build fclones"; exit 1; }
+
+# Universal (arm64 + x86_64): an arch-only sidecar hangs the universal app on the other arch
+# (#221). rustup fetches the missing target slice.
+export GIT_TERMINAL_PROMPT=0
+A=aarch64-apple-darwin
+X=x86_64-apple-darwin
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if command -v rustup >/dev/null 2>&1; then
+  rustup target add "$A" "$X" >/dev/null 2>&1 || true
+fi
+
+echo "building fclones $VERSION for $A …"
+cargo install fclones --version "$VERSION" --locked --target "$A" --root "$TMP/a" </dev/null
+echo "building fclones $VERSION for $X …"
+cargo install fclones --version "$VERSION" --locked --target "$X" --root "$TMP/x" </dev/null
+
+mkdir -p "$CACHE"
+lipo -create -output "$UNIVERSAL" "$TMP/a/bin/fclones" "$TMP/x/bin/fclones"
+chmod +x "$UNIVERSAL"
+echo "built fclones $VERSION -> $UNIVERSAL ($(lipo -archs "$UNIVERSAL"))"


### PR DESCRIPTION
**The bug** (seen on a clean Mac): the Duplicates pane dies with `fclones not found; install it (cargo install fclones) or set BURROW_FCLONES`. fclones — the sidecar `burrow dupes` shells out to — was never bundled, unlike the engine and conductor. It only worked where fclones was on PATH. (It's the *only* external sidecar macOS needs; photos/orphans are native Rust, net uses `nettop`.)

**The fix**: a universal `fclones` ships in `Resources/` and the conductor points `$BURROW_FCLONES` at it (without overriding a user's own). Because fclones has no macOS prebuilt and building it is heavy + disk-hungry (it filled a disk-constrained dev machine), the build is split:
- **build-fclones.sh** — the heavy universal build into a version-keyed cache. **Release-only.**
- **bundle-fclones.sh** — **copy-only** from cache; skips gracefully if absent (local builds stay green, Duplicates falls back to system fclones).
- **release.yml** — cache + build step + a hard assert that a release ships a universal `Resources/fclones`.
- **ci.yml** — a `fclones-sidecar` job validates the cross-compile + seeds the cache **on this PR**.

Ships to users in the next release; `brew install fclones` is the interim workaround for dev/test machines.