### PR TITLE
ci: fail fast on Homebrew tap credential failures

### DIFF
--- a/.github/workflows/homebrew-tap-credential-check.yml
+++ b/.github/workflows/homebrew-tap-credential-check.yml
@@ -1,0 +1,19 @@
+name: Homebrew tap credential check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Pin checkout because this workflow receives the external-tap token.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Verify Homebrew tap write access
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PAT }}
+        run: bash scripts/verify-homebrew-tap-access.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ name: release
 # the Homebrew cask in caezium/homebrew-tap so `brew upgrade --cask
 # caezium/tap/burrow` picks it up. Pushing ordinary commits to main does NOT
 # touch the tap — only a tag. Releases fail closed when any signing or
-# notarization credential is absent.
+# notarization credential is absent, or when the external-tap token cannot
+# write its target repository.
 #
 # Required secrets:
 #   MACOS_CERT_P12        base64 of a "Developer ID Application" .p12
@@ -87,6 +88,11 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Verify Homebrew tap write access
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PAT }}
+        run: bash scripts/verify-homebrew-tap-access.sh
 
       # Fetch the bundled MIT engine OUTSIDE the work tree (RUNNER_TEMP), at its
       # pinned submodule commit. (This once looked like it hung SPM — the real
@@ -485,82 +491,13 @@ jobs:
           SHA="${{ steps.pkg.outputs.sha }}"
           gh auth setup-git
           git clone "https://github.com/caezium/homebrew-tap.git" tap
