### PR TITLE
fix(release): retain delayed notarization status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,9 @@ jobs:
   release:
     runs-on: macos-15
     # The build is capped at 38 minutes and Apple's synchronous notarization
-    # wait at 30 minutes, so the job cap must leave room for both plus packaging.
-    timeout-minutes: 75
+    # wait at 60 minutes. Keep bounded headroom for setup, signing, stapling,
+    # packaging, publication, and the external tap update.
+    timeout-minutes: 120
     steps:
       # Pinned to a commit SHA, not a floating tag: this job holds
       # contents:write, the signing cert, and TAP_PAT, so a moved tag must
@@ -353,20 +354,44 @@ jobs:
           set +e
           xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
             --key "$RUNNER_TEMP/ac_key.p8" --key-id "$AC_KEY_ID" --issuer "$AC_ISSUER_ID" \
-            --wait --timeout 30m --output-format json > "$RUNNER_TEMP/notary-result.json"
+            --wait --timeout 60m --output-format json \
+            > "$RUNNER_TEMP/notary-result.json" 2>&1
           NOTARY_EXIT=$?
           set -e
           cat "$RUNNER_TEMP/notary-result.json"
-          SUBMISSION_ID="$(jq -r '.id // empty' "$RUNNER_TEMP/notary-result.json")"
-          STATUS="$(jq -r '.status // empty' "$RUNNER_TEMP/notary-result.json")"
-          if [ "$NOTARY_EXIT" -ne 0 ] || [ "$STATUS" != "Accepted" ]; then
-            if [ -n "$SUBMISSION_ID" ]; then
+          # notarytool writes its timeout JSON to stderr, so capture both
+          # streams above. A timeout response still carries the submission ID;
+          # retain it and make one authoritative status query to cover a race
+          # where Apple accepts just as the local wait expires.
+          SUBMISSION_ID="$(
+            jq -r '.id // empty' "$RUNNER_TEMP/notary-result.json" 2>/dev/null || true
+          )"
+          STATUS="$(
+            jq -r '.status // empty' "$RUNNER_TEMP/notary-result.json" 2>/dev/null || true
+          )"
+          if [ -n "$SUBMISSION_ID" ] && [ "$STATUS" != "Accepted" ]; then
+            set +e
+            xcrun notarytool info "$SUBMISSION_ID" \
+              --key "$RUNNER_TEMP/ac_key.p8" --key-id "$AC_KEY_ID" --issuer "$AC_ISSUER_ID" \
+              --output-format json > "$RUNNER_TEMP/notary-info.json" 2>&1
+            INFO_EXIT=$?
+            set -e
+            cat "$RUNNER_TEMP/notary-info.json"
+            if [ "$INFO_EXIT" -eq 0 ]; then
+              INFO_STATUS="$(
+                jq -r '.status // empty' "$RUNNER_TEMP/notary-info.json" 2>/dev/null || true
+              )"
+              [ -n "$INFO_STATUS" ] && STATUS="$INFO_STATUS"
+            fi
+          fi
+          if [ -z "$SUBMISSION_ID" ] || [ "$STATUS" != "Accepted" ]; then
+            if [ -n "$SUBMISSION_ID" ] && [ "$STATUS" != "In Progress" ]; then
               xcrun notarytool log "$SUBMISSION_ID" \
                 --key "$RUNNER_TEMP/ac_key.p8" --key-id "$AC_KEY_ID" --issuer "$AC_ISSUER_ID" \
                 "$RUNNER_TEMP/notary-log.json" || true
               [ -f "$RUNNER_TEMP/notary-log.json" ] && cat "$RUNNER_TEMP/notary-log.json"
             fi
-            echo "::error::Notarization failed (status=${STATUS:-unknown}, submission=${SUBMISSION_ID:-unknown})."
+            echo "::error::Notarization blocked (status=${STATUS:-unknown}, submission=${SUBMISSION_ID:-unknown}, command_exit=$NOTARY_EXIT)."
             exit 1
           fi
           xcrun stapler staple "$APP"

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -180,6 +180,13 @@ The workflow order is:
    quarantine bypass and unsigned warning only after the verified artifact
    exists.
 
+CI waits up to 60 minutes for Apple and preserves the submission ID even when
+that wait expires. A timeout still blocks stapling, packaging, the GitHub
+release, and the tap update. Query the existing ID with `notarytool info`
+instead of submitting a duplicate; a failed runner cannot resume its discarded
+build, so create one fresh release build only after the existing submission
+reaches a terminal state.
+
 Download the release asset and verify the distributed copy:
 
 ```bash


### PR DESCRIPTION
## Summary

- capture both `notarytool` output streams so timeout responses retain Apple's submission ID
- extend the synchronous Apple wait from 30 to 60 minutes and the bounded release-job ceiling to 120 minutes
- query the captured submission once after a non-`Accepted` result to cover a timeout/acceptance race
- require both an exact `Accepted` status and a non-empty submission ID before stapling or publishing
- document the no-duplicate recovery path for delayed submissions

## Incident

Release run [30653310703](https://github.com/caezium/Burrow/actions/runs/30653310703) passed Developer ID signing, then timed out after 30 minutes. Apple emitted the timeout response and submission ID on stderr, while the workflow captured only stdout and reported both fields as unknown. The workflow correctly published nothing. Apple later reported submission `2f07b2db-d142-456b-b8e6-34149a0d2171` as `Accepted`.

## Changes

- `.github/workflows/release.yml`: captures timeout JSON, preserves and rechecks the submission ID, keeps all unknown/in-progress/rejected paths fail-closed, and gives the existing 38-minute build cap plus the 60-minute Apple wait bounded headroom.
- `docs/macos-signing.md`: explains how to query a delayed submission without creating a duplicate and why a failed runner needs one fresh build after the existing submission reaches a terminal state.

## Usage

No product-facing usage changes. Release publication still requires Developer ID signing, Apple acceptance, ticket stapling, Gatekeeper assessment, signed Sparkle artifacts, and the existing publication gates.

## Test plan

- [x] `actionlint -shellcheck shellcheck .github/workflows/release.yml`
- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` — 8 passed
- [x] `git diff --check origin/main...HEAD`
- [x] Greenlight preflight on an exact clean archive — GREENLIT, zero findings
- [x] two-axis code review — Standards: 0 findings; Spec: 0 findings
