### PR TITLE
MCP agent UX: surface timeouts, analyze depth/limit/min_size, honest slow-tool docs

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -51,7 +51,7 @@ samples continuously, and every actuating call is **dry-run by default**.
 
 | Tool | Use it proactively when… | Key params |
 |---|---|---|
-| **burrow_analyze** | "What's taking up space in <folder>?" Size-ranked directory tree (the data behind the treemap). Read-only. | `path` |
+| **burrow_analyze** | "What's taking up space in <folder>?" Size-ranked children of a directory, largest first (the data behind the treemap); `depth` > 1 descends into the largest subdirectories so one call replaces a drill-down loop. Scanning a home folder or `~/Library` can take minutes — pass the most specific path you can, and use `min_size` to skip noise. Truncation is reported via `entries_omitted`/`omitted_bytes`, and `partial: true` means the descent hit its time budget. Read-only. | `path`, `depth`, `limit`, `min_size` |
 | **burrow_list_apps** | Before any uninstall, **always call this first** to get the exact app name `burrow_uninstall` accepts. Also answers "what apps are installed?" | — |
 
 ## Discovery (read-only, via the bundled conductor)
@@ -80,7 +80,7 @@ it. Real cleans run at user level (not elevated).
 
 | Tool | What a real run does | Safety | Key params |
 |---|---|---|---|
-| **burrow_clean** | Removes caches, logs, temp files, leftovers (`mo clean`). | Dry-run unless `confirm:true` **and** "Let agents run cleanups" is on, else blocked. | `confirm` |
+| **burrow_clean** | Removes caches, logs, temp files, leftovers (`mo clean`). The scan can take minutes on a full disk; a `timed_out: true` result means the run was killed, not that nothing needed cleaning. | Dry-run unless `confirm:true` **and** "Let agents run cleanups" is on, else blocked. | `confirm` |
 | **burrow_optimize** | Refreshes caches/services, safe maintenance (`mo optimize`). | Same gate as clean. | `confirm` |
 | **burrow_uninstall** | Uninstalls apps + leftovers (`mo uninstall`). Files go to Trash unless `permanent:true`. | Needs `confirm:true` **and both** opt-ins; aborts unless the matcher resolves exactly the apps you named. Call `burrow_list_apps` first. | `apps` (required), `confirm`, `permanent` |
 | **burrow_purge** | Finds dev build artifacts (`node_modules`, `target/`, …). | **Preview-only over MCP** — returns the dry-run list; the real purge is an interactive flow in the app. | `confirm` (reserved) |
@@ -92,12 +92,16 @@ Every actuating call is recorded to Burrow's audit log, so the user can see what
 
 ## Patterns
 
+- **"I'm low on disk"** (the most common real emergency) → `burrow_analyze <folder>` with
+  `depth: 2` on the largest user dirs (skip `burrow_disk_forecast` when the disk is already
+  full — forecasting is for "when will it fill", not "it's full now") →
+  `burrow_dupes`/`burrow_photos`/`burrow_orphans`/`burrow_sentinel` for reclaim candidates →
+  `burrow_purge`/`burrow_installer` previews → `burrow_clean` preview. If user folders don't
+  account for the usage, check APFS local snapshots (`tmutil listlocalsnapshots /`) and
+  purgeable space via the shell — Burrow doesn't report those yet.
 - **"My Mac is slow/hot/loud"** → `burrow_doctor` → `burrow_top_processes` (now) or
   `burrow_process_usage` (over time) → name the culprit; offer `burrow_clean`/`optimize`
   preview only if relevant.
-- **"I'm low on disk"** → `burrow_disk_forecast` → `burrow_analyze <folder>` →
-  `burrow_dupes`/`burrow_photos`/`burrow_orphans`/`burrow_sentinel` for reclaim candidates →
-  `burrow_purge`/`burrow_installer` previews → `burrow_clean` preview.
 - **"Is anything insecure / what's listening?"** → `burrow_doctor` (SIP/Gatekeeper/FileVault/
   firewall) + `burrow_ports`.
 - **"What did Burrow change?"** → `burrow_cleanup_history` + `burrow_deleted_files`.

