### PR TITLE
fix(release): verify tap token can actually push

### DIFF
--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -34,6 +34,15 @@ class ReleaseWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("git push", workflow)
 
+    def test_tap_verifier_checks_token_write_scope_without_mutating(self) -> None:
+        verifier = (ROOT / "scripts" / "verify-homebrew-tap-access.sh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('git -C "$tap_dir" push --dry-run', verifier)
+        self.assertIn("refs/heads/burrow-release-access-probe-", verifier)
+        self.assertNotIn("--jq", verifier)
+
     def test_xcode_27_preview_lane_is_advisory_and_runs_the_full_suite(self) -> None:
         workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")
         start = workflow.index("  xcode-27-compatibility:")

--- a/scripts/tests/test_verify_homebrew_tap_access.py
+++ b/scripts/tests/test_verify_homebrew_tap_access.py
@@ -12,28 +12,72 @@ VERIFIER = ROOT / "scripts" / "verify-homebrew-tap-access.sh"
 class VerifyHomebrewTapAccessTests(unittest.TestCase):
     def run_verifier(
         self,
-        gh_body: str,
         *,
         token: str | None = "test-token",
-    ) -> tuple[subprocess.CompletedProcess[str], str | None]:
+        gh_api_exit: int = 0,
+        gh_auth_exit: int = 0,
+        git_clone_exit: int = 0,
+        git_push_exit: int = 0,
+    ) -> tuple[subprocess.CompletedProcess[str], str, str]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             fake_bin = root / "bin"
             fake_bin.mkdir()
-            call_log = root / "gh-call.txt"
+            gh_call_log = root / "gh-calls.txt"
+            git_call_log = root / "git-calls.txt"
+
             fake_gh = fake_bin / "gh"
             fake_gh.write_text(
-                f'#!/bin/bash\nprintf \'%s\\n\' "$*" > "$GH_CALL_LOG"\n{gh_body}\n',
+                """#!/bin/bash
+printf '%s\\n' "$*" >> "$GH_CALL_LOG"
+if [ "$1" = "api" ]; then
+  [ "$GH_API_EXIT" -eq 0 ] || echo "HTTP 403" >&2
+  exit "$GH_API_EXIT"
+fi
+if [ "$1" = "auth" ] && [ "${2:-}" = "setup-git" ]; then
+  exit "$GH_AUTH_EXIT"
+fi
+exit 99
+""",
                 encoding="utf-8",
             )
             fake_gh.chmod(0o755)
+
+            fake_git = fake_bin / "git"
+            fake_git.write_text(
+                """#!/bin/bash
+printf '%s\\n' "$*" >> "$GIT_CALL_LOG"
+if [ "$1" = "clone" ]; then
+  [ "$GIT_CLONE_EXIT" -eq 0 ] || exit "$GIT_CLONE_EXIT"
+  destination="${!#}"
+  mkdir -p "$destination"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "${3:-}" = "push" ]; then
+  [ "$GIT_PUSH_EXIT" -eq 0 ] || echo "simulated push denial" >&2
+  exit "$GIT_PUSH_EXIT"
+fi
+exit 99
+""",
+                encoding="utf-8",
+            )
+            fake_git.chmod(0o755)
+
             env = os.environ.copy()
             env.pop("GH_TOKEN", None)
             env.pop("GITHUB_TOKEN", None)
             env.update(
                 {
-                    "GH_CALL_LOG": str(call_log),
+                    "GH_API_EXIT": str(gh_api_exit),
+                    "GH_AUTH_EXIT": str(gh_auth_exit),
+                    "GH_CALL_LOG": str(gh_call_log),
+                    "GIT_CALL_LOG": str(git_call_log),
+                    "GIT_CLONE_EXIT": str(git_clone_exit),
+                    "GIT_PUSH_EXIT": str(git_push_exit),
                     "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+                    "RUNNER_TEMP": str(root),
+                    "GITHUB_RUN_ID": "123",
+                    "GITHUB_RUN_ATTEMPT": "2",
                 }
             )
             if token is not None:
@@ -45,47 +89,72 @@ class VerifyHomebrewTapAccessTests(unittest.TestCase):
                 text=True,
                 env=env,
             )
