### PR TITLE
fix(release): vendor Sparkle framework deterministically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Fetch vendored Sentry framework
         run: bash ../scripts/fetch-sentry.sh
 
+      # Sparkle's Swift package wraps a binary artifact, and that artifact
+      # downloader hard-hung both v0.11.0 release attempts. Fetch the official
+      # checksum-pinned universal framework directly instead.
+      - name: Fetch vendored Sparkle framework
+        run: bash ../scripts/fetch-sparkle.sh
+
       - name: Generate project
         run: xcodegen generate
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,9 @@ jobs:
 
       # Fetch the bundled MIT engine OUTSIDE the work tree (RUNNER_TEMP), at its
       # pinned submodule commit. (This once looked like it hung SPM — the real
-      # cause was Sentry's SPM binary-artifact download, now vendored via
-      # scripts/fetch-sentry.sh so SPM never touches Sentry.) NON-FATAL: without
-      # ENGINE_PAT the app falls back to system `mo`. Token scoped via `git -c`.
+      # cause was binary-artifact resolution. Sentry and Sparkle are now both
+      # fetched directly with pinned checksums.) NON-FATAL: without ENGINE_PAT
+      # the app falls back to system `mo`. Token scoped via `git -c`.
       - name: Fetch bundled engine (outside the work tree)
         env:
           ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
@@ -186,9 +186,9 @@ jobs:
           if [ -n "$ENGINE_PAT" ]; then
             git config --global url."https://x-access-token:${ENGINE_PAT}@github.com/".insteadOf "https://github.com/"
           fi
-          # Sentry is vendored as a local framework (scripts/fetch-sentry.sh),
-          # not an SPM package, so the SPM binary-download hang is gone — this is
-          # a plain build now. The step timeout-minutes above is the hard cap.
+          # Sentry and Sparkle are vendored as checksum-pinned local frameworks
+          # (scripts/fetch-{sentry,sparkle}.sh), so SwiftPM has no binary
+          # artifacts left to download. The step timeout above remains the cap.
           bash scripts/release.sh
           APP="build_dist/Build/Products/Release/Burrow.app"
           [ -d "$APP" ] || { echo "::error::build produced no app at $APP"; exit 1; }
@@ -366,24 +366,9 @@ jobs:
           echo "Built Burrow ${{ steps.build.outputs.version }} (Developer ID signed + notarized) sha256=$SHA"
 
       - name: Install pinned Sparkle release tools
-        env:
-          SPARKLE_VERSION: "2.9.4"
-          SPARKLE_SHA256: "ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9"
         run: |
-          ARCHIVE="$RUNNER_TEMP/Sparkle-${SPARKLE_VERSION}.tar.xz"
           TOOLS="$RUNNER_TEMP/sparkle-release-tools"
-          curl --fail --location --silent --show-error \
-            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
-            --output "$ARCHIVE"
-          ACTUAL="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
-          if [ "$ACTUAL" != "$SPARKLE_SHA256" ]; then
-            echo "::error::Sparkle tools checksum mismatch: got $ACTUAL"
-            exit 1
-          fi
-          mkdir -p "$TOOLS"
-          tar -xf "$ARCHIVE" -C "$TOOLS"
-          [ -x "$TOOLS/bin/generate_appcast" ] && [ -x "$TOOLS/bin/sign_update" ] \
-            || { echo "::error::Pinned Sparkle archive is missing release tools."; exit 1; }
+          bash scripts/fetch-sparkle.sh --tools "$TOOLS"
           echo "SPARKLE_TOOLS=$TOOLS/bin" >> "$GITHUB_ENV"
 
       - name: Generate and verify signed Sparkle appcast

--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,10 @@ scripts/release.env
 # local build output (this session's DerivedData)
 build_dd/
 
