### PR TITLE
release(macos): 0.10.2 — crash + updater fixes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,28 @@
+# Burrow 0.10.2
+
+A fix release. Three crashes are gone — the menu-bar popover, the streaming
+task report, and a nil-font HUD metric — and the in-app updater no longer
+silently reopens the same build when Homebrew won't upgrade in place.
+
+## Fixes
+- **No more menu-bar popover or streaming-report crashes.** Two `EXC_BAD_ACCESS`
+  faults inside SwiftUI's view graph — one in the menu-bar popover header
+  button, one in the live task report/ticker as a job streamed — are fixed by
+  keeping those view subtrees structurally stable across snapshot and scroll
+  updates instead of restructuring them mid-update.
+  ([#299](https://github.com/caezium/Burrow/pull/299))
+- **The menu-bar metric no longer crashes on a nil font.**
+  `NSFont.monospacedSystemFont` is declared non-null but can transiently return
+  nil under memory pressure; that null reached CoreText and crashed at draw
+  time (Sentry BURROW-8Y). The metric widgets now fall back to the plain system
+  font — cosmetic at worst, never a crash.
+  ([#290](https://github.com/caezium/Burrow/pull/290))
+- **In-app update actually updates.** When the cask "cannot be upgraded as-is,"
+  Homebrew prints a warning but exits 0 — so the one-click updater reported
+  success and reopened the same build. It now detects the refusal by message
+  and runs the `brew reinstall --force` Homebrew recommends.
+  ([#287](https://github.com/caezium/Burrow/pull/287))
+
 # Burrow 0.10.1
 
 Three new panes, and Duplicates finally works on a clean Mac. This release

--- a/docs/index.html
+++ b/docs/index.html
@@ -323,7 +323,7 @@
 
   <!-- ===== HERO ===== -->
   <header class="hero">
-    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.10.1</span>
+    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.10.2</span>
     <h1>Burrow
       <svg class="mark" viewBox="0 0 100 100" aria-hidden="true"><path d="M14 74 a36 36 0 0 1 72 0 Z" fill="#F3ECDD"/><rect x="38" y="74" width="24" height="7" rx="3.5" fill="#121217"/></svg>
     </h1>
@@ -389,36 +389,30 @@
     <div class="sec-head wn-head">
       <div>
         <span class="sec-num">What's new · July 2026</span>
-        <h2 class="sec-title">New in 0.10.1</h2>
+        <h2 class="sec-title">New in 0.10.2</h2>
       </div>
       <a class="btn btn-out btn-sm" href="releases.html">All releases</a>
     </div>
 
     <div class="grid3 wn-grid">
-      <article class="tcard" style="--c: var(--lilac)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M9.59 4.59A2 2 0 1111 8H2m10.59 11.41A2 2 0 1014 16H2m15.73-8.27A2.5 2.5 0 1119.5 12H2"/></svg></div><div class="nm">New: Leftovers</div></div>
-        <p class="ds">Surface the files an app leaves behind after you delete it — caches, preferences, application support, launch agents — and clear the orphans.</p>
-      </article>
-      <article class="tcard" style="--c: var(--apricot)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l1.8 4.6L18 10l-4.2 1.4L12 16l-1.8-4.6L6 10l4.2-1.4z"/><path d="M18.5 15.5l.9 2.1 2.1.9-2.1.9-.9 2.1-.9-2.1-2.1-.9 2.1-.9z"/></svg></div><div class="nm">New: Similar Photos</div></div>
-        <p class="ds">Cluster visually-similar images — near-duplicate screenshots, burst shots, re-exports — by perceptual hash. Read-only: review the sets, reveal in Finder.</p>
+      <article class="tcard" style="--c: var(--teal)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Popover &amp; streaming crashes gone</div></div>
+        <p class="ds">Two EXC_BAD_ACCESS faults in SwiftUI's view graph — the menu-bar popover header and the live task report while a job streams — are fixed by keeping those subtrees stable across updates.</p>
       </article>
       <article class="tcard" style="--c: var(--azure)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c2.6 2.5 4 5.6 4 9s-1.4 6.5-4 9c-2.6-2.5-4-5.6-4-9s1.4-6.5 4-9z"/></svg></div><div class="nm">New: Network</div></div>
-        <p class="ds">See per-app bandwidth at a glance — which apps are actually talking to the internet.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19a9 9 0 1114 0"/><path d="M12 13l4-4"/><circle cx="12" cy="13" r="1.6"/></svg></div><div class="nm">HUD font crash fixed</div></div>
+        <p class="ds">The menu-bar metric could crash on a transiently-nil monospaced system font; it now falls back to the system font instead of crashing (Sentry BURROW-8Y).</p>
       </article>
-      <article class="tcard" style="--c: var(--green)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8l-9-5-9 5v8l9 5 9-5z"/><path d="M3 8l9 5 9-5M12 13v8"/></svg></div><div class="nm">Duplicates works out of the box</div></div>
-        <p class="ds">The <code>fclones</code> sidecar it relies on now ships inside the app — no more “fclones not found” on a clean Mac.</p>
+      <article class="tcard" style="--c: var(--apricot)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8l-9-5-9 5v8l9 5 9-5z"/><path d="M3 8l9 5 9-5M12 13v8"/></svg></div><div class="nm">In-app update actually updates</div></div>
+        <p class="ds">When Homebrew refused to upgrade the cask in place it exited 0, so the one-click updater reopened the same build. It now detects the refusal and reinstalls.</p>
       </article>
     </div>
 
-    <div class="extra-label mono">// also tightened in 0.10.1</div>
+    <div class="extra-label mono">// also tightened in 0.10.2</div>
     <div class="wn-chips">
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Similar Photos says when it skipped HEIC instead of showing an empty scan</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Menu-bar popover no longer drifts sideways and clips; the tool strip wraps into a grid</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>No more ~2-second hang opening the window or switching panes</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Finder-launched app finds Homebrew-installed helpers on its PATH</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>On 0.10.1 the in-app updater may reopen the same build — grab 0.10.2 with <code>brew upgrade --cask burrow</code> (or <code>brew reinstall --cask --force burrow</code>), or the direct download.</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Still ad-hoc-signed — re-grant Full Disk Access once after updating.</span>
     </div>
     <!-- WN:END -->
   </section>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -123,13 +123,32 @@
 <header class="hero page">
   <h1>Changelog</h1>
   <p>Every version at a glance — what it added, changed, and fixed. Full notes for each live on GitHub.</p>
-  <p class="count">18 releases · latest 0.10.1 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
+  <p class="count">19 releases · latest 0.10.2 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
 </header>
 
 <main class="page">
+    <article class="entry" id="v0.10.2">
+      <div class="ver-col">
+        <h2 class="ver">0.10.2<span class="latest">latest</span></h2>
+        <span class="date mono">Jul 24, 2026</span>
+        <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.10.2" target="_blank" rel="noopener">full notes ↗</a>
+      </div>
+      <div class="sbody">
+        <p class="lead">A fix release — three crashes squashed (the menu-bar popover, the streaming task report, and a nil-font HUD metric), and the in-app updater no longer silently reopens the same build.</p>
+        <div class="sblock">
+          <div class="slabel mono">fixed</div>
+          <ul class="slist">
+            <li><b>No more menu-bar popover or streaming-report crashes.</b> Two <code>EXC_BAD_ACCESS</code> faults inside SwiftUI's view graph — one in the popover header button, one in the live task report/ticker as a job streamed — are fixed by keeping those view subtrees structurally stable across snapshot and scroll updates instead of restructuring them mid-update. (<a href="https://github.com/caezium/Burrow/pull/299" target="_blank" rel="noopener">#299</a>)</li>
+            <li><b>The menu-bar metric no longer crashes on a nil font.</b> <code>NSFont.monospacedSystemFont</code> is declared non-null but can transiently return nil under memory pressure; that null reached CoreText and crashed at draw time (Sentry BURROW-8Y). The metric widgets now fall back to the plain system font — cosmetic at worst, never a crash. (<a href="https://github.com/caezium/Burrow/pull/290" target="_blank" rel="noopener">#290</a>)</li>
+            <li><b>In-app update actually updates.</b> When the cask “cannot be upgraded as-is,” Homebrew prints a warning but exits 0 — so the one-click updater reported success and reopened the same build. It now detects the refusal by message and runs the <code>brew reinstall --force</code> Homebrew recommends. (<a href="https://github.com/caezium/Burrow/pull/287" target="_blank" rel="noopener">#287</a>)</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
     <article class="entry" id="v0.10.1">
       <div class="ver-col">
-        <h2 class="ver">0.10.1<span class="latest">latest</span></h2>
+        <h2 class="ver">0.10.1</h2>
         <span class="date mono">Jul 13, 2026</span>
         <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.10.1" target="_blank" rel="noopener">full notes ↗</a>
       </div>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -2,6 +2,46 @@
   "_comment": "Source of truth for the site's release history. Newest first. Edit this, then run `python3 scripts/site-release.py` to regenerate the homepage 'New in X' section and releases.html. Icons/colors: run `python3 scripts/site-release.py --list-icons`.",
   "releases": [
     {
+      "version": "0.10.2",
+      "date": "2026-07-24",
+      "tag": "v0.10.2",
+      "tagline": "A fix release — three crashes squashed (the menu-bar popover, the streaming task report, and a nil-font HUD metric), and the in-app updater no longer silently reopens the same build.",
+      "highlights": [
+        {
+          "icon": "shield",
+          "color": "teal",
+          "title": "Popover & streaming crashes gone",
+          "line": "Two EXC_BAD_ACCESS faults in SwiftUI's view graph — the menu-bar popover header and the live task report while a job streams — are fixed by keeping those subtrees stable across updates."
+        },
+        {
+          "icon": "gauge",
+          "color": "azure",
+          "title": "HUD font crash fixed",
+          "line": "The menu-bar metric could crash on a transiently-nil monospaced system font; it now falls back to the system font instead of crashing (Sentry BURROW-8Y)."
+        },
+        {
+          "icon": "package",
+          "color": "apricot",
+          "title": "In-app update actually updates",
+          "line": "When Homebrew refused to upgrade the cask in place it exited 0, so the one-click updater reopened the same build. It now detects the refusal and reinstalls."
+        }
+      ],
+      "chips": [
+        "On 0.10.1 the in-app updater may reopen the same build — grab 0.10.2 with `brew upgrade --cask burrow` (or `brew reinstall --cask --force burrow`), or the direct download.",
+        "Still ad-hoc-signed — re-grant Full Disk Access once after updating."
+      ],
+      "sections": [
+        {
+          "label": "fixed",
+          "items": [
+            "**No more menu-bar popover or streaming-report crashes.** Two `EXC_BAD_ACCESS` faults inside SwiftUI's view graph — one in the popover header button, one in the live task report/ticker as a job streamed — are fixed by keeping those view subtrees structurally stable across snapshot and scroll updates instead of restructuring them mid-update. ([#299](https://github.com/caezium/Burrow/pull/299))",
+            "**The menu-bar metric no longer crashes on a nil font.** `NSFont.monospacedSystemFont` is declared non-null but can transiently return nil under memory pressure; that null reached CoreText and crashed at draw time (Sentry BURROW-8Y). The metric widgets now fall back to the plain system font — cosmetic at worst, never a crash. ([#290](https://github.com/caezium/Burrow/pull/290))",
+            "**In-app update actually updates.** When the cask “cannot be upgraded as-is,” Homebrew prints a warning but exits 0 — so the one-click updater reported success and reopened the same build. It now detects the refusal by message and runs the `brew reinstall --force` Homebrew recommends. ([#287](https://github.com/caezium/Burrow/pull/287))"
+          ]
+        }
+      ]
+    },
+    {
       "version": "0.10.1",
       "date": "2026-07-13",
       "tag": "v0.10.1",

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -54,8 +54,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.10.1"
-        CFBundleVersion: "18"
+        CFBundleShortVersionString: "0.10.2"
+        CFBundleVersion: "19"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Friendly, one-time prompts for the standard folders Mole scans
         # (purge/installer touch these). Full Disk Access still covers the


### PR DESCRIPTION
Cuts **0.10.2**, a patch release carrying the three macOS fixes that landed since 0.10.1. Version bumped to `0.10.2` (build 19); notes + landing site regenerated.

## What ships
- **#299** — two SwiftUI AttributeGraph `EXC_BAD_ACCESS` crashes (menu-bar popover header + streaming task report/ticker)
- **#290** — nil monospaced-font crash in the menu-bar metric (Sentry BURROW-8Y)
- **#287** — in-app updater silently no-ops when Homebrew won't upgrade the cask in place

The Windows history-file race fix (#292) is on the separate Windows preview train and is **not** part of this macOS release.

## Files
- `macos/project.yml` — `CFBundleShortVersionString` 0.10.1 → 0.10.2, `CFBundleVersion` 18 → 19
- `RELEASES.md` — 0.10.2 section prepended
- `docs/releases.json` — 0.10.2 entry prepended
- `docs/index.html`, `docs/releases.html` — regenerated by `scripts/site-release.py` (`--check` is clean)

## Release mechanics
Merging this doesn't publish. The build/publish is triggered by pushing the `v0.10.2` tag (release.yml verifies the tag matches `CFBundleShortVersionString`, builds, notarizes, publishes the GitHub release from `RELEASES.md`, and bumps the Homebrew cask). I'll push the tag once this merges and you've okayed the notes.