### PR TITLE
fix(gui): stop two SwiftUI AttributeGraph EXC_BAD_ACCESS crashes (#297, #298)

### DIFF
--- a/macos/Sources/Components/TaskTicker.swift
+++ b/macos/Sources/Components/TaskTicker.swift
@@ -111,10 +111,17 @@ struct TaskTickerView: View {
                 .frame(maxWidth: 460)
                 .background(RoundedRectangle(cornerRadius: 13, style: .continuous).fill(Color.black.opacity(0.25)))
                 .overlay(RoundedRectangle(cornerRadius: 13, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
+                // Deferred past the current update transaction: a synchronous
+                // scrollTo here mutates the scroll responder graph mid-way
+                // through responder-preference combination, which can fault in
+                // ScrollViewResponder.updateValue (Sentry BURROW-96,
+                // EXC_BAD_ACCESS in AttributeGraph).
                 .onChange(of: state.count) { _, _ in
                     guard pinnedToBottom else { return }
-                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
-                        proxy.scrollTo("TICKER_BOTTOM", anchor: .bottom)
+                    DispatchQueue.main.async {
+                        withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
+                            proxy.scrollTo("TICKER_BOTTOM", anchor: .bottom)
+                        }
                     }
                 }
             }

--- a/macos/Sources/PopupView.swift
+++ b/macos/Sources/PopupView.swift
@@ -110,11 +110,16 @@ struct PopupView: View {
                 Text(headline(s)).font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
                     .lineLimit(1).truncationMode(.tail)
                 Spacer(minLength: 6)
-                if let disk = s.disks.first {
-                    Text(String(format: NSLocalizedString("%@ free", comment: ""),
-                                Fmt.bytes(Int64(disk.total) - Int64(disk.used))))
-                        .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
-                }
+                // Render the free-space line unconditionally (empty string when
+                // no disk is reported yet) so this live-updating label keeps a
+                // constant TupleView shape across snapshot ticks. A
+                // `_ConditionalContent` that flips as `s.disks` populates
+                // restructures the HStack subtree while the button's `.help`
+                // tooltip tracking and responder are live — an AttributeGraph
+                // EXC_BAD_ACCESS (Sentry BURROW-9A, same class as the BURROW-K
+                // popover fault).
+                Text(freeSpace(s))
+                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
                 Image(systemName: "chevron.right").font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(Brand.textTertiary)
             }
@@ -123,6 +128,16 @@ struct PopupView: View {
         .buttonStyle(.plain)
         .help(NSLocalizedString("Open Burrow", comment: ""))
         .accessibilityLabel(String(format: NSLocalizedString("Health %d. Open Burrow.", comment: ""), s.healthScore))
+    }
+
+    /// Free space on the primary disk, or "" when no disk has been reported.
+    /// Returning a plain string lets `header` render a structurally-constant
+    /// `Text` instead of a `_ConditionalContent`, keeping the button's label
+    /// subtree stable across snapshot ticks (Sentry BURROW-9A).
+    private func freeSpace(_ s: MoleStatus) -> String {
+        guard let disk = s.disks.first else { return "" }
+        return String(format: NSLocalizedString("%@ free", comment: ""),
+                      Fmt.bytes(Int64(disk.total) - Int64(disk.used)))
     }
 
     private func headline(_ s: MoleStatus) -> String {

--- a/macos/Sources/TaskReport.swift
+++ b/macos/Sources/TaskReport.swift
@@ -256,9 +256,16 @@ struct TaskReportView: View {
                 .padding(.horizontal, 18).padding(.vertical, 12)
             }
             .scrollIndicators(.hidden)
-            // Tail-follow the report as new lines stream in.
+            // Tail-follow the report as new lines stream in. The scroll is
+            // deferred past the current update transaction: calling scrollTo
+            // synchronously inside onChange mutates the scroll responder graph
+            // while SwiftUI is still combining responder preferences for this
+            // pass, which can fault in ScrollViewResponder.updateValue
+            // (Sentry BURROW-96, EXC_BAD_ACCESS in AttributeGraph).
             .onChange(of: itemCount) { _, _ in
-                withAnimation(.linear(duration: 0.15)) { proxy.scrollTo("BOTTOM", anchor: .bottom) }
+                DispatchQueue.main.async {
+                    withAnimation(.linear(duration: 0.15)) { proxy.scrollTo("BOTTOM", anchor: .bottom) }
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes two single-event fatal crashes auto-filed from Sentry. Both are `EXC_BAD_ACCESS` faults inside SwiftUI/AttributeGraph with **no Burrow app frames** in the stack, so each fix targets the app-side pattern the crashing node points at.

## #297 — BURROW-96, `ScrollViewResponder.updateValue`
`TaskReportView` and `TaskTickerView` both call `proxy.scrollTo(...)` **synchronously inside an `onChange`** that fires as the collection they render mutates (streaming task output). That mutates the scroll-responder graph while SwiftUI is still combining responder preferences for the same update pass — the exact machinery in the crash stack (`ScrollViewResponder.updateValue` → `ViewRespondersKey` → preference combiners).

**Fix:** defer the `scrollTo` to the next runloop tick via `DispatchQueue.main.async`, so it runs after the update transaction completes. Tail-follow behavior is unchanged (scrolls one tick later).

## #298 — BURROW-9A, popover header `Button` (`.help` + `.buttonStyle`)
The crashing type demangles to the menu-bar popover header button, whose label `HStack` wrapped the free-space line in `if let disk = s.disks.first { … }`. As snapshots arrive and `s.disks` goes empty → populated, the `_ConditionalContent` flips between branches, **restructuring the live label subtree** while the button's `.help` tooltip tracking and responder are active — an AttributeGraph bad-access, same class as the earlier BURROW-K popover fault.

**Fix:** render the free-space `Text` unconditionally (empty string when no disk yet) via a `freeSpace(_:)` helper, so the label keeps a constant `TupleView` shape across snapshot ticks. No visible layout change (empty string renders nothing; `Spacer` absorbs the space).

## Notes
- Both are `Events: 1`, no app frames — these are best-effort mitigations for the pattern each crash node implicates, consistent with how prior AttributeGraph faults here were handled (BURROW-1, BURROW-E, BURROW-K).
- Not built locally (host disk was near-full); relying on CI for the build. Changes are minimal and use patterns already present in the module.

Closes #297
Closes #298