### PR TITLE
fix(release): verify tap token through write endpoint

### DIFF
--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -160,11 +160,13 @@ cutting a tag:
 gh workflow run homebrew-tap-credential-check.yml --repo caezium/Burrow
 ```
 
-The check clones the tap with `TAP_PAT` and performs a `git push --dry-run` to a
-unique probe ref. That reaches GitHub's real receive-pack authorization without
-creating a branch or commit; the repository API's `permissions.push` field is
-not sufficient because it describes the account's role rather than a
-fine-grained token's Contents scope. The tag workflow runs this same check
+The check reads the tap's `main` ref, then calls GitHub's write-only
+**Update a reference** endpoint with that exact same SHA. GitHub requires
+fine-grained **Contents: Read and write** permission for the endpoint, while
+the same-SHA request leaves the ref unchanged and creates no branch or commit.
+Neither the repository API's `permissions.push` field nor `git push --dry-run`
+is sufficient: the former describes the account's role and the latter sends no
+update for GitHub to authorize. The tag workflow runs the same same-SHA check
 before any build, signing, or notarization work. Open the run URL printed by
 `gh` and require a successful result.
 
@@ -243,10 +245,11 @@ signing, notarization, stapling, Gatekeeper, Sparkle verification, and GitHub
 publication, then its final tap push received HTTP 403 because the stored
 `TAP_PAT` could read the repository but lacked effective Contents write scope.
 The cask was repaired with the owner credential at tap commit
-`9a2357bf9419b9e39836cd69391dfa2a5d5bd421`; [#324](https://github.com/caezium/Burrow/pull/324)
-replaced the misleading API role check with a non-mutating Git dry-run probe.
-Replace `TAP_PAT` before the next tag and require the manual credential workflow
-to pass.
+`9a2357bf9419b9e39836cd69391dfa2a5d5bd421`. The first correction in
+[#324](https://github.com/caezium/Burrow/pull/324) proved that Git's dry run
+also returns a false positive; the current verifier uses GitHub's Contents-write
+reference endpoint while keeping `main` on its existing SHA. Replace `TAP_PAT`
+before the next tag and require the manual credential workflow to pass.
 
 A real Sparkle update then moved the installed signed app from 0.11.0 build 21
 to 0.11.1 build 22 through the native UI without Terminal or Homebrew. The app

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -34,14 +34,16 @@ class ReleaseWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("git push", workflow)
 
-    def test_tap_verifier_checks_token_write_scope_without_mutating(self) -> None:
+    def test_tap_verifier_checks_write_scope_without_moving_the_ref(self) -> None:
         verifier = (ROOT / "scripts" / "verify-homebrew-tap-access.sh").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn('git -C "$tap_dir" push --dry-run', verifier)
-        self.assertIn("refs/heads/burrow-release-access-probe-", verifier)
-        self.assertNotIn("--jq", verifier)
+        self.assertIn("gh api --method PATCH", verifier)
+        self.assertIn("git/refs/heads/main", verifier)
+        self.assertIn('-f sha="$current_sha"', verifier)
+        self.assertNotIn('git -C "$tap_dir" push --dry-run', verifier)
+        self.assertNotIn("git clone", verifier)
 
     def test_xcode_27_preview_lane_is_advisory_and_runs_the_full_suite(self) -> None:
         workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")

--- a/scripts/tests/test_verify_homebrew_tap_access.py
+++ b/scripts/tests/test_verify_homebrew_tap_access.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 VERIFIER = ROOT / "scripts" / "verify-homebrew-tap-access.sh"
+TAP_SHA = "9a2357bf9419b9e39836cd69391dfa2a5d5bd421"
 
 
 class VerifyHomebrewTapAccessTests(unittest.TestCase):
@@ -14,28 +15,29 @@ class VerifyHomebrewTapAccessTests(unittest.TestCase):
         self,
         *,
         token: str | None = "test-token",
-        gh_api_exit: int = 0,
-        gh_auth_exit: int = 0,
-        git_clone_exit: int = 0,
-        git_push_exit: int = 0,
-    ) -> tuple[subprocess.CompletedProcess[str], str, str]:
+        read_exit: int = 0,
+        write_exit: int = 0,
+        write_sha: str = TAP_SHA,
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             fake_bin = root / "bin"
             fake_bin.mkdir()
-            gh_call_log = root / "gh-calls.txt"
-            git_call_log = root / "git-calls.txt"
+            call_log = root / "gh-calls.txt"
 
             fake_gh = fake_bin / "gh"
             fake_gh.write_text(
                 """#!/bin/bash
 printf '%s\\n' "$*" >> "$GH_CALL_LOG"
-if [ "$1" = "api" ]; then
-  [ "$GH_API_EXIT" -eq 0 ] || echo "HTTP 403" >&2
-  exit "$GH_API_EXIT"
+if [[ "$*" == *"--method PATCH"* ]]; then
+  [ "$GH_WRITE_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GH_WRITE_EXIT"; }
+  printf '%s\\n' "$GH_WRITE_SHA"
+  exit 0
 fi
-if [ "$1" = "auth" ] && [ "${2:-}" = "setup-git" ]; then
-  exit "$GH_AUTH_EXIT"
+if [[ "$*" == *"git/ref/heads/main"* ]]; then
+  [ "$GH_READ_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GH_READ_EXIT"; }
+  printf '%s\\n' "$GH_READ_SHA"
+  exit 0
 fi
 exit 99
 """,
@@ -43,41 +45,17 @@ exit 99
             )
             fake_gh.chmod(0o755)
 
-            fake_git = fake_bin / "git"
-            fake_git.write_text(
-                """#!/bin/bash
-printf '%s\\n' "$*" >> "$GIT_CALL_LOG"
-if [ "$1" = "clone" ]; then
-  [ "$GIT_CLONE_EXIT" -eq 0 ] || exit "$GIT_CLONE_EXIT"
-  destination="${!#}"
-  mkdir -p "$destination"
-  exit 0
-fi
-if [ "$1" = "-C" ] && [ "${3:-}" = "push" ]; then
-  [ "$GIT_PUSH_EXIT" -eq 0 ] || echo "simulated push denial" >&2
-  exit "$GIT_PUSH_EXIT"
-fi
-exit 99
-""",
-                encoding="utf-8",
-            )
-            fake_git.chmod(0o755)
-
             env = os.environ.copy()
             env.pop("GH_TOKEN", None)
             env.pop("GITHUB_TOKEN", None)
             env.update(
                 {
-                    "GH_API_EXIT": str(gh_api_exit),
-                    "GH_AUTH_EXIT": str(gh_auth_exit),
-                    "GH_CALL_LOG": str(gh_call_log),
-                    "GIT_CALL_LOG": str(git_call_log),
-                    "GIT_CLONE_EXIT": str(git_clone_exit),
-                    "GIT_PUSH_EXIT": str(git_push_exit),
+                    "GH_CALL_LOG": str(call_log),
+                    "GH_READ_EXIT": str(read_exit),
+                    "GH_READ_SHA": TAP_SHA,
+                    "GH_WRITE_EXIT": str(write_exit),
+                    "GH_WRITE_SHA": write_sha,
                     "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
-                    "RUNNER_TEMP": str(root),
-                    "GITHUB_RUN_ID": "123",
-                    "GITHUB_RUN_ATTEMPT": "2",
                 }
             )
             if token is not None:
@@ -89,72 +67,54 @@ exit 99
                 text=True,
                 env=env,
             )
-            gh_calls = (
-                gh_call_log.read_text(encoding="utf-8")
-                if gh_call_log.exists()
+            calls = (
+                call_log.read_text(encoding="utf-8")
+                if call_log.exists()
                 else ""
             )
-            git_calls = (
-                git_call_log.read_text(encoding="utf-8")
-                if git_call_log.exists()
-                else ""
-            )
-            return result, gh_calls, git_calls
+            return result, calls
 
-    def test_accepts_token_with_actual_git_push_access(self) -> None:
-        result, gh_calls, git_calls = self.run_verifier()
+    def test_accepts_token_with_contents_write_access(self) -> None:
+        result, calls = self.run_verifier()
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("Homebrew tap write access verified", result.stdout)
-        self.assertEqual(
-            gh_calls.splitlines(),
-            ["api repos/caezium/homebrew-tap", "auth setup-git"],
-        )
-        self.assertIn(
-            "clone --quiet --depth 1 https://github.com/caezium/homebrew-tap.git",
-            git_calls,
-        )
-        self.assertIn("push --dry-run origin", git_calls)
-        self.assertIn(
-            "HEAD:refs/heads/burrow-release-access-probe-123-2",
-            git_calls,
-        )
+        self.assertIn("write access verified", result.stdout)
+        self.assertIn("git/ref/heads/main --jq .object.sha", calls)
+        self.assertIn("--method PATCH", calls)
+        self.assertIn("git/refs/heads/main", calls)
+        self.assertIn(f"-f sha={TAP_SHA}", calls)
+        self.assertIn("-F force=false", calls)
 
     def test_rejects_missing_token_before_calling_github(self) -> None:
-        result, gh_calls, git_calls = self.run_verifier(token=None)
+        result, calls = self.run_verifier(token=None)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TAP_PAT is missing", result.stderr)
-        self.assertEqual(gh_calls, "")
-        self.assertEqual(git_calls, "")
+        self.assertEqual(calls, "")
 
-    def test_rejects_token_that_can_read_but_cannot_push(self) -> None:
-        result, _, git_calls = self.run_verifier(git_push_exit=128)
+    def test_rejects_token_that_can_read_but_cannot_write(self) -> None:
+        result, calls = self.run_verifier(write_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("simulated push denial", result.stderr)
+        self.assertIn("HTTP 403", result.stderr)
         self.assertIn(
             "TAP_PAT cannot push to caezium/homebrew-tap",
             result.stderr,
         )
-        self.assertIn("push --dry-run origin", git_calls)
+        self.assertIn("--method PATCH", calls)
 
-    def test_reports_github_api_failure(self) -> None:
-        result, _, git_calls = self.run_verifier(gh_api_exit=1)
+    def test_reports_reference_read_failure(self) -> None:
+        result, calls = self.run_verifier(read_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TAP_PAT cannot read caezium/homebrew-tap", result.stderr)
-        self.assertEqual(git_calls, "")
+        self.assertNotIn("--method PATCH", calls)
 
-    def test_reports_git_auth_setup_failure_before_cloning(self) -> None:
-        result, _, git_calls = self.run_verifier(gh_auth_exit=1)
+    def test_rejects_unexpected_write_response(self) -> None:
+        result, _ = self.run_verifier(write_sha="0" * 40)
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn(
-            "Unable to configure Git authentication from TAP_PAT",
-            result.stderr,
-        )
-        self.assertEqual(git_calls, "")
+        self.assertIn("unexpected ref SHA", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/verify-homebrew-tap-access.sh
+++ b/scripts/verify-homebrew-tap-access.sh
@@ -7,39 +7,32 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
-if ! gh api repos/caezium/homebrew-tap >/dev/null; then
+if ! current_sha="$(
+  gh api repos/caezium/homebrew-tap/git/ref/heads/main --jq '.object.sha'
+)"; then
   echo "::error::TAP_PAT cannot read caezium/homebrew-tap." >&2
   exit 1
 fi
 
-if ! gh auth setup-git; then
-  echo "::error::Unable to configure Git authentication from TAP_PAT." >&2
-  exit 1
-fi
-
-probe_root="$(
-  mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/burrow-tap-write.XXXXXX"
-)"
-trap 'rm -rf "$probe_root"' EXIT
-tap_dir="$probe_root/tap"
-
-if ! git clone --quiet --depth 1 \
-  https://github.com/caezium/homebrew-tap.git "$tap_dir"; then
-  echo "::error::TAP_PAT cannot clone caezium/homebrew-tap." >&2
-  exit 1
-fi
-
 # The repository API's `.permissions.push` field describes the account's role,
-# not a fine-grained token's Contents scope. Exercise the same receive-pack
-# authorization as the release's final push, but --dry-run guarantees this
-# probe creates no branch or commit on the external tap.
-probe_ref="refs/heads/burrow-release-access-probe-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
-if ! push_output="$(
-  git -C "$tap_dir" push --dry-run origin "HEAD:$probe_ref" 2>&1
+# and `git push --dry-run` does not send an update for GitHub to authorize.
+# GitHub documents the Update a reference endpoint as requiring fine-grained
+# Contents: write. Pointing main at its exact current SHA exercises that write
+# endpoint without moving the ref, creating a commit, or triggering a release.
+if ! verified_sha="$(
+  gh api --method PATCH \
+    repos/caezium/homebrew-tap/git/refs/heads/main \
+    -f sha="$current_sha" \
+    -F force=false \
+    --jq '.object.sha'
 )"; then
-  printf '%s\n' "$push_output" >&2
   echo "::error::TAP_PAT cannot push to caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
   exit 1
 fi
 
-echo "Homebrew tap write access verified with a non-mutating Git dry run."
+if [ "$verified_sha" != "$current_sha" ]; then
+  echo "::error::Homebrew tap write probe returned an unexpected ref SHA." >&2
+  exit 1
+fi
+
+echo "Homebrew tap write access verified without moving its main ref."


### PR DESCRIPTION
## Summary

- verify `TAP_PAT` against GitHub's authenticated Update a reference endpoint
- update the tap's `main` ref to its existing SHA so the check proves Contents write access without changing repository state
- cover read failures, write denials, and unexpected responses in the release-script tests
- document why repository role metadata and `git push --dry-run` both produced false positives

## Why

The v0.11.1 release reached the final Homebrew publication step before GitHub rejected the stored token with HTTP 403. PR #324 replaced the repository-role check with `git push --dry-run`, but the manual follow-up workflow showed that Git does not send an update for GitHub to authorize during that dry run. This change exercises an actual write-only API endpoint before a tag can build, sign, notarize, or publish anything.

## Verification

- `bash -n scripts/verify-homebrew-tap-access.sh`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `git diff --check`
- live same-SHA probe with an owner token; tap `main` remained at `9a2357bf9419b9e39836cd69391dfa2a5d5bd421`
