### PR TITLE
fix(menubar): guard against nil monospaced system font (#289)

### DIFF
--- a/macos/Sources/MenuBarWidgets.swift
+++ b/macos/Sources/MenuBarWidgets.swift
@@ -343,9 +343,25 @@ enum MenuBarRenderer {
     private static let pad: CGFloat = 3         // leading/trailing
     // Fonts take a per-widget text size (issue #245) so each metric sizes
     // independently. `.medium` == the historical 11/8/8 pt.
-    static func valueFont(_ size: MenuBarTextSize) -> NSFont { .monospacedDigitSystemFont(ofSize: size.valueSize, weight: .medium) }
-    static func labelFont(_ size: MenuBarTextSize) -> NSFont { .monospacedSystemFont(ofSize: size.labelSize, weight: .bold) }
-    static func speedFont(_ size: MenuBarTextSize) -> NSFont { .monospacedDigitSystemFont(ofSize: size.speedSize, weight: .medium) }
+    static func valueFont(_ size: MenuBarTextSize) -> NSFont { monospaced(size.valueSize, weight: .medium, digits: true) }
+    static func labelFont(_ size: MenuBarTextSize) -> NSFont { monospaced(size.labelSize, weight: .bold, digits: false) }
+    static func speedFont(_ size: MenuBarTextSize) -> NSFont { monospaced(size.speedSize, weight: .medium, digits: true) }
+
+    /// The `monospaced…SystemFont` factories are declared `_Nonnull`, but the
+    /// underlying AppKit call can transiently return nil (font system not yet
+    /// ready, memory pressure). A nil font gets copied into a non-optional
+    /// `NSFont` and silently lands in a text-attributes dictionary; the app
+    /// then crashes deep in CoreText — "attempt to insert nil object from
+    /// objects[0]" — when AppKit re-invokes the cached menu-bar image's
+    /// drawing handler during a button redraw (issue #289). Recover the real
+    /// nullability by routing through an optional, and fall back to the plain
+    /// system font (which does not fail) so the row can never draw with nil.
+    private static func monospaced(_ size: CGFloat, weight: NSFont.Weight, digits: Bool) -> NSFont {
+        let mono: NSFont? = digits
+            ? .monospacedDigitSystemFont(ofSize: size, weight: weight)
+            : .monospacedSystemFont(ofSize: size, weight: weight)
+        return mono ?? .systemFont(ofSize: size, weight: weight)
+    }
     private static let barW: CGFloat = 22
     private static let barH: CGFloat = 4
     private static let sparkW: CGFloat = 26


### PR DESCRIPTION
Fixes #289 (Sentry BURROW-8Y — `NSInvalidArgumentException: attempt to insert nil object from objects[0]`, fatal).

## Root cause
The crash fires deep in CoreText's `TAttributes::ApplyFont` while AppKit re-draws the cached menu-bar `NSImage`. Walking the stack:

- The crashing draw is the `.labeled` widget rendering its metric tag (e.g. `"CPU"`) via `(s as NSString).draw(at:withAttributes: [.font: font, .foregroundColor: color])` (`MenuBarWidgets.swift:572`, called from `drawLabeled` at `:599`).
- `color` there is `NSColor.secondaryLabelColor` — a class property, never nil.
- The string is a fixed literal and the size is a sane constant (7–14 pt).
- `objects[0]` in that dictionary literal is `.font`, so **the font is nil**.

`NSFont.monospacedSystemFont(ofSize:weight:)` / `monospacedDigitSystemFont(...)` are declared `_Nonnull`, but the underlying AppKit call can **transiently** return nil (font system not yet ready, memory pressure — consistent with this app's App Hang / low-resource history). Swift copies that null into a non-optional `NSFont`; it lands silently in the attributes dict and CoreText crashes later when the cached image's drawing handler is re-invoked during a button redraw.

That it crashes at *draw* time — not at width-measure/render time, which uses the same font first — and only twice confirms a **transient** nil, not a constant one.

## Fix
Route the three font accessors (`valueFont` / `labelFont` / `speedFont`) through one helper that recovers the real nullability (a null class pointer copied into `NSFont?` reads as `.none`) and falls back to the plain system font, which does not fail:

```swift
private static func monospaced(_ size: CGFloat, weight: NSFont.Weight, digits: Bool) -> NSFont {
    let mono: NSFont? = digits
        ? .monospacedDigitSystemFont(ofSize: size, weight: weight)
        : .monospacedSystemFont(ofSize: size, weight: weight)
    return mono ?? .systemFont(ofSize: size, weight: weight)
}
```

Every draw and width-measure site already goes through those three accessors, so all paths are covered. Worst case a widget briefly renders in the proportional system font instead of monospaced — cosmetic, never a crash.

## Testing
Not locally buildable in this environment (disk-constrained); relying on CI. The change is a targeted, isolated swap of the font factory with a fallback; no behavior change on the happy path.