-            call = (
-                call_log.read_text(encoding="utf-8").strip()
-                if call_log.exists()
-                else None
+            gh_calls = (
+                gh_call_log.read_text(encoding="utf-8")
+                if gh_call_log.exists()
+                else ""
             )
-            return result, call
+            git_calls = (
+                git_call_log.read_text(encoding="utf-8")
+                if git_call_log.exists()
+                else ""
+            )
+            return result, gh_calls, git_calls
 
-    def test_accepts_token_with_push_access(self) -> None:
-        result, call = self.run_verifier("printf 'true\\n'")
+    def test_accepts_token_with_actual_git_push_access(self) -> None:
+        result, gh_calls, git_calls = self.run_verifier()
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Homebrew tap write access verified", result.stdout)
         self.assertEqual(
-            call,
-            "api repos/caezium/homebrew-tap --jq .permissions.push",
+            gh_calls.splitlines(),
+            ["api repos/caezium/homebrew-tap", "auth setup-git"],
+        )
+        self.assertIn(
+            "clone --quiet --depth 1 https://github.com/caezium/homebrew-tap.git",
+            git_calls,
+        )
+        self.assertIn("push --dry-run origin", git_calls)
+        self.assertIn(
+            "HEAD:refs/heads/burrow-release-access-probe-123-2",
+            git_calls,
         )
 
     def test_rejects_missing_token_before_calling_github(self) -> None:
-        result, call = self.run_verifier("printf 'true\\n'", token=None)
+        result, gh_calls, git_calls = self.run_verifier(token=None)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TAP_PAT is missing", result.stderr)
-        self.assertIsNone(call)
+        self.assertEqual(gh_calls, "")
+        self.assertEqual(git_calls, "")
 
-    def test_rejects_token_without_push_access(self) -> None:
-        result, _ = self.run_verifier("printf 'false\\n'")
+    def test_rejects_token_that_can_read_but_cannot_push(self) -> None:
+        result, _, git_calls = self.run_verifier(git_push_exit=128)
 
         self.assertNotEqual(result.returncode, 0)
+        self.assertIn("simulated push denial", result.stderr)
         self.assertIn(
             "TAP_PAT cannot push to caezium/homebrew-tap",
             result.stderr,
         )
+        self.assertIn("push --dry-run origin", git_calls)
 
     def test_reports_github_api_failure(self) -> None:
-        result, _ = self.run_verifier("echo 'HTTP 403' >&2\nexit 1")
+        result, _, git_calls = self.run_verifier(gh_api_exit=1)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("TAP_PAT cannot read caezium/homebrew-tap", result.stderr)
+        self.assertEqual(git_calls, "")
+
+    def test_reports_git_auth_setup_failure_before_cloning(self) -> None:
+        result, _, git_calls = self.run_verifier(gh_auth_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "Unable to verify TAP_PAT access to caezium/homebrew-tap",
+            "Unable to configure Git authentication from TAP_PAT",
             result.stderr,
         )
+        self.assertEqual(git_calls, "")
 
 
 if __name__ == "__main__":

--- a/scripts/verify-homebrew-tap-access.sh
+++ b/scripts/verify-homebrew-tap-access.sh
@@ -7,16 +7,39 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
-if ! permission="$(
-  gh api repos/caezium/homebrew-tap --jq '.permissions.push'
-)"; then
-  echo "::error::Unable to verify TAP_PAT access to caezium/homebrew-tap." >&2
+if ! gh api repos/caezium/homebrew-tap >/dev/null; then
+  echo "::error::TAP_PAT cannot read caezium/homebrew-tap." >&2
   exit 1
 fi
 
-if [ "$permission" != "true" ]; then
+if ! gh auth setup-git; then
+  echo "::error::Unable to configure Git authentication from TAP_PAT." >&2
+  exit 1
+fi
+
+probe_root="$(
+  mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/burrow-tap-write.XXXXXX"
+)"
+trap 'rm -rf "$probe_root"' EXIT
+tap_dir="$probe_root/tap"
+
+if ! git clone --quiet --depth 1 \
+  https://github.com/caezium/homebrew-tap.git "$tap_dir"; then
+  echo "::error::TAP_PAT cannot clone caezium/homebrew-tap." >&2
+  exit 1
+fi
+
+# The repository API's `.permissions.push` field describes the account's role,
+# not a fine-grained token's Contents scope. Exercise the same receive-pack
+# authorization as the release's final push, but --dry-run guarantees this
+# probe creates no branch or commit on the external tap.
+probe_ref="refs/heads/burrow-release-access-probe-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
+if ! push_output="$(
+  git -C "$tap_dir" push --dry-run origin "HEAD:$probe_ref" 2>&1
+)"; then
+  printf '%s\n' "$push_output" >&2
   echo "::error::TAP_PAT cannot push to caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
   exit 1
 fi
 
-echo "Homebrew tap write access verified."
+echo "Homebrew tap write access verified with a non-mutating Git dry run."


### PR DESCRIPTION
## Summary

- replace the misleading repository-role check with a real, non-mutating Git receive-pack authorization probe
- clone the external tap with the same TAP_PAT credential path used by the release and run a dry-run Git push to a unique probe ref
- fail before the release build when a fine-grained token can read the tap but lacks Contents write permission
- add executable success, read-only-token, missing-token, API-failure, and auth-setup coverage

## Root cause

The v0.11.1 workflow's API probe returned permissions.push true because the caezium account can push to the tap, but that field does not prove the fine-grained token itself has Contents write scope. Signing, notarization, Gatekeeper, Sparkle verification, and GitHub publication passed; the final tap push then received HTTP 403. The live tap was repaired separately at caezium/homebrew-tap commit 9a2357b using the exact published archive SHA.

## Safety

The dry-run push reaches GitHub's receive-pack authorization but does not create the probe branch or any commit. A live validation confirmed the remote ref set was identical before and after the check.

## Test plan

- [x] shell syntax validation
- [x] release-workflow unit suite — 27 passed
- [x] live dry-run with a write-capable token
- [x] verify no remote probe branch was created
- [x] whitespace validation
- [ ] pull-request CI
