### PR TITLE
release: 0.10.1 — three new panes + Duplicates/HUD/HEIC fixes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,38 @@
+# Burrow 0.10.1
+
+Three new panes, and Duplicates finally works on a clean Mac. This release
+carries everything since 0.10.0 — the Leftovers, Similar Photos, and Network
+panes, plus a batch of menu-bar HUD and sidecar fixes.
+
+## New panes
+- **Leftovers.** Surface the files an app leaves behind after you delete it —
+  caches, preferences, application support, launch agents — and clear the
+  orphans. ([#273](https://github.com/caezium/Burrow/pull/273))
+- **Similar Photos.** Cluster visually-similar images — near-duplicate
+  screenshots, burst shots, re-exports — by perceptual hash. Read-only: review
+  the sets, reveal anything in Finder.
+  ([#273](https://github.com/caezium/Burrow/pull/273))
+- **Network.** Per-app bandwidth, so you can see what's talking to the internet.
+  ([#273](https://github.com/caezium/Burrow/pull/273))
+
+## Fixes
+- **Duplicates works out of the box.** The `fclones` sidecar it relies on is now
+  bundled inside the app, so there's no more "fclones not found" on a clean Mac.
+  ([#278](https://github.com/caezium/Burrow/pull/278))
+- **Similar Photos is honest about HEIC.** A folder of iPhone photos — HEIC,
+  which the scanner can't decode yet — now says "N HEIC couldn't be read"
+  instead of a bare, misleading empty result.
+  ([#283](https://github.com/caezium/Burrow/pull/283))
+- **Menu-bar HUD polish.** The popover no longer drifts sideways and clips its
+  content, and the tool strip wraps into a grid instead of overflowing.
+  ([#275](https://github.com/caezium/Burrow/pull/275),
+  [#277](https://github.com/caezium/Burrow/pull/277))
+- **No more ~2-second hang** when opening the window or switching panes — tool
+  panes now mount lazily. ([#274](https://github.com/caezium/Burrow/pull/274))
+- **Homebrew-installed helpers resolve.** A Finder-launched app now finds tools
+  on `/opt/homebrew/bin` on its PATH, matching what you see in a terminal.
+  ([#279](https://github.com/caezium/Burrow/pull/279))
+
 # Burrow 0.10.0
 
 The conductor release. Burrow now ships its own command layer — the bundled

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -54,7 +54,7 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.10.0"
+        CFBundleShortVersionString: "0.10.1"
         CFBundleVersion: "18"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Friendly, one-time prompts for the standard folders Mole scans

--- a/windows/BurrowWin.csproj
+++ b/windows/BurrowWin.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>BurrowWin</RootNamespace>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\AppIcon.ico</ApplicationIcon>
     <Platforms>x86;x64;ARM64</Platforms>

--- a/windows/Package.appxmanifest
+++ b/windows/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="DA9687FB-09FD-4C4D-B67F-C35B87E6974E"
     Publisher="CN=Caezium"
-    Version="0.10.0.0" />
+    Version="0.10.1.0" />
 
   <mp:PhoneIdentity PhoneProductId="DA9687FB-09FD-4C4D-B67F-C35B87E6974E" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
Version bump + RELEASES.md for **0.10.1**. Carries everything since v0.10.0 (tagged at a8074d2, before all of it landed): the Leftovers / Similar Photos / Network panes (#273) plus the fclones-bundling, HEIC-surfacing, HUD-popover, lazy-mount, and PATH fixes. Tag `v0.10.1` after merge triggers the release.