### PR TITLE
fix(windows): serialize history file reads against writes (Sentry BURROW-WINDOWS-1)

### DIFF
--- a/windows/Services/JsonOperationHistoryService.cs
+++ b/windows/Services/JsonOperationHistoryService.cs
@@ -10,7 +10,7 @@ public sealed class JsonOperationHistoryService : IOperationHistoryService
         WriteIndented = false
     };
 
-    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
 
     public JsonOperationHistoryService()
         : this(Path.Combine(
@@ -37,7 +37,7 @@ public sealed class JsonOperationHistoryService : IOperationHistoryService
 
         var line = JsonSerializer.Serialize(entry, SerializerOptions);
 
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             await File.AppendAllTextAsync(HistoryFilePath, line + Environment.NewLine, cancellationToken)
@@ -45,7 +45,7 @@ public sealed class JsonOperationHistoryService : IOperationHistoryService
         }
         finally
         {
-            _writeLock.Release();
+            _fileLock.Release();
         }
     }
 
@@ -53,12 +53,29 @@ public sealed class JsonOperationHistoryService : IOperationHistoryService
         int limit,
         CancellationToken cancellationToken = default)
     {
-        if (limit <= 0 || !File.Exists(HistoryFilePath))
+        if (limit <= 0)
         {
             return [];
         }
 
-        var lines = await File.ReadAllLinesAsync(HistoryFilePath, cancellationToken).ConfigureAwait(false);
+        // Reads open the file with FileShare.Read, which makes a concurrent append fail
+        // with a sharing violation on Windows — serialize them against writes.
+        string[] lines;
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(HistoryFilePath))
+            {
+                return [];
+            }
+
+            lines = await File.ReadAllLinesAsync(HistoryFilePath, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+
         var entries = new List<OperationHistoryEntry>(Math.Min(limit, lines.Length));
 
         for (var index = lines.Length - 1; index >= 0 && entries.Count < limit; index--)

--- a/windows/Services/JsonSystemTelemetryHistoryService.cs
+++ b/windows/Services/JsonSystemTelemetryHistoryService.cs
@@ -10,7 +10,7 @@ public sealed class JsonSystemTelemetryHistoryService : ISystemTelemetryHistoryS
         WriteIndented = false
     };
 
-    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly SemaphoreSlim _fileLock = new(1, 1);
     private readonly Func<int> _historyRetentionDaysProvider;
 
     public JsonSystemTelemetryHistoryService()
@@ -53,7 +53,7 @@ public sealed class JsonSystemTelemetryHistoryService : ISystemTelemetryHistoryS
         }
 
         var line = JsonSerializer.Serialize(snapshot, SerializerOptions);
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             await File.AppendAllTextAsync(HistoryFilePath, line + Environment.NewLine, cancellationToken)
@@ -62,7 +62,7 @@ public sealed class JsonSystemTelemetryHistoryService : ISystemTelemetryHistoryS
         }
         finally
         {
-            _writeLock.Release();
+            _fileLock.Release();
         }
     }
 
@@ -70,12 +70,29 @@ public sealed class JsonSystemTelemetryHistoryService : ISystemTelemetryHistoryS
         int limit,
         CancellationToken cancellationToken = default)
     {
-        if (limit <= 0 || !File.Exists(HistoryFilePath))
+        if (limit <= 0)
         {
             return [];
         }
 
-        var lines = await File.ReadAllLinesAsync(HistoryFilePath, cancellationToken).ConfigureAwait(false);
+        // Reads open the file with FileShare.Read, which makes a concurrent append fail
+        // with a sharing violation on Windows — serialize them against writes.
+        string[] lines;
+        await _fileLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!File.Exists(HistoryFilePath))
+            {
+                return [];
+            }
+
+            lines = await File.ReadAllLinesAsync(HistoryFilePath, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _fileLock.Release();
+        }
+
         var snapshots = new List<SystemTelemetrySnapshot>(Math.Min(limit, lines.Length));
 
         for (var index = lines.Length - 1; index >= 0 && snapshots.Count < limit; index--)

--- a/windows/Services/SystemTelemetrySamplerService.cs
+++ b/windows/Services/SystemTelemetrySamplerService.cs
@@ -60,7 +60,16 @@ public sealed class SystemTelemetrySamplerService : BackgroundService, ISystemTe
         try
         {
             var snapshot = await _telemetryService.CaptureAsync(cancellationToken).ConfigureAwait(false);
-            await _historyService.RecordAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _historyService.RecordAsync(snapshot, cancellationToken).ConfigureAwait(false);
+            }
+            catch (IOException)
+            {
+                // History persistence is best-effort: an external process (antivirus scan,
+                // second app instance) holding the file must not fail the sample itself.
+            }
+
             LatestSnapshot = snapshot;
             return snapshot;
         }

--- a/windows/Tests/BurrowWin.Tests/JsonOperationHistoryServiceTests.cs
+++ b/windows/Tests/BurrowWin.Tests/JsonOperationHistoryServiceTests.cs
@@ -57,6 +57,33 @@ public sealed class JsonOperationHistoryServiceTests : IDisposable
             entry => Assert.Equal("optimize", entry.Operation));
     }
 