--- a/macos/Sources/MCP.swift
+++ b/macos/Sources/MCP.swift
@@ -360,11 +360,14 @@ struct ToolCatalog {
             ],
             [
                 "name": "burrow_analyze",
-                "description": "Disk-usage breakdown of a directory via `mo analyze --json` — a size-ranked tree, the data behind Burrow's treemap. Read-only (no deletion). `path` defaults to the home folder. Use to answer 'what's taking up space?'.",
+                "description": "Disk-usage breakdown of a directory via `mo analyze --json` — size-ranked immediate children (the data behind Burrow's treemap), largest first. Read-only (no deletion). Use to answer 'what's taking up space?'. `depth` > 1 also descends into the largest subdirectories, so one call replaces a per-directory drill-down. SLOW ON BIG TARGETS: a home folder or ~/Library can take minutes to scan — pass the most specific path you can and use `min_size` to skip noise. Truncation is always reported (`entries_omitted`/`omitted_bytes`; `partial: true` means the descent hit its time budget).",
                 "inputSchema": [
                     "type": "object",
                     "properties": [
                         "path": ["type": "string", "description": "Absolute directory to analyze. Defaults to the home folder."],
+                        "depth": ["type": "integer", "minimum": 1, "maximum": 3, "description": "Levels to descend into the largest subdirectories (default 1 = just this directory's children)."],
+                        "limit": ["type": "integer", "minimum": 1, "maximum": 1000, "description": "Max entries per level, largest first (default 100)."],
+                        "min_size": ["type": "integer", "minimum": 0, "description": "Omit entries smaller than this many bytes (default 0). E.g. 104857600 = 100MB."],
                     ],
                     "additionalProperties": false,
                 ] as [String: Any],
@@ -462,7 +465,7 @@ struct ToolCatalog {
             ],
             [
                 "name": "burrow_clean",
-                "description": "Clean caches, logs, temp files and leftovers via `mo clean`. SAFE BY DEFAULT: with no `confirm` (or confirm:false) it runs `--dry-run` and only PREVIEWS what would be freed — nothing is deleted. A real deletion needs confirm:true AND the user's opt-in ('Let agents run cleanups' in Burrow Settings); without the opt-in, confirm:true is refused and reported as blocked. Real runs are not elevated (user-level caches only).",
+                "description": "Clean caches, logs, temp files and leftovers via `mo clean`. SAFE BY DEFAULT: with no `confirm` (or confirm:false) it runs `--dry-run` and only PREVIEWS what would be freed — nothing is deleted. A real deletion needs confirm:true AND the user's opt-in ('Let agents run cleanups' in Burrow Settings); without the opt-in, confirm:true is refused and reported as blocked. Real runs are not elevated (user-level caches only). SLOW: the scan can take minutes on a full disk — a `timed_out: true` result means it was killed, not that there was nothing to clean.",
                 "inputSchema": [
                     "type": "object",
                     "properties": [
@@ -498,7 +501,7 @@ struct ToolCatalog {
             ],
             [
                 "name": "burrow_purge",
-                "description": "Find old project build artifacts (node_modules, target/, build/, …) via `mo purge`. PREVIEW over MCP: this returns the `--dry-run` list of what would be purged. The real purge is an interactive selection flow — run it from the Burrow app. (confirm:true returns the preview plus that note.)",
+                "description": "Find old project build artifacts (node_modules, target/, build/, …) via `mo purge`. PREVIEW over MCP: this returns the `--dry-run` list of what would be purged. The real purge is an interactive selection flow — run it from the Burrow app. (confirm:true returns the preview plus that note.) SLOW: the scan can take several minutes on a disk with many projects.",
                 "inputSchema": [
                     "type": "object",
                     "properties": [
@@ -509,7 +512,7 @@ struct ToolCatalog {
             ],
             [
                 "name": "burrow_installer",
-                "description": "Find leftover installer files (.dmg, .pkg, .iso, .xip, .zip) via `mo installer`. PREVIEW over MCP: returns the `--dry-run` list of what would be removed. The real removal is an interactive selection flow — run it from the Burrow app. (confirm:true returns the preview plus that note.)",
+                "description": "Find leftover installer files (.dmg, .pkg, .iso, .xip, .zip) via `mo installer`. PREVIEW over MCP: returns the `--dry-run` list of what would be removed. The real removal is an interactive selection flow — run it from the Burrow app. (confirm:true returns the preview plus that note.) SLOW: the scan can take several minutes on a large disk.",
                 "inputSchema": [
                     "type": "object",
                     "properties": [
@@ -867,7 +870,7 @@ struct ToolCatalog {
     /// -32603 just because Mole isn't installed.
     static func cleanupHistoryResult(exitCode: Int32, stdout: String) -> String {
         guard exitCode == 0 else {
-            return "{\"error\":\"mo history unavailable\",\"sessions\":[]}"
+            return "{\"error\":\"mo history unavailable\",\"hint\":\"call burrow_info to check whether Burrow is recording data at all\",\"sessions\":[]}"
         }
         let out = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         return out.isEmpty ? "{\"sessions\":[]}" : out
@@ -977,8 +980,9 @@ struct ToolCatalog {
                 return ActionWire.uninstallAbort(apps: expected, matched: matched, mismatch: mismatch)
             }
         }
+        let timeout = ticket.command.timeout ?? 600
         let res = Self.runMo(ticket.command.args, stdin: ticket.command.stdin,
-                             timeout: ticket.command.timeout ?? 600)
+                             timeout: timeout)
         var permanent: Bool?
         if case .uninstall(_, let p) = ticket.action, ticket.mode == .real { permanent = p }
         return ActionWire.result(command: ticket.action.commandName,
@@ -988,16 +992,32 @@ struct ToolCatalog {
                                  output: res.stdout.isEmpty ? res.stderr : res.stdout,
                                  apps: ticket.action.wireApps,
                                  permanent: permanent,
-                                 note: ticket.note)
+                                 note: ticket.note,
+                                 timedOutAfter: res.timedOut ? timeout : nil)
     }
 
-    /// `mo analyze --json <path>` — read-only disk-usage tree. Passes
-    /// through Mole's JSON. Degrades to an error object when `mo` is
-    /// missing or analysis fails.
+    /// `mo analyze --json <path>` — read-only disk-usage breakdown. Mole
+    /// reports one level (immediate children with aggregate sizes);
+    /// `depth` > 1 re-runs it over the largest subdirectories so an agent
+    /// gets a hotspot map in one call instead of a call-per-directory
+    /// drill-down. Entries are pruned (`limit`, `min_size`) with omissions
+    /// counted — never silently — and re-emitted compact (mole pretty-
+    /// prints; agents were seeing 35–60 KB blobs). Degrades to an error
+    /// object when `mo` is missing, too old, or times out.
     private func callAnalyze(_ args: [String: Any]) -> String {
         let path = (args["path"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? NSHomeDirectory()
+        let depth = min(max((args["depth"] as? Int) ?? 1, 1), 3)
+        let limit = min(max((args["limit"] as? Int) ?? 100, 1), 1000)
+        let minSize = Int64(max((args["min_size"] as? Int) ?? 0, 0))
         // 300 s like DiskScanner — analyze on a home dir can take a while.
         let res = Self.runMo(["analyze", "--json", path], timeout: 300)
+        if res.timedOut {
+            return Self.jsonString([
+                "error": "mo analyze timed out",
+                "timed_out": true,
+                "path": path,
+                "hint": "scanning \(path) took over 300s — analyze a more specific subdirectory instead"])
+        }
         guard res.exitCode == 0 else {
             if DiskScanner.indicatesMissingJSONSupport(stderr: res.stderr) {
                 return Self.jsonString([
@@ -1010,7 +1030,94 @@ struct ToolCatalog {
                                     "stderr": Self.stripANSI(res.stderr)])
         }
         let out = res.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        return out.isEmpty ? Self.jsonString(["error": "empty analyze output", "path": path]) : out
+        guard !out.isEmpty else {
+            return Self.jsonString(["error": "empty analyze output", "path": path])
+        }
+        // If mole's JSON shape ever drifts past the parser, pass it through
+        // untouched — the old contract.
+        guard var root = (try? JSONSerialization.jsonObject(with: Data(out.utf8))) as? [String: Any] else {
+            return out
+        }
+        root = Self.prunedAnalyzeLevel(root, limit: limit, minSize: minSize)
+        if depth > 1 {
+            // Budget the descent to stay under the ~120 s window MCP
+            // clients wait before backgrounding a call.
+            let deadline = Date().addingTimeInterval(90)
+            if !self.descendAnalyze(into: &root, levelsLeft: depth - 1, limit: limit,
+                                    minSize: minSize, deadline: deadline) {
+                root["partial"] = true
+                root["hint"] = "the depth descent hit its time budget — entries without `children` were not descended into"
+            }
+        }
+        return Self.jsonString(root)
+    }
+
+    /// One pruned analyze level: entries sorted largest-first, filtered by
+    /// `minSize`, cut to `limit`. Drops are tallied on the level as
+    /// `entries_omitted` / `omitted_bytes` so truncation is visible.
+    static func prunedAnalyzeLevel(_ level: [String: Any], limit: Int, minSize: Int64) -> [String: Any] {
+        var out = level
+        let entries = (level["entries"] as? [[String: Any]]) ?? []
+        let sorted = entries.sorted { Self.entrySize($0) > Self.entrySize($1) }
+        var kept: [[String: Any]] = []
+        var omitted = 0
+        var omittedBytes: Int64 = 0
+        for e in sorted {
+            let size = Self.entrySize(e)
+            if kept.count < limit, size >= minSize {
+                kept.append(e)
+            } else {
+                omitted += 1
+                omittedBytes += size
+            }
+        }
+        out["entries"] = kept
+        if omitted > 0 {
+            out["entries_omitted"] = omitted
+            out["omitted_bytes"] = omittedBytes
+        }
+        return out
+    }
+
+    static func entrySize(_ entry: [String: Any]) -> Int64 {
+        (entry["size"] as? Int64) ?? Int64(entry["size"] as? Int ?? 0)
+    }
+
+    /// Re-run `mo analyze` over the largest directory entries of `level`,
+    /// attaching each pruned result under the entry's `children` (with
+    /// `children_omitted` / `children_omitted_bytes` when cut). At most 8
+    /// directories per level — this is a hotspot map, not a mirror.
+    /// Returns false when the deadline cut the descent short.
+    private func descendAnalyze(into level: inout [String: Any], levelsLeft: Int,
+                                limit: Int, minSize: Int64, deadline: Date) -> Bool {
+        guard levelsLeft > 0, var entries = level["entries"] as? [[String: Any]] else { return true }
+        var complete = true
+        var descended = 0
+        for i in entries.indices {
+            guard descended < 8 else { break }
+            guard (entries[i]["is_dir"] as? Bool) == true,
+                  let childPath = entries[i]["path"] as? String, !childPath.isEmpty else { continue }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 5 else { complete = false; break }
+            descended += 1
+            let res = Self.runMo(["analyze", "--json", childPath], timeout: min(remaining, 60))
+            guard !res.timedOut, res.exitCode == 0,
+                  var child = (try? JSONSerialization.jsonObject(
+                      with: Data(res.stdout.utf8))) as? [String: Any] else {
+                if res.timedOut { complete = false }
+                continue
+            }
+            child = Self.prunedAnalyzeLevel(child, limit: limit, minSize: minSize)
+            if !self.descendAnalyze(into: &child, levelsLeft: levelsLeft - 1, limit: limit,
+                                    minSize: minSize, deadline: deadline) {
+                complete = false
+            }
+            entries[i]["children"] = child["entries"]
+            if let om = child["entries_omitted"] { entries[i]["children_omitted"] = om }
+            if let ob = child["omitted_bytes"] { entries[i]["children_omitted_bytes"] = ob }
+        }
+        level["entries"] = entries
+        return complete
     }
 
     /// `mo uninstall --list` — installed apps + the exact names uninstall

--- a/macos/Sources/MoActions.swift
+++ b/macos/Sources/MoActions.swift
@@ -272,7 +272,7 @@ enum MoActions {
 enum ActionWire {
     static func result(command: String, dryRun: Bool, ran: Bool, exitCode: Int32,
                        output: String, apps: [String]? = nil, permanent: Bool? = nil,
-                       note: String? = nil) -> String {
+                       note: String? = nil, timedOutAfter: TimeInterval? = nil) -> String {
         let stripped = Ansi.strip(output)
         var obj: [String: Any] = [
             "command": command,
@@ -289,6 +289,14 @@ enum ActionWire {
         if let note {
             obj["interactive_only"] = true
             obj["note"] = note
+        }
+        // A killed run otherwise reads as a bare non-zero exit with empty
+        // output (observed in the wild as `exit_code: 9, output: ""`) —
+        // say what actually happened.
+        if let timedOutAfter {
+            obj["timed_out"] = true
+            obj["hint"] = "mo \(command) was killed after \(Int(timedOutAfter))s without finishing"
+                + " — retry, or run it from the Burrow app"
         }
         return json(obj)
     }

--- a/macos/Tests/MCPAnalyzeTests.swift
+++ b/macos/Tests/MCPAnalyzeTests.swift
@@ -1,0 +1,74 @@
+//
+//  MCPAnalyzeTests.swift
+//  BurrowTests
+//
+//  burrow_analyze pruning (issue #302). Mole reports one pretty-printed
+//  level per run; real agent transcripts showed 35–60 KB responses and a
+//  15-call drill-down loop. The pruner is a pure function over mole's
+//  parsed JSON: sort largest-first, filter by min_size, cut to limit,
+//  and count every drop — truncation must never be silent.
+//
+
+import XCTest
+@testable import Burrow
+
+final class MCPAnalyzeTests: XCTestCase {
+
+    private func entry(_ name: String, size: Int, isDir: Bool = true) -> [String: Any] {
+        ["name": name, "path": "/x/\(name)", "size": size, "is_dir": isDir]
+    }
+
+    func testPrune_sortsLargestFirst() throws {
+        let level: [String: Any] = ["path": "/x", "entries": [
+            entry("small", size: 10), entry("big", size: 1000), entry("mid", size: 100),
+        ]]
+        let out = ToolCatalog.prunedAnalyzeLevel(level, limit: 100, minSize: 0)
+        let names = (out["entries"] as? [[String: Any]])?.compactMap { $0["name"] as? String }
+        XCTAssertEqual(names, ["big", "mid", "small"])
+        XCTAssertNil(out["entries_omitted"], "nothing dropped, no marker")
+    }
+
+    func testPrune_limitCutsAndCountsTheTail() throws {
+        let level: [String: Any] = ["entries": (1...5).map { entry("e\($0)", size: $0 * 100) }]
+        let out = ToolCatalog.prunedAnalyzeLevel(level, limit: 2, minSize: 0)
+        XCTAssertEqual((out["entries"] as? [[String: Any]])?.count, 2)
+        XCTAssertEqual(out["entries_omitted"] as? Int, 3)
+        // dropped: 300 + 200 + 100
+        XCTAssertEqual(out["omitted_bytes"] as? Int64, 600)
+    }
+
+    func testPrune_minSizeFiltersNoise() throws {
+        let level: [String: Any] = ["entries": [
+            entry("keep", size: 5000), entry("noise1", size: 10), entry("noise2", size: 20),
+        ]]
+        let out = ToolCatalog.prunedAnalyzeLevel(level, limit: 100, minSize: 1000)
+        XCTAssertEqual((out["entries"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(out["entries_omitted"] as? Int, 2)
+        XCTAssertEqual(out["omitted_bytes"] as? Int64, 30)
+    }
+
+    func testPrune_preservesUnknownLevelAndEntryFields() throws {
+        // The contract tracks mole's — extra fields must survive the prune.
+        let level: [String: Any] = ["path": "/x", "overview": false,
+                                    "entries": [entry("a", size: 1)]]
+        let out = ToolCatalog.prunedAnalyzeLevel(level, limit: 100, minSize: 0)
+        XCTAssertEqual(out["overview"] as? Bool, false)
+        XCTAssertEqual(out["path"] as? String, "/x")
+        XCTAssertEqual((out["entries"] as? [[String: Any]])?.first?["path"] as? String, "/x/a")
+    }
+
+    func testPrune_toleratesMissingEntries() throws {
+        let out = ToolCatalog.prunedAnalyzeLevel(["path": "/x"], limit: 10, minSize: 0)
+        XCTAssertEqual((out["entries"] as? [[String: Any]])?.count, 0)
+    }
+
+    func testEntrySize_readsJSONSerializationNumbers() throws {
+        // Round-trip through JSONSerialization so sizes arrive as NSNumber,
+        // exactly as callAnalyze sees them.
+        let data = Data(#"{"entries":[{"name":"a","size":5368709120}]}"#.utf8)
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let e = try XCTUnwrap((obj["entries"] as? [[String: Any]])?.first)
+        XCTAssertEqual(ToolCatalog.entrySize(e), 5_368_709_120)
+        XCTAssertEqual(ToolCatalog.entrySize(["name": "x"]), 0, "sizeless entry ranks last, not crashes")
+    }
+}

--- a/macos/Tests/MoActionsTests.swift
+++ b/macos/Tests/MoActionsTests.swift
@@ -212,6 +212,20 @@ final class MoActionsTests: XCTestCase {
         XCTAssertEqual(obj["output"] as? String, transcript, "raw output stays — additive only")
     }
 
+    func testWire_timedOutRun_isByteStable_andSaysWhatHappened() {
+        // Observed in real agent transcripts: a killed clean rendered as
+        // `{"exit_code":9,"output":"","ran":false}` — nothing actionable.
+        let json = ActionWire.result(command: "clean", dryRun: true, ran: false,
+                                     exitCode: 9, output: "", timedOutAfter: 600)
+        XCTAssertEqual(json, #"{"command":"clean","dry_run":true,"exit_code":9,"hint":"mo clean was killed after 600s without finishing — retry, or run it from the Burrow app","output":"","ran":false,"timed_out":true}"#)
+    }
+
+    func testWire_untimedResult_carriesNoTimeoutMarker() {
+        let json = ActionWire.result(command: "clean", dryRun: true, ran: false,
+                                     exitCode: 0, output: "ok")
+        XCTAssertFalse(json.contains("timed_out"), "additive only — absent unless it happened")
+    }
+
     func testWire_blockedClean_isByteStable() {
         let json = ActionWire.blocked(command: "clean", reason: .agentCleanupsOptInOff)
         XCTAssertEqual(json, #"{"blocked":true,"command":"clean","ran":false,"reason":"Real cleanups are off. Turn on 'Let agents run cleanups for real' in Burrow ▸ Settings, then retry with confirm:true. (A dry-run preview works without it.)"}"#)

--- a/skills/burrow-system-tools/SKILL.md
+++ b/skills/burrow-system-tools/SKILL.md
@@ -27,8 +27,13 @@ Read-only tools never change anything, so there's no reason to hesitate.
   draining my battery?"
 - **burrow_history** / **burrow_diff** — a trend over time, or what changed since
   a point ("it got slow in the last hour").
-- **burrow_disk_forecast** — "when will my disk fill up?" **burrow_analyze
-  &lt;path&gt;** — "what's eating space in &lt;folder&gt;?"
+- **burrow_disk_forecast** — "when will my disk fill up?" (pointless once the
+  disk is already full — go straight to analyze). **burrow_analyze
+  &lt;path&gt;** — "what's eating space in &lt;folder&gt;?" Supports `depth` (descend
+  into the largest subdirectories in one call), `limit`, and `min_size` — e.g.
+  `depth: 2, min_size: 104857600` maps hotspots without a call per directory.
+  Scanning a home folder or ~/Library can take minutes: pass the most specific
+  path you can.
 - **burrow_ports** — "what's listening / what's on port 3000?" (pid + owner).
 - **burrow_cleanup_history** / **burrow_deleted_files** — what Burrow has cleaned,
   and exactly which files it removed.
@@ -45,7 +50,8 @@ get the user's explicit go before passing `confirm: true`** — never assume a r
 run will execute.
 
 - **burrow_clean** / **burrow_optimize** — remove caches/logs/junk / run safe
-  maintenance.
+  maintenance. The clean scan can take minutes on a full disk; a result with
+  `timed_out: true` means the run was killed, not that nothing needed cleaning.
 - **burrow_uninstall** — remove apps + leftovers (to Trash unless `permanent`;
   resolve names via `burrow_list_apps` first; it aborts unless the matcher hits
   exactly the apps you named).
@@ -62,11 +68,15 @@ behaviour to lean into; don't wait to be asked.
 
 ## Patterns
 
+- **Low on disk** (the most common real emergency) → `burrow_analyze` with
+  `depth: 2` on the suspect folder (largest user dirs first; skip the forecast
+  if the disk is already full) → `burrow_clean` preview → `burrow_purge` /
+  `burrow_installer` previews. If user folders don't account for the usage,
+  check APFS local snapshots (`tmutil listlocalsnapshots /`) and purgeable
+  space — Burrow doesn't report those yet, so shell out for that piece.
 - **Slow / hot / loud** → `burrow_doctor` → `burrow_top_processes` (now) or
   `burrow_process_usage` (over time) → name the culprit → offer a clean/optimize
   *preview* if relevant.
-- **Low on disk** → `burrow_disk_forecast` → `burrow_analyze &lt;folder&gt;` →
-  `burrow_purge` / `burrow_installer` previews → `burrow_clean` preview.
 - **Security / what's listening** → `burrow_doctor` + `burrow_ports`.
 - **Empty or stale results** → `burrow_info` to confirm Burrow is recording.
 


### PR DESCRIPTION
Closes #302 (the in-scope items; the purgeable-space/snapshot tool remains a follow-up there).

Real-usage audit of every agent transcript on a dev machine showed `burrow_analyze`, `burrow_clean`, and `burrow_doctor` carry ~85% of all MCP traffic, and surfaced three concrete failure modes. This PR fixes them:

**Timeouts now say so.** A killed run used to render as `{"exit_code":9,"output":"","ran":false}` (observed twice in the wild). `ActionWire.result` gains an additive `timed_out: true` + `hint` pair, fed from the `timedOut` flag `MoleCLI` already captured but `execute()` dropped. The analyze error path gets the same treatment. Existing golden tests are untouched (additive, sorted keys); a new byte-stable golden covers the timed-out shape.

**`burrow_analyze` gains `depth`, `limit`, `min_size`.** Mole reports one directory level per run, which forced agents into call-per-directory drill-downs (a real session made 15 sequential analyze calls) and 35–60 KB pretty-printed responses (one overflowed the client into a persisted-output file). The tool now prunes each level (largest first, `limit` default 100, `min_size` filter), re-emits compact JSON, and `depth` > 1 descends into the largest subdirectories (≤8 per level, 90 s budget) so one call yields a hotspot map. Truncation is never silent: `entries_omitted`/`omitted_bytes` per level, `partial: true` + hint when the descent hits its budget. Unparseable mole output passes through verbatim, as before.

**Descriptions and docs match reality.** The slow tools (analyze, clean, purge, installer) now say they're slow, so agents scope paths instead of hanging into their client's ~120 s backgrounding window and falling back to raw `du`/`df`. `docs/agent-tools.md` and the `burrow-system-tools` skill lead with the low-disk pattern (the only one that fires in practice), skip the forecast when the disk is already full, and point at APFS local snapshots/purgeable space for the case Burrow can't see yet. `burrow_cleanup_history`'s "mo history unavailable" error now points at `burrow_info`.

New tests: `MCPAnalyzeTests` (prune sorting/limit/min_size/omission accounting/field passthrough/NSNumber sizes) and two `ActionWire` wire tests (timed-out golden + absence check).
