### PR TITLE
fix(macos): tell the user when Similar Photos skipped HEIC (not a bare empty scan)

### DIFF
--- a/macos/Sources/PhotosModel.swift
+++ b/macos/Sources/PhotosModel.swift
@@ -31,6 +31,25 @@ struct PhotosReport: Equatable {
     /// dHash hamming-distance threshold (CLI default 10; 0 when absent).
     let threshold: Int
     let groups: [PhotoGroup]
+    /// Images the engine couldn't decode — HEIC (the dominant iPhone format) & friends. Surfaced
+    /// so a folder of HEIC doesn't read as an empty "no similar photos" result. 0 on older
+    /// engines that don't report it (the field is absent → treated as none skipped).
+    let skippedUnsupported: Int
+    /// The skipped count broken down by lowercased extension (e.g. ["heic": 42]). Empty when none.
+    let skippedFormats: [String: Int]
+
+    /// A short human note like "42 HEIC photos couldn't be read yet", or nil when nothing was
+    /// skipped. Leads with HEIC (the case users hit) and rolls the rest into "other".
+    var skippedNote: String? {
+        guard skippedUnsupported > 0 else { return nil }
+        let heic = (skippedFormats["heic"] ?? 0) + (skippedFormats["heif"] ?? 0)
+        let others = skippedUnsupported - heic
+        var parts: [String] = []
+        if heic > 0 { parts.append("\(heic) HEIC") }
+        if others > 0 { parts.append("\(others) other") }
+        let what = parts.isEmpty ? "\(skippedUnsupported)" : parts.joined(separator: " + ")
+        return "\(what) image\(skippedUnsupported == 1 ? "" : "s") couldn't be read (HEIC isn't supported yet)"
+    }
 
     /// Decode the photos JSON. Loose everywhere except the spine: a group
     /// that isn't {paths:[...]} — or holds fewer than two paths — is dropped,
@@ -54,9 +73,18 @@ struct PhotosReport: Equatable {
             return l != r ? l > r : $0.offset < $1.offset
         }.map(\.element)
 
+        // Loose numeric read: the count arrives as an Int, but tolerate any NSNumber.
+        let skipped = (raw["skipped_unsupported"] as? NSNumber)?.intValue ?? 0
+        var formats: [String: Int] = [:]
+        if let raw = raw["skipped_formats"] as? [String: Any] {
+            for (k, v) in raw { if let n = (v as? NSNumber)?.intValue { formats[k] = n } }
+        }
+
         return PhotosReport(
             dir: (raw["dir"] as? String) ?? "",
             threshold: (raw["threshold"] as? Int) ?? 0,
-            groups: ranked)
+            groups: ranked,
+            skippedUnsupported: skipped,
+            skippedFormats: formats)
     }
 }

--- a/macos/Sources/PhotosView.swift
+++ b/macos/Sources/PhotosView.swift
@@ -37,7 +37,7 @@ struct PhotosView: View {
                 } else if let err = model.error {
                     errorState(err)
                 } else if let report = model.report {
-                    if report.groups.isEmpty { cleanState } else { results(report) }
+                    if report.groups.isEmpty { cleanState(report) } else { results(report) }
                 } else {
                     idleState
                 }
@@ -175,13 +175,20 @@ struct PhotosView: View {
         }
     }
 
-    private var cleanState: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "checkmark.circle").font(.system(size: 24)).foregroundStyle(Tool.photos.accent)
-            Text(NSLocalizedString("No look-alikes here", comment: ""))
+    private func cleanState(_ report: PhotosReport) -> some View {
+        // A folder of iPhone photos scans as "empty" because the engine can't decode HEIC — say so
+        // rather than claiming everything's unique, which would be an outright lie for that folder.
+        let skipped = report.skippedNote
+        return VStack(spacing: 8) {
+            Image(systemName: skipped == nil ? "checkmark.circle" : "photo.badge.exclamationmark")
+                .font(.system(size: 24)).foregroundStyle(Tool.photos.accent)
+            Text(skipped == nil
+                 ? NSLocalizedString("No look-alikes here", comment: "")
+                 : NSLocalizedString("Nothing scannable here", comment: ""))
                 .font(Brand.serif(17, .medium)).foregroundStyle(Brand.textPrimary)
-            Text(NSLocalizedString("Every PNG and JPEG in this folder looks one of a kind.", comment: ""))
+            Text(skipped ?? NSLocalizedString("Every PNG and JPEG in this folder looks one of a kind.", comment: ""))
                 .font(Brand.mono(11)).foregroundStyle(Brand.textSecondary)
+                .multilineTextAlignment(.center).frame(maxWidth: 440)
         }
     }
 
@@ -195,6 +202,9 @@ struct PhotosView: View {
                         .font(Brand.serif(22, .medium)).foregroundStyle(Brand.textPrimary)
                     Text(NSLocalizedString("Images in a set look alike to a perceptual hash — not byte-identical, so judge with your eyes. Read-only: reveal anything in Finder.", comment: ""))
                         .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                    if let skipped = report.skippedNote {
+                        Text(skipped).font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                    }
                 }
                 Spacer()
             }

--- a/macos/Tests/PhotosModelTests.swift
+++ b/macos/Tests/PhotosModelTests.swift
@@ -91,4 +91,32 @@ final class PhotosModelTests: XCTestCase {
         let g = PhotoGroup(paths: ["/tmp/x.png", "/tmp/y.png"])
         XCTAssertEqual(g.id, "/tmp/x.png")
     }
+
+    // MARK: skipped-unsupported (HEIC) surfacing
+
+    func testParse_skippedUnsupportedIsRead() throws {
+        let data = """
+        {"dir":"/p","threshold":10,"similar_groups":[],
+         "skipped_unsupported":43,"skipped_formats":{"heic":42,"tiff":1}}
+        """.data(using: .utf8)!
+        let report = try XCTUnwrap(PhotosReport.parse(data))
+        XCTAssertEqual(report.skippedUnsupported, 43)
+        XCTAssertEqual(report.skippedFormats["heic"], 42)
+        // Note leads with HEIC and rolls the rest into "other".
+        XCTAssertEqual(report.skippedNote, "42 HEIC + 1 other images couldn't be read (HEIC isn't supported yet)")
+    }
+
+    func testParse_noSkippedFieldMeansNoNote() throws {
+        // Older engines omit the field — absent must read as zero, no note (no false alarm).
+        let data = #"{"similar_groups":[{"paths":["/a.png","/b.png"]}]}"#.data(using: .utf8)!
+        let report = try XCTUnwrap(PhotosReport.parse(data))
+        XCTAssertEqual(report.skippedUnsupported, 0)
+        XCTAssertNil(report.skippedNote)
+    }
+
+    func testSkippedNote_singularHeicOnly() {
+        let r = PhotosReport(dir: "", threshold: 0, groups: [],
+                             skippedUnsupported: 1, skippedFormats: ["heic": 1])
+        XCTAssertEqual(r.skippedNote, "1 HEIC image couldn't be read (HEIC isn't supported yet)")
+    }
 }


### PR DESCRIPTION
Pairs with caezium/burrow-cli#16. A folder of iPhone photos is mostly **HEIC**, which the engine can't decode — so the pane claimed "Every PNG and JPEG looks one of a kind", a lie for a folder it never read. Now the empty state reads **"Nothing scannable here — 42 HEIC photos couldn't be read (HEIC isn't supported yet)"**, and a partial scan shows the same note under the results header.

Backward-compatible: fields read loosely, absent → 0 → no note (a pre-#16 bundled engine behaves exactly as before). Pure parser + note logic, unit-tested.