+    [Fact]
+    public async Task RecordAsync_AndReadRecentAsync_DoNotThrowUnderConcurrency()
+    {
+        var service = new JsonOperationHistoryService(_historyPath);
+        await service.RecordAsync(CreateEntry("seed", 0));
+
+        var writer = Task.Run(async () =>
+        {
+            for (var offset = 1; offset <= 100; offset++)
+            {
+                await service.RecordAsync(CreateEntry("clean", offset));
+            }
+        });
+        var reader = Task.Run(async () =>
+        {
+            for (var iteration = 0; iteration < 100; iteration++)
+            {
+                await service.ReadRecentAsync(10);
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+
+        var entries = await service.ReadRecentAsync(101);
+        Assert.Equal(101, entries.Count);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempRoot))

--- a/windows/Tests/BurrowWin.Tests/JsonSystemTelemetryHistoryServiceTests.cs
+++ b/windows/Tests/BurrowWin.Tests/JsonSystemTelemetryHistoryServiceTests.cs
@@ -48,6 +48,33 @@ public sealed class JsonSystemTelemetryHistoryServiceTests : IDisposable
             snapshot => Assert.Equal(DateTimeOffset.Parse("2026-06-15T00:02:00Z"), snapshot.CapturedAt));
     }
 
+    [Fact]
+    public async Task RecordAsync_AndReadRecentAsync_DoNotThrowUnderConcurrency()
+    {
+        var service = new JsonSystemTelemetryHistoryService(_historyPath);
+        await service.RecordAsync(CreateSnapshot(0));
+
+        var writer = Task.Run(async () =>
+        {
+            for (var offset = 1; offset <= 100; offset++)
+            {
+                await service.RecordAsync(CreateSnapshot(offset));
+            }
+        });
+        var reader = Task.Run(async () =>
+        {
+            for (var iteration = 0; iteration < 100; iteration++)
+            {
+                await service.ReadRecentAsync(10);
+            }
+        });
+
+        await Task.WhenAll(writer, reader);
+
+        var snapshots = await service.ReadRecentAsync(101);
+        Assert.Equal(101, snapshots.Count);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempRoot))

--- a/windows/ViewModels/DashboardViewModel.cs
+++ b/windows/ViewModels/DashboardViewModel.cs
@@ -285,8 +285,19 @@ public partial class DashboardViewModel : ViewModelBase
     private async Task RefreshTelemetryAsync()
     {
         var snapshot = await _telemetrySamplerService.SampleNowAsync();
-        var recentSnapshots = await _systemTelemetryHistoryService.ReadRecentAsync(Math.Max(CpuBarCount, NetworkPointCount));
-        var recentActivity = await _operationHistoryService.ReadRecentAsync(5);
+
+        IReadOnlyList<SystemTelemetrySnapshot> recentSnapshots = [];
+        IReadOnlyList<OperationHistoryEntry> recentActivity = [];
+        try
+        {
+            recentSnapshots = await _systemTelemetryHistoryService.ReadRecentAsync(Math.Max(CpuBarCount, NetworkPointCount));
+            recentActivity = await _operationHistoryService.ReadRecentAsync(5);
+        }
+        catch (IOException)
+        {
+            // History files can be briefly held by an external process; render the fresh
+            // snapshot without charts rather than crashing the async void refresh tick.
+        }
 
         RunOnUiThread(() =>
         {


### PR DESCRIPTION
Fixes #291 (Sentry `BURROW-WINDOWS-1`, project `burrow-windows`).

## Root cause

`JsonSystemTelemetryHistoryService.RecordAsync` takes `_writeLock` before appending, but `ReadRecentAsync` reads `telemetry-history.jsonl` **without taking the lock**. `File.ReadAllLinesAsync` opens the file with `FileShare.Read`, which denies write access while the handle is open — so when a read overlaps the sampler's append (or the retention prune, which rewrites the whole file), the writer fails with the exact `IOException` in the Sentry event. The "other process" is BurrowWin itself: the history service is a DI singleton read concurrently by the local MCP server (5 call sites), `HistoryViewModel`, and the dashboard, while the 15s `RefreshTimer_Tick` → `SampleNowAsync` → `RecordAsync` path writes. Because the tick handler is `async void`, one dropped sample became an unhandled-crash-level event.

`JsonOperationHistoryService` (`history.jsonl`) had the identical latent race with even more readers.

## Changes

- **Both history services:** `ReadRecentAsync` now takes the same semaphore as writes (renamed `_writeLock` → `_fileLock` since it now guards all file access). No deadlock risk: `PruneAsync` only runs inside the lock already held by `RecordAsync` and doesn't re-acquire.
- **`SystemTelemetrySamplerService.SampleNowAsync`:** the history append is now best-effort — if an *actual* external process (AV scanner, second app instance) holds the file, the sample still returns and the UI still updates, instead of the `IOException` escaping through the `async void` tick handler. Mirrors the existing keep-alive stance in `ExecuteAsync`.
- **`DashboardViewModel.RefreshTelemetryAsync`:** same tolerance on the read side — render the fresh snapshot without chart history rather than crash.
- **Tests:** concurrency regression tests for both services (interleaved `RecordAsync`/`ReadRecentAsync`, then verify no lines were lost). These are meaningful on the `windows-latest` CI runner where `FileShare` semantics are enforced.

## Testing

No local .NET/Windows toolchain on this machine — relying on `windows-ci.yml` (`dotnet test` on `windows-latest`) to compile and run the suite.