### PR TITLE
ci(release): let the conductor build fetch the private burrow-engine dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,18 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # bundle-burrow.sh does `cargo build` on the vendored conductor, which now depends on the
+          # PRIVATE burrow-engine crate over git. Fetch it via the git CLI so the token below applies.
+          ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: |
+          # Let cargo read the private burrow-engine dependency during the conductor build. Set
+          # AFTER the conductor-fetch step (which clones burrow-cli unauthenticated) so this token —
+          # scoped to burrow-engine only — can't 403 that clone. No-op until the vendored burrow-cli
+          # actually carries the git dependency, so it's safe to land ahead of the submodule bump.
+          if [ -n "$ENGINE_PAT" ]; then
+            git config --global url."https://x-access-token:${ENGINE_PAT}@github.com/".insteadOf "https://github.com/"
+          fi
           # Sentry is vendored as a local framework (scripts/fetch-sentry.sh),
           # not an SPM package, so the SPM binary-download hang is gone — this is
           # a plain build now. The step timeout-minutes above is the hard cap.

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -59,6 +59,9 @@ jobs:
         shell: pwsh
         env:
           ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
+          # burrow-cli now depends on the PRIVATE burrow-engine crate over git; fetch it via the
+          # git CLI so the url.insteadOf token below applies.
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: |
           try {
             $sha = (git ls-tree HEAD windows/vendor/burrow-cli).Split()[2]
@@ -71,6 +74,12 @@ jobs:
               git -c "url.https://x-access-token:$($env:ENGINE_PAT)@github.com/.insteadOf=https://github.com/" clone --quiet https://github.com/caezium/burrow-cli.git $dest
             }
             git -C $dest -c advice.detachedHead=false checkout --quiet $sha
+            # cargo build fetches the private burrow-engine — authorize github.com for the CLI
+            # fetcher. Set AFTER the burrow-cli clone above so the burrow-engine-scoped token can't
+            # 403 that clone. No-op until the vendored burrow-cli carries the git dependency.
+            if ($env:ENGINE_PAT) {
+              git config --global url."https://x-access-token:$($env:ENGINE_PAT)@github.com/".insteadOf "https://github.com/"
+            }
             cargo build --release --manifest-path (Join-Path $dest 'Cargo.toml')
             Copy-Item (Join-Path $dest 'target\release\burrow.exe') 'windows\Assets\burrow.exe' -Force
             Write-Host "staged burrow.exe @ $($sha.Substring(0,7))"


### PR DESCRIPTION
Prep for caezium/burrow-cli#17 (burrow-cli now depends on the private `burrow-engine` crate over git). Both the macOS and Windows release `cargo build` the vendored conductor, so cargo must fetch burrow-engine: adds `CARGO_NET_GIT_FETCH_WITH_CLI` + an `ENGINE_PAT` `url.insteadOf` rewrite, set **after** the burrow-cli clone so the engine-scoped token can't 403 it.

**No-op until the vendored burrow-cli submodule is bumped** to the git-dep commit — safe to land now so the pipeline is ready and never breaks mid-migration.