### PR TITLE
fix(macos): augment conductor PATH with Homebrew bins (Finder-launch trap)

### DIFF
--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -73,7 +73,22 @@ enum BurrowConductor {
         if env["BURROW_FCLONES"] == nil, let fclones = fclonesURL() {
             env["BURROW_FCLONES"] = fclones.path
         }
+        env["PATH"] = augmentedPATH(env["PATH"])
         return env
+    }
+
+    /// A Finder/LaunchServices launch strips PATH to `/usr/bin:/bin:/usr/sbin:/sbin` — no
+    /// `/opt/homebrew/bin` or `/usr/local/bin`. Absolute-path tools (the bundled engine/conductor/
+    /// fclones, `/usr/bin/nettop`, `/usr/bin/brctl`) don't care, but a user-installed fallback
+    /// sidecar AND the engine's own shell-outs to brew tools would silently vanish. Prepend the
+    /// Homebrew bins (idempotent) so PATH resolution matches what the user sees in a terminal.
+    /// Pure — unit-tested.
+    static func augmentedPATH(_ current: String?) -> String {
+        let base = (current?.isEmpty == false) ? current! : "/usr/bin:/bin:/usr/sbin:/sbin"
+        let brew = ["/opt/homebrew/bin", "/usr/local/bin"]
+        let entries = base.split(separator: ":").map(String.init)
+        let missing = brew.filter { !entries.contains($0) }
+        return missing.isEmpty ? base : (missing.joined(separator: ":") + ":" + base)
     }
 
     // MARK: - Capture (one-shot JSON commands)

--- a/macos/Tests/BurrowEnvelopeTests.swift
+++ b/macos/Tests/BurrowEnvelopeTests.swift
@@ -98,6 +98,29 @@ final class BurrowEnvelopeTests: XCTestCase {
         XCTAssertNil(BurrowConductor.environment(engineDir: nil)["BURROW_ENGINE_DIR"])
     }
 
+    // MARK: PATH augmentation (the Finder-launch trap — brew sidecars/engine shell-outs)
+
+    func testAugmentedPATH_prependsHomebrewBinsToStrippedLaunchPATH() {
+        // The launchd/Finder default — no /opt/homebrew/bin.
+        let out = BurrowConductor.augmentedPATH("/usr/bin:/bin:/usr/sbin:/sbin")
+        XCTAssertEqual(out, "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")
+    }
+
+    func testAugmentedPATH_isIdempotentAndPreservesExistingEntries() {
+        // A terminal launch already has the brew bins — don't duplicate them or reorder.
+        let terminal = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+        XCTAssertEqual(BurrowConductor.augmentedPATH(terminal), terminal)
+        // Only the missing one is added.
+        XCTAssertEqual(BurrowConductor.augmentedPATH("/opt/homebrew/bin:/usr/bin"),
+                       "/usr/local/bin:/opt/homebrew/bin:/usr/bin")
+    }
+
+    func testAugmentedPATH_handlesEmptyOrNil() {
+        let fallback = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        XCTAssertEqual(BurrowConductor.augmentedPATH(nil), fallback)
+        XCTAssertEqual(BurrowConductor.augmentedPATH(""), fallback)
+    }
+
     // MARK: streaming argv translation (safety-critical: mo↔burrow dry-run/apply INVERSION)
 
     func testStreamArgv_preview_dropsDryRun_neverApply() {


### PR DESCRIPTION
Found auditing the fclones-class of bugs. A Finder-launched app gets a **stripped PATH** (`/usr/bin:/bin:/usr/sbin:/sbin` — no `/opt/homebrew/bin`). Absolute-path tools are fine, but a **user-installed fallback sidecar** (the `brew install fclones` workaround!) and the **engine's own brew-tool shell-outs** silently vanished. `BurrowConductor.environment` now prepends the Homebrew bins (idempotent, order-preserving). Pure + unit-tested (`augmentedPATH`).