### PR TITLE
release(macos): prepare 0.11.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,45 +1,54 @@
 <!-- Latest release ONLY. This file is the GitHub release body (release.yml --notes-file), so it must contain just the newest version. OVERWRITE it each release; do not accumulate. Full prose history lives in docs/releases.json → docs/releases.html (the site Releases page). -->
 
-# Burrow 0.11.0
+# Burrow 0.11.1
 
-Burrow's first Developer ID signed and Apple-notarized release. Gatekeeper can
-verify the app before first launch, and official tags now fail closed instead
-of publishing an unsigned or un-notarized build.
+A guarded-startup and diagnostics patch for the system-wide input freeze
+reported on macOS 27 Beta 4. This release reduces the risky launch surface on
+the affected build and records enough redacted state to isolate any remaining
+failure without collecting screen contents or user files.
 
-> Upgrading from 0.10.5 or earlier changes Burrow from an ad-hoc identity to a
-> stable Developer ID identity. macOS may ask you to grant Full Disk Access one
-> final time; subsequent signed updates keep the same identity.
+> **Affected macOS 27 beta users:** please install 0.11.1 and report the result
+> in [#319](https://github.com/caezium/Burrow/issues/319). The issue remains open
+> until the notarized release is verified on a Mac that reproduced the freeze.
+
+## Fixed
+- **The affected macOS 27 beta gets a safer launch path.** On Beta 4 build
+  `26A5388g`, Burrow starts with a Dock icon instead of creating its menu-bar
+  status item. The fallback is deliberately limited to that exact build and is
+  retried after either Burrow or macOS changes. Manual update checks remain
+  available even when automatic Sparkle startup is paused.
+- **Interrupted launches recover one component at a time.** A durable launch
+  journal gives the status item and Sparkle separate 30-second stability
+  windows. If launch is interrupted, the next run suppresses only the component
+  whose window was active, shows a recovery alert, and offers a one-click
+  redacted diagnostic report. ([#321](https://github.com/caezium/Burrow/pull/321))
 
 ## Improved
-- **Official downloads are trusted by Gatekeeper.** The app and every bundled
-  executable carry a Developer ID signature, hardened runtime, secure
-  timestamp, and a stapled Apple notarization ticket. Direct-download users no
-  longer need to strip quarantine or use the right-click Open workaround.
-- **Full Disk Access has a stable identity.** Developer ID gives macOS one
-  consistent code identity across releases, so privacy grants can survive
-  normal updates after the one-time transition from an older ad-hoc build.
-- **Privacy disclosures match the app.** The bundled privacy manifest declares
-  Product Interaction, Other Usage, Crash, Performance, and Other Diagnostic
-  data as unlinked and non-tracking. Analytics and crash reporting remain
-  opt-out, and signing adds no telemetry.
-- **Updates stay inside the trusted release chain.** Burrow now uses Sparkle's
-  native UI. Automatic checks remain on by default, but downloads and installs
-  always wait for approval. Both `Burrow-0.11.0.zip` and `appcast.xml` carry
-  Ed25519 signatures that are verified before publication and again on-device.
-  This release proves that foundation; the first live 0.11-to-successor update
-  remains tracked in [#281](https://github.com/caezium/Burrow/issues/281).
-- **The bundled engine no longer rewrites the app.** It updates only with a
-  signed Burrow release, preserving the Developer ID resource seal. Source
-  builds using an external engine still expose its manual updater.
+- **Sentry can now explain hangs that never become crashes.** Release-health
+  sessions, hang tracking, low-memory context, fixed-name sampled performance
+  spans, and coarse launch/updater state cover the failure modes that a normal
+  crash report misses. Outbound data is scrubbed fail closed, with no
+  screenshots, view hierarchies, user paths, URLs, request bodies, or automatic
+  UI, file, database, and network tracing.
+- **PostHog analytics no longer bring an AppKit-facing SDK into startup.** Burrow
+  still sends the same opt-out semantic product, screen, and operation events to
+  PostHog, but a small background HTTPS transport replaces `posthog-ios`. It has
+  a bounded serialized retry queue and no session replay, autocapture, remote
+  feature flags, AppKit timer, or main-thread disk I/O. Existing 0.11.0 anonymous
+  identities are migrated once so release-to-release funnels remain accurate.
+- **The first signed Sparkle successor is ready to test.** This is the first
+  update after 0.11.0, so it exercises the complete signed in-app update path
+  tracked in [#281](https://github.com/caezium/Burrow/issues/281). The issue stays
+  open until a real 0.11.0-to-0.11.1 update succeeds.
+
+## Privacy
+- **Telemetry remains optional, unlinked, and non-tracking.** One Settings
+  switch disables both PostHog analytics and Sentry diagnostics. The privacy
+  manifest continues to declare Product Interaction, Other Usage, Crash,
+  Performance, and Other Diagnostic data; this release adds no signing-specific
+  telemetry and records no screen content.
 
 ## Security
-- **A tag cannot publish a partially trusted build.** The release stops before
-  publication unless signing, notarization, ticket stapling, strict code-sign
-  verification, Gatekeeper assessment, the Sparkle keypair match, and both
-  update signatures all succeed. A new release remains a draft until both
-  assets upload; a mismatched rerun fails signature validation closed.
-- **Homebrew preserves Apple's security checks.** Only after the notarized
-  artifact passes every gate does the workflow remove Burrow's legacy
-  quarantine bypass and unsigned warning from the live cask; it also marks the
-  cask `auto_updates true` because Sparkle owns future in-app updates.
-  ([#312](https://github.com/caezium/Burrow/pull/312))
+- **The release chain remains fail closed.** The tag cannot publish unless the
+  app is Developer ID signed, notarized, stapled, accepted by Gatekeeper, and
+  both the update archive and appcast pass Sparkle signature verification.

--- a/docs/index.html
+++ b/docs/index.html
@@ -323,7 +323,7 @@
 
   <!-- ===== HERO ===== -->
   <header class="hero">
-    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.11.0</span>
+    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.11.1</span>
     <h1>Burrow
       <svg class="mark" viewBox="0 0 100 100" aria-hidden="true"><path d="M14 74 a36 36 0 0 1 72 0 Z" fill="#F3ECDD"/><rect x="38" y="74" width="24" height="7" rx="3.5" fill="#121217"/></svg>
     </h1>
@@ -389,31 +389,31 @@
     <div class="sec-head wn-head">
       <div>
         <span class="sec-num">What's new · August 2026</span>
-        <h2 class="sec-title">New in 0.11.0</h2>
+        <h2 class="sec-title">New in 0.11.1</h2>
       </div>
       <a class="btn btn-out btn-sm" href="releases.html">All releases</a>
     </div>
 
     <div class="grid3 wn-grid">
       <article class="tcard" style="--c: var(--green)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Trusted by Gatekeeper</div></div>
-        <p class="ds">The app and every bundled executable carry a Developer ID signature, hardened runtime, secure timestamp, and stapled Apple notarization ticket.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Safer on the affected macOS beta</div></div>
+        <p class="ds">On macOS 27 Beta 4 build <code>26A5388g</code>, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; normal behavior is retried after Burrow or macOS changes.</p>
       </article>
       <article class="tcard" style="--c: var(--azure)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 9.5A8 8 0 0120 12"/><path d="M7 12a5 5 0 0110 0c0 3-1 6-2.5 8"/><path d="M12 12c0 3-.6 5.5-1.8 7.6"/></svg></div><div class="nm">Full Disk Access keeps its identity</div></div>
-        <p class="ds">Burrow now has one stable Team ID across releases, so macOS privacy grants can survive normal updates after the one-time move from an ad-hoc build.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5-7 4 14 2.5-7h5"/></svg></div><div class="nm">Startup tells us where it stopped</div></div>
+        <p class="ds">A durable launch journal isolates the status item and Sparkle behind separate stability windows, then suppresses only the component implicated by an interrupted launch.</p>
       </article>
       <article class="tcard" style="--c: var(--lilac)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l1.8 4.6L18 10l-4.2 1.4L12 16l-1.8-4.6L6 10l4.2-1.4z"/><path d="M18.5 15.5l.9 2.1 2.1.9-2.1.9-.9 2.1-.9-2.1-2.1-.9 2.1-.9z"/></svg></div><div class="nm">Signed update foundation</div></div>
-        <p class="ds">Sparkle checks a signed feed and verifies every update archive, then waits for approval. The first live 0.11-to-successor upgrade remains tracked in <a href="https://github.com/caezium/Burrow/issues/281" target="_blank" rel="noopener">#281</a>.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 9.5A8 8 0 0120 12"/><path d="M7 12a5 5 0 0110 0c0 3-1 6-2.5 8"/><path d="M12 12c0 3-.6 5.5-1.8 7.6"/></svg></div><div class="nm">Useful diagnostics, tighter privacy</div></div>
+        <p class="ds">Sentry can detect hangs and PostHog keeps semantic product analytics, while both exclude screen contents, user files, paths, replay, autocapture, and automatic UI or network tracing.</p>
       </article>
     </div>
 
-    <div class="extra-label mono">// also tightened in 0.11.0</div>
+    <div class="extra-label mono">// also tightened in 0.11.1</div>
     <div class="wn-chips">
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Official tags cannot publish unless signing, notarization, stapling, Gatekeeper, and Sparkle verification all pass</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Homebrew preserves quarantine — no <code>xattr</code> bypass or unsigned warning</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Privacy declarations are unlinked and non-tracking; opt-out analytics and crash reporting are unchanged</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Manual update checks remain available when automatic Sparkle startup is paused</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Existing PostHog anonymous identities are preserved; no session replay or autocapture</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg><a href="https://github.com/caezium/Burrow/issues/319" target="_blank" rel="noopener">#319</a> stays open until the affected macOS beta is verified</span>
     </div>
     <!-- WN:END -->
   </section>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -123,13 +123,51 @@
 <header class="hero page">
   <h1>Changelog</h1>
   <p>Every version at a glance — what it added, changed, and fixed. Full notes for each live on GitHub.</p>
-  <p class="count">21 releases · latest 0.11.0 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
+  <p class="count">22 releases · latest 0.11.1 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
 </header>
 
 <main class="page">
+    <article class="entry" id="v0.11.1">
+      <div class="ver-col">
+        <h2 class="ver">0.11.1<span class="latest">latest</span></h2>
+        <span class="date mono">Aug 3, 2026</span>
+        <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.11.1" target="_blank" rel="noopener">full notes ↗</a>
+      </div>
+      <div class="sbody">
+        <p class="lead">A guarded-startup and diagnostics patch for the system-wide input freeze reported on macOS 27 Beta 4, with a safer exact-build fallback and privacy-hardened hang telemetry.</p>
+        <div class="sblock">
+          <div class="slabel mono">fixed</div>
+          <ul class="slist">
+            <li><b>The affected macOS 27 beta gets a safer launch path.</b> On Beta 4 build <code>26A5388g</code>, Burrow starts with a Dock icon instead of creating its menu-bar status item. The fallback is limited to that exact build and is retried after either Burrow or macOS changes. Manual update checks remain available even when automatic Sparkle startup is paused.</li>
+            <li><b>Interrupted launches recover one component at a time.</b> A durable launch journal gives the status item and Sparkle separate 30-second stability windows. If launch is interrupted, the next run suppresses only the component whose window was active, shows a recovery alert, and offers a one-click redacted diagnostic report. (<a href="https://github.com/caezium/Burrow/pull/321" target="_blank" rel="noopener">#321</a>)</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">improved</div>
+          <ul class="slist">
+            <li><b>Sentry can now explain hangs that never become crashes.</b> Release-health sessions, hang tracking, low-memory context, fixed-name sampled performance spans, and coarse launch/updater state cover failure modes that a normal crash report misses. Outbound data is scrubbed fail closed, with no screenshots, view hierarchies, user paths, URLs, request bodies, or automatic UI, file, database, and network tracing.</li>
+            <li><b>PostHog analytics no longer bring an AppKit-facing SDK into startup.</b> Burrow still sends the same opt-out semantic product, screen, and operation events to PostHog, but a small background HTTPS transport replaces <code>posthog-ios</code>. It has a bounded serialized retry queue and no session replay, autocapture, remote feature flags, AppKit timer, or main-thread disk I/O. Existing 0.11.0 anonymous identities are migrated once so release-to-release funnels remain accurate.</li>
+            <li><b>The first signed Sparkle successor is ready to test.</b> This is the first update after 0.11.0, so it exercises the complete signed in-app update path tracked in <a href="https://github.com/caezium/Burrow/issues/281" target="_blank" rel="noopener">#281</a>. That issue stays open until a real 0.11.0-to-0.11.1 update succeeds.</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">privacy</div>
+          <ul class="slist">
+            <li><b>Telemetry remains optional, unlinked, and non-tracking.</b> One Settings switch disables both PostHog analytics and Sentry diagnostics. The privacy manifest continues to declare Product Interaction, Other Usage, Crash, Performance, and Other Diagnostic data; this release adds no signing-specific telemetry and records no screen content.</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">security</div>
+          <ul class="slist">
+            <li><b>The release chain remains fail closed.</b> The tag cannot publish unless the app is Developer ID signed, notarized, stapled, accepted by Gatekeeper, and both the update archive and appcast pass Sparkle signature verification.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
     <article class="entry" id="v0.11.0">
       <div class="ver-col">
-        <h2 class="ver">0.11.0<span class="latest">latest</span></h2>
+        <h2 class="ver">0.11.0</h2>
         <span class="date mono">Aug 1, 2026</span>
         <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.11.0" target="_blank" rel="noopener">full notes ↗</a>
       </div>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -2,6 +2,66 @@
   "_comment": "Source of truth for the site's release history. Newest first. Edit this, then run `python3 scripts/site-release.py` to regenerate the homepage 'New in X' section and releases.html. Icons/colors: run `python3 scripts/site-release.py --list-icons`.",
   "releases": [
     {
+      "version": "0.11.1",
+      "date": "2026-08-03",
+      "tag": "v0.11.1",
+      "tagline": "A guarded-startup and diagnostics patch for the system-wide input freeze reported on macOS 27 Beta 4, with a safer exact-build fallback and privacy-hardened hang telemetry.",
+      "highlights": [
+        {
+          "icon": "shield",
+          "color": "green",
+          "title": "Safer on the affected macOS beta",
+          "line": "On macOS 27 Beta 4 build `26A5388g`, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; normal behavior is retried after Burrow or macOS changes."
+        },
+        {
+          "icon": "pulse",
+          "color": "azure",
+          "title": "Startup tells us where it stopped",
+          "line": "A durable launch journal isolates the status item and Sparkle behind separate stability windows, then suppresses only the component implicated by an interrupted launch."
+        },
+        {
+          "icon": "fingerprint",
+          "color": "lilac",
+          "title": "Useful diagnostics, tighter privacy",
+          "line": "Sentry can detect hangs and PostHog keeps semantic product analytics, while both exclude screen contents, user files, paths, replay, autocapture, and automatic UI or network tracing."
+        }
+      ],
+      "chips": [
+        "Manual update checks remain available when automatic Sparkle startup is paused",
+        "Existing PostHog anonymous identities are preserved; no session replay or autocapture",
+        "[#319](https://github.com/caezium/Burrow/issues/319) stays open until the affected macOS beta is verified"
+      ],
+      "sections": [
+        {
+          "label": "fixed",
+          "items": [
+            "**The affected macOS 27 beta gets a safer launch path.** On Beta 4 build `26A5388g`, Burrow starts with a Dock icon instead of creating its menu-bar status item. The fallback is limited to that exact build and is retried after either Burrow or macOS changes. Manual update checks remain available even when automatic Sparkle startup is paused.",
+            "**Interrupted launches recover one component at a time.** A durable launch journal gives the status item and Sparkle separate 30-second stability windows. If launch is interrupted, the next run suppresses only the component whose window was active, shows a recovery alert, and offers a one-click redacted diagnostic report. ([#321](https://github.com/caezium/Burrow/pull/321))"
+          ]
+        },
+        {
+          "label": "improved",
+          "items": [
+            "**Sentry can now explain hangs that never become crashes.** Release-health sessions, hang tracking, low-memory context, fixed-name sampled performance spans, and coarse launch/updater state cover failure modes that a normal crash report misses. Outbound data is scrubbed fail closed, with no screenshots, view hierarchies, user paths, URLs, request bodies, or automatic UI, file, database, and network tracing.",
+            "**PostHog analytics no longer bring an AppKit-facing SDK into startup.** Burrow still sends the same opt-out semantic product, screen, and operation events to PostHog, but a small background HTTPS transport replaces `posthog-ios`. It has a bounded serialized retry queue and no session replay, autocapture, remote feature flags, AppKit timer, or main-thread disk I/O. Existing 0.11.0 anonymous identities are migrated once so release-to-release funnels remain accurate.",
+            "**The first signed Sparkle successor is ready to test.** This is the first update after 0.11.0, so it exercises the complete signed in-app update path tracked in [#281](https://github.com/caezium/Burrow/issues/281). That issue stays open until a real 0.11.0-to-0.11.1 update succeeds."
+          ]
+        },
+        {
+          "label": "privacy",
+          "items": [
+            "**Telemetry remains optional, unlinked, and non-tracking.** One Settings switch disables both PostHog analytics and Sentry diagnostics. The privacy manifest continues to declare Product Interaction, Other Usage, Crash, Performance, and Other Diagnostic data; this release adds no signing-specific telemetry and records no screen content."
+          ]
+        },
+        {
+          "label": "security",
+          "items": [
+            "**The release chain remains fail closed.** The tag cannot publish unless the app is Developer ID signed, notarized, stapled, accepted by Gatekeeper, and both the update archive and appcast pass Sparkle signature verification."
+          ]
+        }
+      ]
+    },
+    {
       "version": "0.11.0",
       "date": "2026-08-01",
       "tag": "v0.11.0",

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.11.1</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSUIElement</key>

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -51,8 +51,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.11.0"
-        CFBundleVersion: "21"
+        CFBundleShortVersionString: "0.11.1"
+        CFBundleVersion: "22"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Burrow uses only exempt encryption supplied by macOS (for example,
         # URLSession HTTPS); it contains no proprietary or non-exempt crypto.


### PR DESCRIPTION
## Summary

- prepare Burrow 0.11.1 / build 22 from the reviewed macOS 27 startup-recovery work in #321
- publish release notes and website history that describe the exact-build compatibility fallback, component-isolated launch recovery, and expanded privacy-hardened diagnostics
- keep #319 open until an affected macOS 27 Beta 4 user verifies the notarized build, and keep #281 open until a real Sparkle 0.11.0-to-0.11.1 update succeeds
- preserve the fail-closed Developer ID, notarization, Gatekeeper, Sparkle-signature, and Homebrew publication chain

## Changes

- `macos/project.yml` and `macos/Resources/Info.plist`: bump the marketing version to 0.11.1 and build number to 22
- `RELEASES.md`: replace the latest-release body with the guarded-startup, telemetry, privacy, and verification notes for 0.11.1
- `docs/releases.json`: add 0.11.1 as the newest release
- `docs/index.html` and `docs/releases.html`: regenerate the website from the release source of truth

## Release boundary

This PR does not create the tag. After it merges and CI is green, `v0.11.1` will be created from the resulting `main` commit. The tag workflow must sign, notarize, staple, pass Gatekeeper, verify both Sparkle signatures, publish the GitHub release, and update the Homebrew cask; any failed gate stops publication.

## Test plan

- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 25 passed
- [x] `greenlight preflight macos --exit-code` — GREENLIT, no findings
- [x] `python3 scripts/site-release.py --check`
- [x] Info.plist, privacy manifest, and both localization files pass `plutil -lint`
- [x] release metadata asserts 0.11.1 / build 22 / non-exempt encryption false
- [x] `git diff --check`
- [ ] pull-request CI
- [ ] notarized release workflow
- [ ] affected-user verification on macOS 27 Beta 4
