### PR TITLE
release(macos): 0.10.5 — MCP agent UX from the real-usage audit

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,27 +1,32 @@
 <!-- Latest release ONLY. This file is the GitHub release body (release.yml --notes-file), so it must contain just the newest version. OVERWRITE it each release; do not accumulate. Full prose history lives in docs/releases.json → docs/releases.html (the site Releases page). -->
 
-# Burrow 0.10.2
+# Burrow 0.10.5
 
-A fix release. Three crashes are gone — the menu-bar popover, the streaming
-task report, and a nil-font HUD metric — and the in-app updater no longer
-silently reopens the same build when Homebrew won't upgrade in place.
+Burrow's MCP tools, tuned against real agent transcripts. We audited how AI
+agents actually used the tools in the wild — what they called, where they
+stalled, and when they gave up and fell back to raw `du`/`df` — and fixed what
+tripped them up ([#302](https://github.com/caezium/Burrow/issues/302)).
 
-## Fixes
-- **No more menu-bar popover or streaming-report crashes.** Two `EXC_BAD_ACCESS`
-  faults inside SwiftUI's view graph — one in the menu-bar popover header
-  button, one in the live task report/ticker as a job streamed — are fixed by
-  keeping those view subtrees structurally stable across snapshot and scroll
-  updates instead of restructuring them mid-update.
-  ([#299](https://github.com/caezium/Burrow/pull/299))
-- **The menu-bar metric no longer crashes on a nil font.**
-  `NSFont.monospacedSystemFont` is declared non-null but can transiently return
-  nil under memory pressure; that null reached CoreText and crashed at draw
-  time (Sentry BURROW-8Y). The metric widgets now fall back to the plain system
-  font — cosmetic at worst, never a crash.
-  ([#290](https://github.com/caezium/Burrow/pull/290))
-- **In-app update actually updates.** When the cask "cannot be upgraded as-is,"
-  Homebrew prints a warning but exits 0 — so the one-click updater reported
-  success and reopened the same build. It now detects the refusal by message
-  and runs the `brew reinstall --force` Homebrew recommends.
-  ([#287](https://github.com/caezium/Burrow/pull/287))
+## Improved
+- **One `burrow_analyze` call now maps disk hotspots.** The engine reports one
+  directory level per run, which forced agents into a call per directory (a
+  real session made 15 in a row). `analyze` gains `depth` (descend into the
+  largest subdirectories), `limit`, and `min_size`, emits compact JSON instead
+  of 35–60 KB pretty-printed blobs, and always reports what it pruned
+  (`entries_omitted` / `omitted_bytes`, `partial: true` when the descent hits
+  its time budget). ([#303](https://github.com/caezium/Burrow/pull/303))
+- **The slow tools now say they're slow.** `analyze`, `clean`, `purge`, and
+  `installer` descriptions warn that big scans take minutes, so agents scope to
+  a specific folder instead of hanging past their client's patience and falling
+  back to shell commands. The agent docs and the `burrow-system-tools` skill
+  now lead with the low-disk emergency playbook — the pattern that actually
+  fires in practice. ([#303](https://github.com/caezium/Burrow/pull/303))
 
+## Fixed
+- **Killed runs no longer fail silently.** A `burrow_clean` that hit its time
+  limit rendered as `{"exit_code": 9, "output": ""}` — nothing an agent could
+  act on. Timed-out actions (and analyze) now return `timed_out: true` plus a
+  hint. ([#303](https://github.com/caezium/Burrow/pull/303))
+- **`burrow_cleanup_history` explains itself.** When engine history is
+  unavailable, the error now points at `burrow_info` to check whether Burrow is
+  recording at all. ([#303](https://github.com/caezium/Burrow/pull/303))

--- a/docs/index.html
+++ b/docs/index.html
@@ -323,7 +323,7 @@
 
   <!-- ===== HERO ===== -->
   <header class="hero">
-    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.10.2</span>
+    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.10.5</span>
     <h1>Burrow
       <svg class="mark" viewBox="0 0 100 100" aria-hidden="true"><path d="M14 74 a36 36 0 0 1 72 0 Z" fill="#F3ECDD"/><rect x="38" y="74" width="24" height="7" rx="3.5" fill="#121217"/></svg>
     </h1>
@@ -389,29 +389,28 @@
     <div class="sec-head wn-head">
       <div>
         <span class="sec-num">What's new · July 2026</span>
-        <h2 class="sec-title">New in 0.10.2</h2>
+        <h2 class="sec-title">New in 0.10.5</h2>
       </div>
       <a class="btn btn-out btn-sm" href="releases.html">All releases</a>
     </div>
 
     <div class="grid3 wn-grid">
-      <article class="tcard" style="--c: var(--teal)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Popover &amp; streaming crashes gone</div></div>
-        <p class="ds">Two EXC_BAD_ACCESS faults in SwiftUI's view graph — the menu-bar popover header and the live task report while a job streams — are fixed by keeping those subtrees stable across updates.</p>
+      <article class="tcard" style="--c: var(--lilac)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9l3 3-3 3M13 15h4"/></svg></div><div class="nm">One analyze call, whole hotspot map</div></div>
+        <p class="ds">burrow_analyze gains depth, limit, and min_size — it descends into the largest subdirectories itself, emits compact JSON instead of 35–60 KB blobs, and always reports what it pruned.</p>
       </article>
       <article class="tcard" style="--c: var(--azure)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 19a9 9 0 1114 0"/><path d="M12 13l4-4"/><circle cx="12" cy="13" r="1.6"/></svg></div><div class="nm">HUD font crash fixed</div></div>
-        <p class="ds">The menu-bar metric could crash on a transiently-nil monospaced system font; it now falls back to the system font instead of crashing (Sentry BURROW-8Y).</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></div><div class="nm">Timeouts say so</div></div>
+        <p class="ds">A killed clean used to render as exit_code 9 with empty output. Timed-out actions now return timed_out: true plus a hint an agent can act on.</p>
       </article>
       <article class="tcard" style="--c: var(--apricot)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8l-9-5-9 5v8l9 5 9-5z"/><path d="M3 8l9 5 9-5M12 13v8"/></svg></div><div class="nm">In-app update actually updates</div></div>
-        <p class="ds">When Homebrew refused to upgrade the cask in place it exited 0, so the one-click updater reopened the same build. It now detects the refusal and reinstalls.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h13M8 12h13M8 18h13M3.5 6h.01M3.5 12h.01M3.5 18h.01"/></svg></div><div class="nm">Honest slow-tool docs</div></div>
+        <p class="ds">The tools that scan for minutes now say so, and the agent docs + skill lead with the low-disk emergency playbook — the pattern that actually fires in practice.</p>
       </article>
     </div>
 
-    <div class="extra-label mono">// also tightened in 0.10.2</div>
+    <div class="extra-label mono">// also tightened in 0.10.5</div>
     <div class="wn-chips">
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>On 0.10.1 the in-app updater may reopen the same build — grab 0.10.2 with <code>brew upgrade --cask burrow</code> (or <code>brew reinstall --cask --force burrow</code>), or the direct download.</span>
       <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Still ad-hoc-signed — re-grant Full Disk Access once after updating.</span>
     </div>
     <!-- WN:END -->

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -123,13 +123,38 @@
 <header class="hero page">
   <h1>Changelog</h1>
   <p>Every version at a glance — what it added, changed, and fixed. Full notes for each live on GitHub.</p>
-  <p class="count">19 releases · latest 0.10.2 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
+  <p class="count">20 releases · latest 0.10.5 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
 </header>
 
 <main class="page">
+    <article class="entry" id="v0.10.5">
+      <div class="ver-col">
+        <h2 class="ver">0.10.5<span class="latest">latest</span></h2>
+        <span class="date mono">Jul 25, 2026</span>
+        <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.10.5" target="_blank" rel="noopener">full notes ↗</a>
+      </div>
+      <div class="sbody">
+        <p class="lead">Burrow's MCP tools, tuned against real agent transcripts — one analyze call maps disk hotspots, killed runs say so instead of failing silently, and slow scans warn you up front.</p>
+        <div class="sblock">
+          <div class="slabel mono">improved</div>
+          <ul class="slist">
+            <li><b>One <code>burrow_analyze</code> call now maps disk hotspots.</b> The engine reports one directory level per run, which forced agents into a call per directory (a real session made 15 in a row). <code>analyze</code> gains <code>depth</code> (descend into the largest subdirectories), <code>limit</code>, and <code>min_size</code>, emits compact JSON instead of 35–60 KB pretty-printed blobs, and always reports what it pruned (<code>entries_omitted</code> / <code>omitted_bytes</code>, <code>partial: true</code> when the descent hits its time budget). (<a href="https://github.com/caezium/Burrow/pull/303" target="_blank" rel="noopener">#303</a>)</li>
+            <li><b>The slow tools now say they're slow.</b> <code>analyze</code>, <code>clean</code>, <code>purge</code>, and <code>installer</code> descriptions warn that big scans take minutes, so agents scope to a specific folder instead of hanging past their client's patience and falling back to shell commands. The agent docs and the <code>burrow-system-tools</code> skill now lead with the low-disk emergency playbook — the pattern that actually fires in practice. (<a href="https://github.com/caezium/Burrow/pull/303" target="_blank" rel="noopener">#303</a>)</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">fixed</div>
+          <ul class="slist">
+            <li><b>Killed runs no longer fail silently.</b> A <code>burrow_clean</code> that hit its time limit rendered as <code>{"exit_code": 9, "output": ""}</code> — nothing an agent could act on. Timed-out actions (and analyze) now return <code>timed_out: true</code> plus a hint. (<a href="https://github.com/caezium/Burrow/pull/303" target="_blank" rel="noopener">#303</a>)</li>
+            <li><b><code>burrow_cleanup_history</code> explains itself.</b> When engine history is unavailable, the error now points at <code>burrow_info</code> to check whether Burrow is recording at all. (<a href="https://github.com/caezium/Burrow/pull/303" target="_blank" rel="noopener">#303</a>)</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
     <article class="entry" id="v0.10.2">
       <div class="ver-col">
-        <h2 class="ver">0.10.2<span class="latest">latest</span></h2>
+        <h2 class="ver">0.10.2</h2>
         <span class="date mono">Jul 24, 2026</span>
         <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.10.2" target="_blank" rel="noopener">full notes ↗</a>
       </div>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -2,6 +2,51 @@
   "_comment": "Source of truth for the site's release history. Newest first. Edit this, then run `python3 scripts/site-release.py` to regenerate the homepage 'New in X' section and releases.html. Icons/colors: run `python3 scripts/site-release.py --list-icons`.",
   "releases": [
     {
+      "version": "0.10.5",
+      "date": "2026-07-25",
+      "tag": "v0.10.5",
+      "tagline": "Burrow's MCP tools, tuned against real agent transcripts — one analyze call maps disk hotspots, killed runs say so instead of failing silently, and slow scans warn you up front.",
+      "highlights": [
+        {
+          "icon": "robot",
+          "color": "lilac",
+          "title": "One analyze call, whole hotspot map",
+          "line": "burrow_analyze gains depth, limit, and min_size — it descends into the largest subdirectories itself, emits compact JSON instead of 35–60 KB blobs, and always reports what it pruned."
+        },
+        {
+          "icon": "clock",
+          "color": "azure",
+          "title": "Timeouts say so",
+          "line": "A killed clean used to render as exit_code 9 with empty output. Timed-out actions now return timed_out: true plus a hint an agent can act on."
+        },
+        {
+          "icon": "list",
+          "color": "apricot",
+          "title": "Honest slow-tool docs",
+          "line": "The tools that scan for minutes now say so, and the agent docs + skill lead with the low-disk emergency playbook — the pattern that actually fires in practice."
+        }
+      ],
+      "chips": [
+        "Still ad-hoc-signed — re-grant Full Disk Access once after updating."
+      ],
+      "sections": [
+        {
+          "label": "improved",
+          "items": [
+            "**One `burrow_analyze` call now maps disk hotspots.** The engine reports one directory level per run, which forced agents into a call per directory (a real session made 15 in a row). `analyze` gains `depth` (descend into the largest subdirectories), `limit`, and `min_size`, emits compact JSON instead of 35–60 KB pretty-printed blobs, and always reports what it pruned (`entries_omitted` / `omitted_bytes`, `partial: true` when the descent hits its time budget). ([#303](https://github.com/caezium/Burrow/pull/303))",
+            "**The slow tools now say they're slow.** `analyze`, `clean`, `purge`, and `installer` descriptions warn that big scans take minutes, so agents scope to a specific folder instead of hanging past their client's patience and falling back to shell commands. The agent docs and the `burrow-system-tools` skill now lead with the low-disk emergency playbook — the pattern that actually fires in practice. ([#303](https://github.com/caezium/Burrow/pull/303))"
+          ]
+        },
+        {
+          "label": "fixed",
+          "items": [
+            "**Killed runs no longer fail silently.** A `burrow_clean` that hit its time limit rendered as `{\"exit_code\": 9, \"output\": \"\"}` — nothing an agent could act on. Timed-out actions (and analyze) now return `timed_out: true` plus a hint. ([#303](https://github.com/caezium/Burrow/pull/303))",
+            "**`burrow_cleanup_history` explains itself.** When engine history is unavailable, the error now points at `burrow_info` to check whether Burrow is recording at all. ([#303](https://github.com/caezium/Burrow/pull/303))"
+          ]
+        }
+      ]
+    },
+    {
       "version": "0.10.2",
       "date": "2026-07-24",
       "tag": "v0.10.2",

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -54,8 +54,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.10.2"
-        CFBundleVersion: "19"
+        CFBundleShortVersionString: "0.10.5"
+        CFBundleVersion: "20"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Friendly, one-time prompts for the standard folders Mole scans
         # (purge/installer touch these). Full Disk Access still covers the


### PR DESCRIPTION
Version bump to 0.10.5 (build 20) + release notes + regenerated site pages. Ships #303 (MCP agent UX: timeout surfacing, analyze depth/limit/min_size, honest slow-tool docs). Notes text approved in session.