### PR TITLE
fix(release): keep entitlement checks fail closed

### DIFF
--- a/scripts/sign-macos-app.sh
+++ b/scripts/sign-macos-app.sh
@@ -91,6 +91,31 @@ read_entitlements() {
   printf '%s' "$plist"
 }
 
+plist_has_key() {
+  local key="$1"
+  local xml
+  if ! xml="$(plutil -convert xml1 -o - - 2>/dev/null)"; then
+    return 2
+  fi
+  if grep -Fq "<key>$key</key>" <<< "$xml"; then
+    return 0
+  fi
+  return 1
+}
+
+required_plist_raw() {
+  local key="$1"
+  local expected_type="$2"
+  local value
+  if ! value="$(
+    plutil -extract "$key" raw -expect "$expected_type" -o - - 2>/dev/null
+  )"; then
+    echo "error: could not extract plist key '$key' as $expected_type" >&2
+    return 1
+  fi
+  printf '%s' "$value"
+}
+
 echo "==> signing nested Mach-O files ($MODE)"
 SIGNED_MACHO=0
 while IFS= read -r -d '' candidate; do
@@ -154,8 +179,7 @@ if [ -d "$SPARKLE_FRAMEWORK" ]; then
   SPARKLE_ENTITLEMENTS="$(read_entitlements "$SPARKLE_AUTOUPDATE")"
   SPARKLE_APP_ID="$(
     printf '%s' "$SPARKLE_ENTITLEMENTS" \
-      | plutil -extract 'com\.apple\.application-identifier' raw -o - - 2>/dev/null \
-      || true
+      | required_plist_raw 'com\.apple\.application-identifier' string
   )"
   [ "$SPARKLE_APP_ID" = "org.sparkle-project.Sparkle.Autoupdate" ] || {
     echo "error: Sparkle Autoupdate entitlement was lost while re-signing" >&2
@@ -164,17 +188,22 @@ if [ -d "$SPARKLE_FRAMEWORK" ]; then
 fi
 
 APP_ENTITLEMENTS="$(read_entitlements "$APP")"
-GET_TASK_ALLOW="$(
-  printf '%s' "$APP_ENTITLEMENTS" \
-    | plutil -extract 'com\.apple\.security\.get-task-allow' raw -o - - 2>/dev/null \
-    || true
-)"
-case "$GET_TASK_ALLOW" in
-  ""|false) ;;
-  *)
+GET_TASK_ALLOW_KEY='com.apple.security.get-task-allow'
+if printf '%s' "$APP_ENTITLEMENTS" | plist_has_key "$GET_TASK_ALLOW_KEY"; then
+  GET_TASK_ALLOW="$(
+    printf '%s' "$APP_ENTITLEMENTS" \
+      | required_plist_raw 'com\.apple\.security\.get-task-allow' bool
+  )"
+  if [ "$GET_TASK_ALLOW" != false ]; then
     echo "error: release app contains invalid com.apple.security.get-task-allow=$GET_TASK_ALLOW" >&2
     exit 1
-    ;;
-esac
+  fi
+else
+  KEY_STATUS=$?
+  if [ "$KEY_STATUS" -ne 1 ]; then
+    echo "error: could not inspect app entitlements for $GET_TASK_ALLOW_KEY" >&2
+    exit 1
+  fi
+fi
 
 echo "signed $SIGNED_MACHO Mach-O file(s) and $SIGNED_CONTAINERS code container(s); strict verification passed"