-# Vendored Sentry framework — fetched by scripts/fetch-sentry.sh, not committed.
-# Sentry is a local framework, not an SPM package (SPM's binary-artifact
-# download hangs xcodebuild on CI; see that script).
+# Vendored binary frameworks — fetched and checksum-verified, not committed.
+# SwiftPM's binary-artifact downloader hangs xcodebuild on release runners;
+# see scripts/fetch-sentry.sh and scripts/fetch-sparkle.sh.
 macos/vendor/Sentry.xcframework/
 macos/vendor/.sentry-*.ok
+macos/vendor/Sparkle.framework/
+macos/vendor/.sparkle-cache/

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ bridge still posts to `/mcp`.
 ```bash
 cd macos        # the macOS app lives here (monorepo: macos/ + windows/)
 bash ../scripts/fetch-sentry.sh   # vendor Sentry.xcframework (it's a local framework, not an SPM dep)
+bash ../scripts/fetch-sparkle.sh  # vendor the checksum-pinned official Sparkle.framework
 xcodegen generate
 xcodebuild -project Burrow.xcodeproj -scheme Burrow \
   -configuration Debug -destination 'platform=macOS' test

--- a/docs/index.html
+++ b/docs/index.html
@@ -500,7 +500,7 @@
       <a class="btn btn-fill" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" style="padding:15px 40px; font-size:16px;">Get Burrow</a>
       <div class="price-lines">All five tools, the menu-bar HUD, history, and the MCP server included.<br>
         <span style="color:var(--ink-3)">or <a class="u" href="#build">build it from source</a></span></div>
-      <div class="price-meta">unlimited Macs<span class="dot">·</span>no account<span class="dot">·</span>Developer ID release gate<span class="dot">·</span>engine + conductor bundled — nothing else to install</div>
+      <div class="price-meta">unlimited Macs<span class="dot">·</span>no account<span class="dot">·</span>Developer ID release gate<span class="dot">·</span>official downloads bundle the engine + conductor</div>
     </div>
 
     <div class="installs" id="build">
@@ -517,10 +517,12 @@ brew install --cask caezium/tap/burrow</div>
       </div>
       <div class="inst">
         <h3>Build from source</h3>
-        <p>Needs <code class="k">xcodegen</code> plus the repository submodules; the build stages the engine into the app. Every line is yours to read first.</p>
+        <p>Needs <code class="k">xcodegen</code>. This builds a locally ad-hoc-signed GUI with checksum-pinned frameworks; unlike official downloads, a plain public checkout falls back to compatible command-line tools already installed on your Mac.</p>
         <div class="code" data-copy="git clone https://github.com/caezium/Burrow.git
-cd Burrow/macos && xcodegen generate"><button class="copy">copy</button>git clone …/caezium/Burrow.git
-cd Burrow/macos && xcodegen generate</div>
+cd Burrow
+bash scripts/release.sh"><button class="copy">copy</button>git clone …/caezium/Burrow.git
+cd Burrow
+bash scripts/release.sh</div>
       </div>
     </div>
 

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -167,7 +167,8 @@ public tag.
 The workflow order is:
 
 1. Require all Apple, Sparkle, and external-tap secrets.
-2. Build and confirm the bundled conductor, engine, and fclones sidecar.
+2. Fetch and checksum-validate the official Sentry and Sparkle frameworks,
+   then build and confirm the bundled conductor, engine, and fclones sidecar.
 3. Require the Sparkle private seed to match the public key embedded in the app.
 4. Sign every executable and the outer app with Developer ID.
 5. Require Apple’s notarization result to be `Accepted`.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -27,17 +27,14 @@ settings:
 # Both are inert unless a release injects keys (see the per-target settings
 # below): a plain `xcodegen + xcodebuild` dev build ships with empty keys and
 # never touches either network.
-# Pinned EXACTLY (not `from:`): the .xcodeproj — and with it the only
-# Package.resolved — is gitignored, so a range would let every CI release
-# resolve whatever the latest compatible SDK is at build time. Exact pins
-# keep releases reproducible from a tag; bump deliberately.
+# PostHog is pinned EXACTLY (not `from:`): the .xcodeproj — and with it the
+# only Package.resolved — is gitignored, so a range would let every CI release
+# resolve whatever the latest compatible SDK is at build time. The exact pin
+# keeps releases reproducible from a tag; bump deliberately.
 packages:
   PostHog:
     url: https://github.com/PostHog/posthog-ios
     exactVersion: 3.59.3
-  Sparkle:
-    url: https://github.com/sparkle-project/Sparkle
-    exactVersion: 2.9.4
 # Sentry is NOT an SPM package: SPM eagerly downloads ALL of sentry-cocoa's
 # binary xcframework variants during resolution (Sentry, -Dynamic, -WithARM64e,
 # …, ~500 MB), and on the release runner that download hard-hangs xcodebuild
@@ -45,6 +42,10 @@ packages:
 # vendor only the one static Sentry.xcframework we actually use, fetched by
 # scripts/fetch-sentry.sh (curl), and link it directly. Pin matches the old SPM
 # exactVersion. Crash reporting (CrashReporter.swift) is unchanged.
+# Sparkle is also a local framework: its Swift package wraps a binary artifact,
+# and that artifact-resolution step hard-hung both v0.11.0 release attempts.
+# scripts/fetch-sparkle.sh downloads the official 2.9.4 release archive with a
+# pinned checksum and validates the universal framework before xcodegen runs.
 
 targets:
   Burrow:
@@ -107,7 +108,8 @@ targets:
         SENTRY_DSN: ""
     dependencies:
       - package: PostHog
-      - package: Sparkle
+      - framework: vendor/Sparkle.framework
+        embed: true
       - framework: vendor/Sentry.xcframework
         embed: false
     postBuildScripts:
@@ -177,6 +179,12 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: dev.caezium.BurrowTests
     dependencies:
       - target: Burrow
+      # The tests import Burrow's compiled Swift module, which records Sparkle
+      # as a module dependency. Local frameworks are not propagated through a
+      # target dependency the way Swift package products are, so expose its
+      # module to the test compiler without embedding another copy.
+      - framework: vendor/Sparkle.framework
+        embed: false
 
 # Shared scheme so `xcodebuild test` works headlessly (CI and CLI runs)
 # instead of depending on Xcode auto-creating a local scheme on first open.

--- a/macos/scripts/build.sh
+++ b/macos/scripts/build.sh
@@ -17,6 +17,8 @@ cd "$(dirname "$0")/.."   # macos/
 CONFIG="${1:-Debug}"
 ENGINE_SRC="${BURROW_ENGINE_SRC:-$PWD/vendor/burrow-engine}"
 
+bash ../scripts/fetch-sentry.sh
+bash ../scripts/fetch-sparkle.sh
 xcodegen generate >/dev/null
 
 BURROW_ENGINE_SRC="$ENGINE_SRC" xcodebuild -project Burrow.xcodeproj -scheme Burrow \

--- a/scripts/fetch-sparkle.sh
+++ b/scripts/fetch-sparkle.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# fetch-sparkle.sh — vendor Sparkle's official universal framework locally.
+#
+# Sparkle's Swift package is a thin wrapper around a binary artifact. On the
+# GitHub macOS release runner, SwiftPM checks out Sparkle and then hangs forever
+# while resolving that artifact; two v0.11.0 release attempts reached the
+# 38-minute hard timeout before compilation. curl downloads the same official
+# release archive reliably, so fetch it explicitly, pin its checksum, validate
+# the framework, and keep SwiftPM responsible only for source packages.
+#
+# Usage:
+#   fetch-sparkle.sh                    # install macos/vendor/Sparkle.framework
+#   fetch-sparkle.sh --tools <dir>      # install the matching release tools
+#
+# The verified release archive is cached locally, but its full SHA-256 is
+# checked on every invocation and outputs are always re-extracted from it. An
+# ignored marker file cannot make modified framework contents look trusted.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VERSION="2.9.4"
+# sha256 of Sparkle-2.9.4.tar.xz from the official GitHub release. Framework
+# and appcast tools both come through this single pin.
+SHA256="ce89daf967db1e1893ed3ebd67575ed82d3902563e3191ca92aaec9164fbdef9"
+URL="https://github.com/sparkle-project/Sparkle/releases/download/${VERSION}/Sparkle-${VERSION}.tar.xz"
+DEST="macos/vendor/Sparkle.framework"
+CACHE_DIR="macos/vendor/.sparkle-cache"
+ARCHIVE="$CACHE_DIR/Sparkle-${VERSION}.tar.xz"
+
+MODE="framework"
+TOOLS_DEST=""
+case "$#" in
+  0) ;;
+  2)
+    if [ "$1" != "--tools" ] || [ -z "$2" ]; then
+      echo "usage: $0 [--tools <destination>]" >&2
+      exit 2
+    fi
+    MODE="tools"
+    TOOLS_DEST="$2"
+    ;;
+  *)
+    echo "usage: $0 [--tools <destination>]" >&2
+    exit 2
+    ;;
+esac
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ensure_archive() {
+  local got
+
+  if [ -f "$ARCHIVE" ]; then
+    got="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
+    if [ "$got" = "$SHA256" ]; then
+      echo "==> verified cached Sparkle ${VERSION} release archive"
+      return
+    fi
+    echo "warning: cached Sparkle archive checksum is $got; downloading a clean copy" >&2
+  fi
+
+  echo "==> fetching Sparkle ${VERSION} release archive"
+  curl -fSL --retry 5 --retry-delay 3 --retry-all-errors \
+    --connect-timeout 30 --max-time 300 \
+    -o "$TMP/Sparkle.tar.xz" "$URL"
+
+  got="$(shasum -a 256 "$TMP/Sparkle.tar.xz" | awk '{print $1}')"
+  if [ "$got" != "$SHA256" ]; then
+    echo "error: Sparkle release checksum mismatch (got $got, want $SHA256)" >&2
+    exit 1
+  fi
+
+  mkdir -p "$CACHE_DIR"
+  mv -f "$TMP/Sparkle.tar.xz" "$ARCHIVE"
+}
+
+validate_framework() {
+  local framework="$1"
+  local binary="$framework/Sparkle"
+  local info="$framework/Resources/Info.plist"
+  local actual_version arches
+
+  [ -f "$binary" ] \
+    || { echo "error: Sparkle framework binary is missing: $binary" >&2; return 1; }
+  [ -f "$info" ] \
+    || { echo "error: Sparkle framework Info.plist is missing: $info" >&2; return 1; }
+  [ -x "$framework/Autoupdate" ] \
+    || { echo "error: Sparkle Autoupdate helper is missing" >&2; return 1; }
+  [ -x "$framework/Updater.app/Contents/MacOS/Updater" ] \
+    || { echo "error: Sparkle Updater helper is missing" >&2; return 1; }
+  [ -x "$framework/XPCServices/Downloader.xpc/Contents/MacOS/Downloader" ] \
+    || { echo "error: Sparkle Downloader XPC service is missing" >&2; return 1; }
+  [ -x "$framework/XPCServices/Installer.xpc/Contents/MacOS/Installer" ] \
+    || { echo "error: Sparkle Installer XPC service is missing" >&2; return 1; }
+
+  actual_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$info")"
+  [ "$actual_version" = "$VERSION" ] \
+    || { echo "error: Sparkle framework version is $actual_version, expected $VERSION" >&2; return 1; }
+
+  arches="$(lipo -archs "$binary")"
+  [[ " $arches " == *" arm64 "* ]] \
+    || { echo "error: Sparkle framework is missing arm64: $arches" >&2; return 1; }
+  [[ " $arches " == *" x86_64 "* ]] \
+    || { echo "error: Sparkle framework is missing x86_64: $arches" >&2; return 1; }
+
+  codesign --verify --deep --strict "$framework" 2>/dev/null \
+    || { echo "error: Sparkle framework's distributed signature is invalid" >&2; return 1; }
+}
+
+ensure_archive
+
+if [ "$MODE" = "tools" ]; then
+  [ ! -e "$TOOLS_DEST" ] \
+    || { echo "error: Sparkle tools destination already exists: $TOOLS_DEST" >&2; exit 2; }
+  mkdir -p "$TMP/tools"
+  tar -xf "$ARCHIVE" -C "$TMP/tools" ./bin
+  [ -x "$TMP/tools/bin/generate_appcast" ] && [ -x "$TMP/tools/bin/sign_update" ] \
+    || { echo "error: Sparkle release archive is missing required tools" >&2; exit 1; }
+  mkdir -p "$(dirname "$TOOLS_DEST")"
+  mv "$TMP/tools" "$TOOLS_DEST"
+  echo "==> installed Sparkle ${VERSION} release tools at $TOOLS_DEST/bin"
+  exit 0
+fi
+
+mkdir -p "$TMP/unpacked"
+tar -xf "$ARCHIVE" -C "$TMP/unpacked" ./Sparkle.framework
+validate_framework "$TMP/unpacked/Sparkle.framework"
+mkdir -p macos/vendor
+rm -rf "$DEST"
+mv "$TMP/unpacked/Sparkle.framework" "$DEST"
+echo "==> vendored $DEST"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,11 @@ echo "==> fetching vendored Sentry.xcframework"
 # download hard-hangs the release runner — see scripts/fetch-sentry.sh).
 bash scripts/fetch-sentry.sh
 
+echo "==> fetching vendored Sparkle.framework"
+# Sparkle's package also wraps a binary artifact. Fetch the official framework
+# with curl so xcodebuild never enters SwiftPM's hanging artifact downloader.
+bash scripts/fetch-sparkle.sh
+
 echo "==> xcodegen generate"
 # The macOS app lives under macos/ (monorepo: macos/ + windows/). Generate the
 # project there; build artifacts still land at the repo root (build_dist/, dist/).


### PR DESCRIPTION
## Summary

- remove Sparkle’s binary artifact from SwiftPM after both v0.11.0 release attempts hung before compilation
- fetch and validate the official universal Sparkle 2.9.4 framework from one checksum-pinned archive
- reuse that verified archive for Sparkle appcast tools while preserving every signing, notarization, and publication gate

The failed workflow is [GitHub Actions run 30635912673](https://github.com/caezium/Burrow/actions/runs/30635912673).

## Changes

- add `scripts/fetch-sparkle.sh` with checksum-backed archive caching, framework validation, and a `--tools` mode
- link and embed the local Sparkle framework in the app and expose it to tests; PostHog remains exact-pinned in SwiftPM
- wire local builds, CI, and the release workflow through the deterministic fetcher
- update the README, website, and macOS signing guide

## Test plan

- [x] SwiftPM resolves only PostHog in 6.8 seconds
- [x] 745 macOS tests pass with one expected skip
- [x] a clean local Release build completes in 66.6 seconds
- [x] embedded Sparkle 2.9.4 is universal and strict code-signature verification passes before and after ZIP extraction
- [x] Sparkle release tools launch from the shared verified archive
- [x] Greenlight preflight is GREENLIT
- [x] actionlint, shellcheck, plist lint, release-helper unit tests, and the final two-axis code review pass

## Release recovery

No v0.11.0 release, draft, or Homebrew mutation exists. After this PR merges, the failed v0.11.0 tag will be recreated once on the merge commit. The unchanged fail-closed workflow must then complete Developer ID signing, Apple notarization, Sparkle verification, GitHub publication, and the tap update.