-          CASK="tap/Casks/burrow.rb"
-          /usr/bin/sed -i '' -E \
-            -e "s/version \"[^\"]+\"/version \"${VERSION}\"/" \
-            -e "s/sha256 \"[^\"]+\"/sha256 \"${SHA}\"/" \
-            "$CASK"
-          # This step only runs after Developer ID signing, accepted
-          # notarization, stapling, and Gatekeeper assessment. Remove the
-          # legacy quarantine bypass now that preserving quarantine is what
-          # lets Gatekeeper validate the notarization ticket.
-          ruby <<'RUBY'
-          cask_path = "tap/Casks/burrow.rb"
-          cask = File.read(cask_path)
-          unless cask.match?(/^\s*auto_updates true\s*$/)
-            changed = cask.sub!(/^(\s*version "[^"]+"\s*\n)/, "\\1  auto_updates true\n")
-            abort "Burrow cask has no version line for auto_updates" unless changed
-          end
-          legacy = <<'LEGACY'
-            # Pre-1.0 builds aren't notarized yet, so clear the quarantine flag to
-            # avoid a Gatekeeper block on first launch. Remove this once the app
-            # ships signed + notarized.
-            postflight do
-              system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Burrow.app"], sudo: false
-            end
-
-            caveats <<~EOS
-              Burrow is an unsigned pre-1.0 build. If macOS still blocks it, right-click
-              the app and choose Open, or run:  xattr -cr "#{appdir}/Burrow.app"
-            EOS
-
-          LEGACY
-          if cask.include?(legacy)
-            File.write(cask_path, cask.sub(legacy, ""))
-          elsif cask.match?(/xattr.*-cr|Burrow is an unsigned pre-1\.0 build/)
-            abort "Burrow cask security block has drifted; remove it deliberately"
-          end
-
-          path = "tap/README.md"
-          text = File.read(path)
-          old = <<~'OLD'
-            - These are currently self-signed pre-1.0 builds (not yet notarized), so the
-              casks clear the Gatekeeper quarantine flag automatically on install. If macOS
-              still blocks an app, right-click it and choose **Open**.
-          OLD
-          replacement = <<~'NEW'
-            - Burrow's current cask is Developer ID signed and notarized. It preserves
-              quarantine so Gatekeeper can validate Apple's notarization ticket.
-            - Wisp and Nib are currently self-signed pre-1.0 builds, so their casks clear
-              quarantine automatically. If macOS still blocks either app, right-click it
-              and choose **Open**.
-          NEW
-          if text.include?(old)
-            File.write(path, text.sub(old, replacement))
-          elsif !text.include?("Burrow's current cask is Developer ID signed and notarized")
-            abort "tap README security note has drifted; update it deliberately"
-          end
-          RUBY
-          # Guard against a silent no-op: if the cask's format ever drifts so
-          # the sed matches nothing, the version/sha won't be present and the
-          # `git diff --quiet` below would otherwise report success while the
-          # tap stays stale. Fail loudly instead.
-          if ! grep -q "version \"${VERSION}\"" "$CASK" || ! grep -q "sha256 \"${SHA}\"" "$CASK"; then
-            echo "::error::cask edit didn't take — $CASK is missing version \"${VERSION}\" or the new sha256 after sed. Its format may have drifted; bump it by hand."
-            exit 1
-          fi
-          if grep -qE 'xattr.*-cr|unsigned pre-1\.0' "$CASK"; then
-            echo "::error::legacy Gatekeeper-bypass text remains in $CASK after notarization."
-            exit 1
-          fi
-          if ! grep -qE '^\s*auto_updates true\s*$' "$CASK"; then
-            echo "::error::Burrow cask is missing auto_updates true after enabling Sparkle."
-            exit 1
-          fi
-          if grep -qF 'These are currently self-signed pre-1.0 builds' tap/README.md; then
-            echo "::error::tap README still claims Burrow is unsigned after notarization."
-            exit 1
-          fi
+          # This runs only after signing, notarization, stapling, Gatekeeper,
+          # and Sparkle verification. The helper also normalizes
+          # auto_updates beside the homepage stanza and fails closed if the
+          # cask or its security copy has drifted.
+          python3 scripts/update-homebrew-tap.py tap \
+            --version "$VERSION" \
+            --sha256 "$SHA"
           cd tap
           if git diff --quiet; then
             echo "cask already at ${VERSION}; nothing to do"

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -153,6 +153,18 @@ gh secret list --app actions --repo caezium/Burrow \
   | grep -E '^(MACOS_|AC_API_|SPARKLE_|TAP_PAT)'
 ```
 
+After creating or rotating `TAP_PAT`, run the manual credential check before
+cutting a tag:
+
+```bash
+gh workflow run homebrew-tap-credential-check.yml --repo caezium/Burrow
+```
+
+The check reads GitHub's authenticated repository permissions and requires
+`push: true`; it does not modify the tap. The tag workflow runs the same check
+before any build, signing, or notarization work. Open the run URL printed by
+`gh` and require a successful result.
+
 After the secrets are stored, move every exported private-key file out of
 Downloads and into the password manager’s encrypted file storage. Keep tested
 backups of the `.p12` and Sparkle seed: losing either one prevents future
@@ -166,7 +178,8 @@ release has published.
 
 The workflow order is:
 
-1. Require all Apple, Sparkle, and external-tap secrets.
+1. Require all Apple, Sparkle, and external-tap secrets, then verify that
+   `TAP_PAT` can write `caezium/homebrew-tap`.
 2. Fetch and checksum-validate the official Sentry and Sparkle frameworks,
    then build and confirm the bundled conductor, engine, and fclones sidecar.
 3. Require the Sparkle private seed to match the public key embedded in the app.
@@ -176,9 +189,9 @@ The workflow order is:
 7. Package the exact verified app, generate the signed appcast, and
    cryptographically verify the ZIP and feed before publishing either asset.
 8. Keep a new release draft until both assets exist, then publish it.
-9. Update `caezium/homebrew-tap`: add `auto_updates true` and remove the legacy
-   quarantine bypass and unsigned warning only after the verified artifact
-   exists.
+9. Update `caezium/homebrew-tap`: normalize `auto_updates true` beside the
+   homepage stanza and fail if the legacy quarantine bypass, unsigned warning,
+   or stale security note ever reappears.
 
 CI waits up to 60 minutes for Apple and preserves the submission ID even when
 that wait expires. A timeout still blocks stapling, packaging, the GitHub

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    def test_tap_permission_check_runs_before_the_release_build(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+
+        require_credentials = workflow.index("- name: Require release credentials")
+        verify_tap = workflow.index("- name: Verify Homebrew tap write access")
+        build_release = workflow.index("- name: Build (Release)")
+
+        self.assertLess(require_credentials, verify_tap)
+        self.assertLess(verify_tap, build_release)
+        self.assertIn(
+            "run: bash scripts/verify-homebrew-tap-access.sh",
+            workflow[verify_tap:build_release],
+        )
+
+    def test_manual_tap_check_is_read_only_and_uses_the_same_verifier(self) -> None:
+        workflow = (WORKFLOWS / "homebrew-tap-credential-check.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertIn(
+            "run: bash scripts/verify-homebrew-tap-access.sh",
+            workflow,
+        )
+        self.assertNotIn("git push", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_update_homebrew_tap.py
+++ b/scripts/tests/test_update_homebrew_tap.py
@@ -1,0 +1,218 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATER = ROOT / "scripts" / "update-homebrew-tap.py"
+OLD_SHA = "b" * 64
+NEW_SHA = "a" * 64
+CURRENT_README = "Burrow's current cask is Developer ID signed and notarized.\n"
+OLD_README_NOTE = """- These are currently self-signed pre-1.0 builds (not yet notarized), so the
+  casks clear the Gatekeeper quarantine flag automatically on install. If macOS
+  still blocks an app, right-click it and choose **Open**.
+"""
+CURRENT_CASK = f'''cask "burrow" do
+  version "0.11.0"
+  sha256 "{OLD_SHA}"
+  homepage "https://github.com/caezium/Burrow"
+
+  auto_updates true
+
+  app "Burrow.app"
+end
+'''
+CASK_WITHOUT_AUTO_UPDATES = f'''cask "burrow" do
+  version "0.11.0"
+  sha256 "{OLD_SHA}"
+
+  url "https://github.com/caezium/Burrow/releases/download/v#{{version}}/Burrow-#{{version}}.zip"
+  name "Burrow"
+  desc "Free, open-source native GUI for the Mole CLI"
+  homepage "https://github.com/caezium/Burrow"
+
+  depends_on macos: :sonoma
+  app "Burrow.app"
+end
+'''
+LEGACY_CASK_BLOCK = """  # Pre-1.0 builds aren't notarized yet, so clear the quarantine flag to
+  # avoid a Gatekeeper block on first launch. Remove this once the app
+  # ships signed + notarized.
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Burrow.app"], sudo: false
+  end
+
+  caveats <<~EOS
+    Burrow is an unsigned pre-1.0 build. If macOS still blocks it, right-click
+    the app and choose Open, or run:  xattr -cr "#{appdir}/Burrow.app"
+  EOS
+
+"""
+
+
+class UpdateHomebrewTapTests(unittest.TestCase):
+    def make_tap(
+        self,
+        root: Path,
+        cask: str = CURRENT_CASK,
+        readme: str = CURRENT_README,
+    ) -> Path:
+        tap = root / "tap"
+        casks = tap / "Casks"
+        casks.mkdir(parents=True)
+        (casks / "burrow.rb").write_text(cask, encoding="utf-8")
+        (tap / "README.md").write_text(readme, encoding="utf-8")
+        return tap
+
+    def run_updater(
+        self,
+        tap: Path,
+        *,
+        version: str = "0.12.0",
+        sha256: str = NEW_SHA,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(UPDATER),
+                str(tap),
+                "--version",
+                version,
+                "--sha256",
+                sha256,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_rejected_without_changes(
+        self,
+        error: str,
+        *,
+        cask: str = CURRENT_CASK,
+        readme: str = CURRENT_README,
+        version: str = "0.12.0",
+        sha256: str = NEW_SHA,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            tap = self.make_tap(Path(directory), cask, readme)
+
+            result = self.run_updater(tap, version=version, sha256=sha256)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(error, result.stderr)
+            self.assertEqual(
+                (tap / "Casks" / "burrow.rb").read_text(encoding="utf-8"), cask
+            )
+            self.assertEqual((tap / "README.md").read_text(encoding="utf-8"), readme)
+
+    def test_updates_release_and_inserts_auto_updates_after_homepage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            tap = self.make_tap(Path(directory), CASK_WITHOUT_AUTO_UPDATES)
+
+            result = self.run_updater(tap)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            cask = (tap / "Casks" / "burrow.rb").read_text(encoding="utf-8")
+            self.assertIn('version "0.12.0"', cask)
+            self.assertIn(f'sha256 "{NEW_SHA}"', cask)
+            self.assertIn(
+                'homepage "https://github.com/caezium/Burrow"\n\n'
+                "  auto_updates true\n\n"
+                "  depends_on macos: :sonoma",
+                cask,
+            )
+            self.assertEqual(cask.count("auto_updates true"), 1)
+
+    def test_rejects_legacy_quarantine_bypass(self) -> None:
+        legacy_cask = CURRENT_CASK.replace("  auto_updates true\n\n", LEGACY_CASK_BLOCK)
+        self.assert_rejected_without_changes(
+            "cask security block has drifted", cask=legacy_cask
+        )
+
+    def test_moves_existing_auto_updates_to_the_homepage_stanza(self) -> None:
+        misplaced = CURRENT_CASK.replace(
+            f'  sha256 "{OLD_SHA}"\n',
+            f'  auto_updates true\n  sha256 "{OLD_SHA}"\n',
+        ).replace("\n  auto_updates true\n\n  app", "\n  app")
+        with tempfile.TemporaryDirectory() as directory:
+            tap = self.make_tap(Path(directory), misplaced)
+
+            result = self.run_updater(tap)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            cask = (tap / "Casks" / "burrow.rb").read_text(encoding="utf-8")
+            self.assertNotIn('version "0.12.0"\n  auto_updates true', cask)
+            self.assertIn(
+                'homepage "https://github.com/caezium/Burrow"\n\n'
+                "  auto_updates true\n\n"
+                '  app "Burrow.app"',
+                cask,
+            )
+
+    def test_rejects_invalid_sha(self) -> None:
+        self.assert_rejected_without_changes(
+            "sha256 must be 64 lowercase hexadecimal characters",
+            sha256="not-a-sha",
+        )
+
+    def test_rejects_invalid_version(self) -> None:
+        self.assert_rejected_without_changes(
+            "version must be a semantic release version",
+            version='0.12.0"\n  postflight do',
+        )
+
+    def test_rejects_ambiguous_cask_fields(self) -> None:
+        ambiguous = CURRENT_CASK.replace(
+            '  version "0.11.0"',
+            '  version "0.11.0"\n  version "unexpected-second-version"',
+        )
+        self.assert_rejected_without_changes(
+            "expected exactly one version line", cask=ambiguous
+        )
+
+    def test_readme_drift_fails_before_writing_the_cask(self) -> None:
+        self.assert_rejected_without_changes(
+            "tap README security note has drifted", readme="unknown security copy\n"
+        )
+
+    def test_keeps_an_already_correct_auto_updates_stanza_stable(self) -> None:
+        cask_with_comment = CURRENT_CASK.replace(
+            '  app "Burrow.app"',
+            '  # Keep this comment directly below the stanza.\n  app "Burrow.app"',
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            tap = self.make_tap(Path(directory), cask_with_comment)
+
+            result = self.run_updater(tap)
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            cask = (tap / "Casks" / "burrow.rb").read_text(encoding="utf-8")
+            self.assertIn(
+                "  auto_updates true\n\n"
+                "  # Keep this comment directly below the stanza.",
+                cask,
+            )
+            self.assertNotIn("  auto_updates true\n\n\n", cask)
+
+    def test_rejects_remaining_legacy_cask_security_copy(self) -> None:
+        stale = CURRENT_CASK.replace(
+            "  auto_updates true\n\n",
+            LEGACY_CASK_BLOCK
+            + "  # Burrow is an unsigned pre-1.0 build (stale duplicate).\n",
+        )
+        self.assert_rejected_without_changes(
+            "cask security block has drifted", cask=stale
+        )
+
+    def test_rejects_stale_readme_security_copy(self) -> None:
+        self.assert_rejected_without_changes(
+            "tap README security note has drifted",
+            readme=OLD_README_NOTE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_verify_homebrew_tap_access.py
+++ b/scripts/tests/test_verify_homebrew_tap_access.py
@@ -1,0 +1,92 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VERIFIER = ROOT / "scripts" / "verify-homebrew-tap-access.sh"
+
+
+class VerifyHomebrewTapAccessTests(unittest.TestCase):
+    def run_verifier(
+        self,
+        gh_body: str,
+        *,
+        token: str | None = "test-token",
+    ) -> tuple[subprocess.CompletedProcess[str], str | None]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            call_log = root / "gh-call.txt"
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f'#!/bin/bash\nprintf \'%s\\n\' "$*" > "$GH_CALL_LOG"\n{gh_body}\n',
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = os.environ.copy()
+            env.pop("GH_TOKEN", None)
+            env.pop("GITHUB_TOKEN", None)
+            env.update(
+                {
+                    "GH_CALL_LOG": str(call_log),
+                    "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+                }
+            )
+            if token is not None:
+                env["GH_TOKEN"] = token
+
+            result = subprocess.run(
+                ["bash", str(VERIFIER)],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            call = (
+                call_log.read_text(encoding="utf-8").strip()
+                if call_log.exists()
+                else None
+            )
+            return result, call
+
+    def test_accepts_token_with_push_access(self) -> None:
+        result, call = self.run_verifier("printf 'true\\n'")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Homebrew tap write access verified", result.stdout)
+        self.assertEqual(
+            call,
+            "api repos/caezium/homebrew-tap --jq .permissions.push",
+        )
+
+    def test_rejects_missing_token_before_calling_github(self) -> None:
+        result, call = self.run_verifier("printf 'true\\n'", token=None)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("TAP_PAT is missing", result.stderr)
+        self.assertIsNone(call)
+
+    def test_rejects_token_without_push_access(self) -> None:
+        result, _ = self.run_verifier("printf 'false\\n'")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "TAP_PAT cannot push to caezium/homebrew-tap",
+            result.stderr,
+        )
+
+    def test_reports_github_api_failure(self) -> None:
+        result, _ = self.run_verifier("echo 'HTTP 403' >&2\nexit 1")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Unable to verify TAP_PAT access to caezium/homebrew-tap",
+            result.stderr,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update-homebrew-tap.py
+++ b/scripts/update-homebrew-tap.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Update Burrow's external Homebrew tap after a verified release."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+class UpdateError(Exception):
+    pass
+
+
+def replace_one(text: str, pattern: str, replacement: str, label: str) -> str:
+    count = len(re.findall(pattern, text, flags=re.MULTILINE))
+    if count != 1:
+        raise UpdateError(
+            f"expected exactly one {label} line in the Burrow cask, found {count}"
+        )
+    return re.sub(pattern, replacement, text, count=1, flags=re.MULTILINE)
+
+
+def update_cask(text: str, version: str, sha256: str) -> str:
+    text = replace_one(
+        text,
+        r'^  version "[^"]+"$',
+        f'  version "{version}"',
+        "version",
+    )
+    text = replace_one(
+        text,
+        r'^  sha256 "[^"]+"$',
+        f'  sha256 "{sha256}"',
+        "sha256",
+    )
+
+    auto_updates_count = len(
+        re.findall(r"^  auto_updates true$", text, flags=re.MULTILINE)
+    )
+    if auto_updates_count > 1:
+        raise UpdateError("Burrow cask must contain exactly one auto_updates true line")
+    if auto_updates_count == 1:
+        text = re.sub(
+            r"^  auto_updates true$(?:\n\n?)?",
+            "",
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    text = replace_one(
+        text,
+        r'^(  homepage "[^"]+"\n)',
+        r"\1\n  auto_updates true\n",
+        "homepage",
+    )
+
+    if re.search(r"xattr.*-cr|Burrow is an unsigned pre-1\.0 build", text):
+        raise UpdateError(
+            "Burrow cask security block has drifted; remove it deliberately"
+        )
+    return text
+
+
+def validate_readme(text: str) -> None:
+    has_current_note = (
+        "Burrow's current cask is Developer ID signed and notarized" in text
+    )
+    has_stale_note = "These are currently self-signed pre-1.0 builds" in text
+    if not has_current_note or has_stale_note:
+        raise UpdateError(
+            "tap README security note has drifted; update it deliberately"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("tap", type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--sha256", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cask_path = args.tap / "Casks" / "burrow.rb"
+    readme_path = args.tap / "README.md"
+    try:
+        if re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", args.version) is None:
+            raise UpdateError(
+                "version must be a semantic release version (for example, 0.12.0)"
+            )
+        if re.fullmatch(r"[0-9a-f]{64}", args.sha256) is None:
+            raise UpdateError("sha256 must be 64 lowercase hexadecimal characters")
+        cask = update_cask(
+            cask_path.read_text(encoding="utf-8"), args.version, args.sha256
+        )
+        validate_readme(readme_path.read_text(encoding="utf-8"))
+        cask_path.write_text(cask, encoding="utf-8")
+    except (OSError, UpdateError) as error:
+        print(f"Homebrew tap update failed: {error}", file=sys.stderr)
+        return 1
+    print(f"Prepared Homebrew tap for Burrow {args.version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-homebrew-tap-access.sh
+++ b/scripts/verify-homebrew-tap-access.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "::error::TAP_PAT is missing; Homebrew publication cannot be verified." >&2
+  exit 1
+fi
+
+if ! permission="$(
+  gh api repos/caezium/homebrew-tap --jq '.permissions.push'
+)"; then
+  echo "::error::Unable to verify TAP_PAT access to caezium/homebrew-tap." >&2
+  exit 1
+fi
+
+if [ "$permission" != "true" ]; then
+  echo "::error::TAP_PAT cannot push to caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
+  exit 1
+fi
+
+echo "Homebrew tap write access verified."


### PR DESCRIPTION
## Summary

- verify that TAP_PAT can push to caezium/homebrew-tap before any release build, signing, or notarization work begins
- add a manual, non-mutating workflow for checking the stored credential during rotations
- replace the inline tap rewrite with a tested updater that normalizes auto_updates placement and rejects stale unsigned/quarantine-bypass copy
- document the credential check and fail-closed release order

## Validation

- 24 release-helper unit tests
- actionlint
- shellcheck
- ruff check and format check
- git diff --check
- Greenlight preflight: GREENLIT
- live tap updater rehearsal against the current v0.11.0 cask: idempotent

The local Swift suite compiled and ran successfully through many tests, but the existing SystemProcessPortTests.testTimeoutKillsTheChild test hung in the local Xcode runner. This change does not touch that code; clean macOS PR CI remains authoritative.