### PR TITLE
fix(release): preserve signing keychain search path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,8 +298,25 @@ jobs:
           APP="${{ steps.build.outputs.app }}"
           KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
           KPW="$(uuidgen)"
+          if ! ORIGINAL_KEYCHAIN_OUTPUT="$(security list-keychains -d user)"; then
+            echo "::error::Could not read the runner's original keychain search list"
+            exit 1
+          fi
+          if ! PARSED_KEYCHAIN_OUTPUT="$(
+            sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//' \
+              <<< "$ORIGINAL_KEYCHAIN_OUTPUT"
+          )"; then
+            echo "::error::Could not parse the runner's original keychain search list"
+            exit 1
+          fi
+          ORIGINAL_KEYCHAINS=()
+          while IFS= read -r existing_keychain; do
+            [ -n "$existing_keychain" ] && ORIGINAL_KEYCHAINS+=("$existing_keychain")
+          done <<< "$PARSED_KEYCHAIN_OUTPUT"
           cleanup_signing_keychain() {
             rm -f "$RUNNER_TEMP/cert.p12"
+            security list-keychains -d user -s "${ORIGINAL_KEYCHAINS[@]}" \
+              >/dev/null 2>&1 || true
             security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
           }
           trap cleanup_signing_keychain EXIT
@@ -310,9 +327,15 @@ jobs:
           security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KPW" "$KEYCHAIN" >/dev/null
           rm -f "$RUNNER_TEMP/cert.p12"
-          security find-identity -v -p codesigning "$KEYCHAIN" | grep -F "\"$SIGN_IDENTITY\"" \
+          # codesign --keychain restricts lookup to that single file, which
+          # hides Apple's Developer ID intermediate certificates in the
+          # runner's existing keychains. Add our temporary keychain to the
+          # normal search list instead, then prove the exact identity resolves
+          # through the same search path codesign will use.
+          security list-keychains -d user -s "$KEYCHAIN" "${ORIGINAL_KEYCHAINS[@]}"
+          security find-identity -v -p codesigning | grep -F "\"$SIGN_IDENTITY\"" \
             || { echo "::error::Imported keychain does not contain $SIGN_IDENTITY"; exit 1; }
-          CODESIGN_KEYCHAIN="$KEYCHAIN" bash scripts/sign-macos-app.sh \
+          bash scripts/sign-macos-app.sh \
             "$APP" "$SIGN_IDENTITY" developer-id macos/Resources/Burrow.entitlements
           codesign -d --verbose=4 "$APP" 2>&1 \
             | grep -E '^(Authority=Developer ID Application:|TeamIdentifier=|Timestamp=|Runtime Version=)'

--- a/scripts/sign-macos-app.sh
+++ b/scripts/sign-macos-app.sh
@@ -38,11 +38,6 @@ case "$MODE" in
       exit 1
     fi
     SIGN_ARGS=(--force --options runtime --timestamp --sign "$IDENTITY")
-    if [ -n "${CODESIGN_KEYCHAIN:-}" ]; then
-      [ -f "$CODESIGN_KEYCHAIN" ] \
-        || { echo "error: signing keychain not found: $CODESIGN_KEYCHAIN" >&2; exit 1; }
-      SIGN_ARGS+=(--keychain "$CODESIGN_KEYCHAIN")
-    fi
     ;;
   adhoc)
     [ "$IDENTITY" = "-" ] || { echo "error: ad-hoc mode requires identity '-'" >&2; exit 1; }


### PR DESCRIPTION
## Summary

- fix Developer ID signing after the certificate imported as a valid identity but `codesign` could not resolve it
- prepend the temporary signing keychain to the runner's existing search list instead of restricting `codesign` to that single file
- capture, validate, and restore the original search list on every exit, including a genuinely empty list

The failure occurred in [release run 30651791681](https://github.com/caezium/Burrow/actions/runs/30651791681), after the Release build and safety checks passed but before notarization or publication. Apple documents that `codesign --keychain` searches only the specified file, while omitting it uses the normal keychain search path: [TN3161](https://developer.apple.com/documentation/technotes/tn3161-inside-code-signing-certificates).

## Changes

- fail before mutation if the runner's original keychain search list cannot be captured or parsed
- prepend the temporary keychain while retaining the runner's existing keychains and Apple certificate chain
- validate the exact configured Developer ID identity through the same search path used by `codesign`
- restore the verified original list before deleting the temporary keychain
- remove the signing helper's single-keychain restriction

## Test plan

- [x] `actionlint` passes for the release workflow
- [x] `shellcheck` and Bash syntax checks pass
- [x] all eight release-safety helper tests pass
- [x] Greenlight remains GREENLIT from the preceding release recovery validation
- [x] independent standards and release-spec reviews pass with no remaining findings

## Release recovery

The failed run created no GitHub release, draft, assets, or Homebrew mutation. After this merges, `v0.11.0` will be moved from the failed commit to this merge commit and the full fail-closed release will run again.