--- a/scripts/tests/test_sign_macos_app.py
+++ b/scripts/tests/test_sign_macos_app.py
@@ -1,0 +1,154 @@
+import os
+import plistlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SIGNER = ROOT / "scripts" / "sign-macos-app.sh"
+
+
+class SignMacOSAppTests(unittest.TestCase):
+    def make_app(
+        self,
+        root: Path,
+        *,
+        get_task_allow: bool | str | None = None,
+    ) -> tuple[Path, Path]:
+        app = root / "Burrow.app"
+        executable = app / "Contents" / "MacOS" / "Burrow"
+        executable.parent.mkdir(parents=True)
+        # copy2 tries to preserve the system binary's immutable flags, which
+        # an unprivileged process cannot apply to a temporary file on macOS.
+        shutil.copyfile("/usr/bin/true", executable)
+        executable.chmod(0o755)
+
+        with (app / "Contents" / "Info.plist").open("wb") as handle:
+            plistlib.dump(
+                {
+                    "CFBundleExecutable": "Burrow",
+                    "CFBundleIdentifier": "dev.caezium.Burrow.SigningTest",
+                    "CFBundlePackageType": "APPL",
+                },
+                handle,
+            )
+
+        entitlements: dict[str, bool | str] = {
+            "com.apple.security.files.user-selected.read-only": True,
+        }
+        if get_task_allow is not None:
+            entitlements["com.apple.security.get-task-allow"] = get_task_allow
+        entitlements_path = root / "Burrow.entitlements"
+        with entitlements_path.open("wb") as handle:
+            plistlib.dump(entitlements, handle)
+
+        return app, entitlements_path
+
+    def run_signer(
+        self,
+        app: Path,
+        entitlements: Path,
+        *,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(SIGNER), str(app), "-", "adhoc", str(entitlements)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_missing_get_task_allow_ignores_plutil_stdout_diagnostic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app, entitlements = self.make_app(root)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_plutil = fake_bin / "plutil"
+            fake_plutil.write_text(
+                """#!/bin/bash
+if [ "$1" = "-extract" ] && [ "$2" = 'com\\.apple\\.security\\.get-task-allow' ]; then
+  echo '<stdin>: Could not extract value, error: No value at that key path'
+  exit 1
+fi
+exec /usr/bin/plutil "$@"
+""",
+                encoding="utf-8",
+            )
+            fake_plutil.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+            result = self.run_signer(app, entitlements, env=env)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertNotIn("Could not extract value", result.stdout + result.stderr)
+
+    def test_get_task_allow_true_still_blocks_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app, entitlements = self.make_app(root, get_task_allow=True)
+
+            result = self.run_signer(app, entitlements)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "release app contains invalid com.apple.security.get-task-allow=true",
+                result.stderr,
+            )
+
+    def test_get_task_allow_false_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app, entitlements = self.make_app(root, get_task_allow=False)
+
+            result = self.run_signer(app, entitlements)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_non_boolean_get_task_allow_blocks_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app, entitlements = self.make_app(root, get_task_allow="")
+
+            result = self.run_signer(app, entitlements)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "could not extract plist key "
+                "'com\\.apple\\.security\\.get-task-allow' as bool",
+                result.stderr,
+            )
+
+    def test_present_get_task_allow_extraction_failure_blocks_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            app, entitlements = self.make_app(root, get_task_allow=False)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_plutil = fake_bin / "plutil"
+            fake_plutil.write_text(
+                """#!/bin/bash
+if [ "$1" = "-extract" ] && [ "$2" = 'com\\.apple\\.security\\.get-task-allow' ]; then
+  echo '<stdin>: simulated extraction failure'
+  exit 1
+fi
+exec /usr/bin/plutil "$@"
+""",
+                encoding="utf-8",
+            )
+            fake_plutil.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+            result = self.run_signer(app, entitlements, env=env)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("could not extract plist key", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- fix the Xcode 26 runner failure that treated `plutil`'s missing-key stdout diagnostic as an entitlement value
- distinguish genuine key absence from plist conversion or extraction failure, keeping the release check fail closed
- require a present `get-task-allow` entitlement to be Boolean `false` and keep Sparkle's application identifier typed and exact

The failure occurred after the app compiled successfully in [release run 30649878789](https://github.com/caezium/Burrow/actions/runs/30649878789), before Developer ID signing, notarization, publication, or the Homebrew update.

## Tests

- [x] absent `get-task-allow` succeeds even when a runner-style missing-key diagnostic would be written to stdout
- [x] explicit Boolean `false` succeeds
- [x] Boolean `true`, a non-Boolean empty value, and simulated extraction failure all fail closed
- [x] all eight release-helper tests pass
- [x] a full local v0.11.0 Release build, nested Sparkle re-sign, strict verification, and ZIP package complete
- [x] Greenlight is GREENLIT; shellcheck, bash syntax, diff checks, and both independent code-review axes pass

## Release recovery

The failed run created no GitHub release, assets, draft, or Homebrew mutation. After this merges, `v0.11.0` will be moved from the failed merge commit to this fix's merge commit, then the full signing and notarization workflow will be monitored again.
