### PR TITLE
fix(release): isolate Homebrew tap credentials

### DIFF
--- a/.github/workflows/homebrew-tap-credential-check.yml
+++ b/.github/workflows/homebrew-tap-credential-check.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       # Pin checkout because this workflow receives the external-tap token.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Verify Homebrew tap write access
         env:
           GH_TOKEN: ${{ secrets.TAP_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
       # contents:write, the signing cert, and TAP_PAT, so a moved tag must
       # not be able to run new code here. Comment keeps the version legible.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Require release credentials
         env:
@@ -186,12 +188,14 @@ jobs:
           ENGINE_PAT: ${{ secrets.ENGINE_PAT }}
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: |
-          # Let cargo read the private burrow-engine dependency during the conductor build. Set
-          # AFTER the conductor-fetch step (which clones burrow-cli unauthenticated) so this token —
-          # scoped to burrow-engine only — can't 403 that clone. No-op until the vendored burrow-cli
-          # actually carries the git dependency, so it's safe to land ahead of the submodule bump.
+          # Let cargo read the private burrow-engine dependency during the conductor build. Keep
+          # the URL rewrite in this process only: a global rewrite would make the later Homebrew
+          # push authenticate with ENGINE_PAT instead of TAP_PAT. No-op until the vendored
+          # burrow-cli actually carries the git dependency.
           if [ -n "$ENGINE_PAT" ]; then
-            git config --global url."https://x-access-token:${ENGINE_PAT}@github.com/".insteadOf "https://github.com/"
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0="url.https://x-access-token:${ENGINE_PAT}@github.com/.insteadOf"
+            export GIT_CONFIG_VALUE_0="https://github.com/"
           fi
           # Sentry and Sparkle are vendored as checksum-pinned local frameworks
           # (scripts/fetch-{sentry,sparkle}.sh), so SwiftPM has no binary
@@ -489,16 +493,21 @@ jobs:
         run: |
           VERSION="${{ steps.build.outputs.version }}"
           SHA="${{ steps.pkg.outputs.sha }}"
+          SOURCE_ROOT="$PWD"
+          TAP_DIR="$RUNNER_TEMP/homebrew-tap"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/burrow-tap-gitconfig"
+          touch "$GIT_CONFIG_GLOBAL"
           gh auth setup-git
-          git clone "https://github.com/caezium/homebrew-tap.git" tap
+          (cd "$RUNNER_TEMP" && git clone \
+            "https://github.com/caezium/homebrew-tap.git" "$TAP_DIR")
           # This runs only after signing, notarization, stapling, Gatekeeper,
           # and Sparkle verification. The helper also normalizes
           # auto_updates beside the homepage stanza and fails closed if the
           # cask or its security copy has drifted.
-          python3 scripts/update-homebrew-tap.py tap \
+          python3 "$SOURCE_ROOT/scripts/update-homebrew-tap.py" "$TAP_DIR" \
             --version "$VERSION" \
             --sha256 "$SHA"
-          cd tap
+          cd "$TAP_DIR"
           if git diff --quiet; then
             echo "cask already at ${VERSION}; nothing to do"
             exit 0

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -254,7 +254,9 @@ a same-SHA ref update both return false positives. The current verifier pushes,
 verifies, and removes a unique temporary ref through Git itself, exercising the
 release's actual authentication path. The engine rewrite is now process-scoped,
 and the tap step uses an isolated Git configuration so the two credentials
-cannot cross. Require the manual credential workflow to pass before the next
+cannot cross. The stored `TAP_PAT` then passed a
+[real Git push-and-delete credential check](https://github.com/caezium/Burrow/actions/runs/30766229249),
+so it does not need rotation. Require that manual workflow to pass before every
 tag.
 
 A real Sparkle update then moved the installed signed app from 0.11.0 build 21

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -160,15 +160,15 @@ cutting a tag:
 gh workflow run homebrew-tap-credential-check.yml --repo caezium/Burrow
 ```
 
-The check reads the tap's `main` ref, creates a uniquely named temporary ref at
-that SHA through GitHub's **Create a reference** endpoint, and immediately
-deletes it. Creating the ref requires fine-grained **Contents: Read and write**
-permission and forces GitHub to authorize a real write; a successful check
-leaves no branch or commit behind. The repository API's `permissions.push`
-field, `git push --dry-run`, and a same-SHA ref update are all insufficient
-because GitHub can accept them without authorizing a change. The tag workflow
-runs the same create-and-delete check before any build, signing, or notarization
-work. Open the run URL printed by `gh` and require a successful result.
+The check clones the tap, pushes a uniquely named temporary ref through the
+same Git transport used by the release, verifies it, and immediately deletes
+it. The real push requires effective **Contents: Read and write** permission; a
+successful check leaves no branch or commit behind. The repository API's
+`permissions.push` field, `git push --dry-run`, and a same-SHA API update are
+all insufficient because GitHub can accept them without authorizing a Git
+write. The tag workflow runs the same create-and-delete check before any build,
+signing, or notarization work. Open the run URL printed by `gh` and require a
+successful result.
 
 After the secrets are stored, move every exported private-key file out of
 Downloads and into the password manager’s encrypted file storage. Keep tested
@@ -242,16 +242,20 @@ The live `caezium/homebrew-tap` cask is 0.11.1 with the same ZIP SHA, has
 `auto_updates true`, preserves quarantine, and contains no `postflight`,
 `xattr -cr`, or unsigned-build warning. The release job passed Developer ID
 signing, notarization, stapling, Gatekeeper, Sparkle verification, and GitHub
-publication, then its final tap push received HTTP 403 because the stored
-`TAP_PAT` could read the repository but lacked effective Contents write scope.
-The cask was repaired with the owner credential at tap commit
+publication, then its final tap push received HTTP 403 because the build step's
+global GitHub URL rewrite made Git authenticate with `ENGINE_PAT` instead of
+the valid `TAP_PAT`. That engine token is deliberately scoped only to the
+private engine repository. The cask was repaired with the owner credential at
+tap commit
 `9a2357bf9419b9e39836cd69391dfa2a5d5bd421`. The first corrections in
 [#324](https://github.com/caezium/Burrow/pull/324) and
 [#326](https://github.com/caezium/Burrow/pull/326) proved that Git's dry run and
-a same-SHA ref update both return false positives. The current verifier creates
-and removes a unique temporary ref, forcing GitHub to authorize a real write.
-Replace `TAP_PAT` before the next tag and require the manual credential workflow
-to pass.
+a same-SHA ref update both return false positives. The current verifier pushes,
+verifies, and removes a unique temporary ref through Git itself, exercising the
+release's actual authentication path. The engine rewrite is now process-scoped,
+and the tap step uses an isolated Git configuration so the two credentials
+cannot cross. Require the manual credential workflow to pass before the next
+tag.
 
 A real Sparkle update then moved the installed signed app from 0.11.0 build 21
 to 0.11.1 build 22 through the native UI without Terminal or Homebrew. The app

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -160,15 +160,15 @@ cutting a tag:
 gh workflow run homebrew-tap-credential-check.yml --repo caezium/Burrow
 ```
 
-The check reads the tap's `main` ref, then calls GitHub's write-only
-**Update a reference** endpoint with that exact same SHA. GitHub requires
-fine-grained **Contents: Read and write** permission for the endpoint, while
-the same-SHA request leaves the ref unchanged and creates no branch or commit.
-Neither the repository API's `permissions.push` field nor `git push --dry-run`
-is sufficient: the former describes the account's role and the latter sends no
-update for GitHub to authorize. The tag workflow runs the same same-SHA check
-before any build, signing, or notarization work. Open the run URL printed by
-`gh` and require a successful result.
+The check reads the tap's `main` ref, creates a uniquely named temporary ref at
+that SHA through GitHub's **Create a reference** endpoint, and immediately
+deletes it. Creating the ref requires fine-grained **Contents: Read and write**
+permission and forces GitHub to authorize a real write; a successful check
+leaves no branch or commit behind. The repository API's `permissions.push`
+field, `git push --dry-run`, and a same-SHA ref update are all insufficient
+because GitHub can accept them without authorizing a change. The tag workflow
+runs the same create-and-delete check before any build, signing, or notarization
+work. Open the run URL printed by `gh` and require a successful result.
 
 After the secrets are stored, move every exported private-key file out of
 Downloads and into the password manager’s encrypted file storage. Keep tested
@@ -245,11 +245,13 @@ signing, notarization, stapling, Gatekeeper, Sparkle verification, and GitHub
 publication, then its final tap push received HTTP 403 because the stored
 `TAP_PAT` could read the repository but lacked effective Contents write scope.
 The cask was repaired with the owner credential at tap commit
-`9a2357bf9419b9e39836cd69391dfa2a5d5bd421`. The first correction in
-[#324](https://github.com/caezium/Burrow/pull/324) proved that Git's dry run
-also returns a false positive; the current verifier uses GitHub's Contents-write
-reference endpoint while keeping `main` on its existing SHA. Replace `TAP_PAT`
-before the next tag and require the manual credential workflow to pass.
+`9a2357bf9419b9e39836cd69391dfa2a5d5bd421`. The first corrections in
+[#324](https://github.com/caezium/Burrow/pull/324) and
+[#326](https://github.com/caezium/Burrow/pull/326) proved that Git's dry run and
+a same-SHA ref update both return false positives. The current verifier creates
+and removes a unique temporary ref, forcing GitHub to authorize a real write.
+Replace `TAP_PAT` before the next tag and require the manual credential workflow
+to pass.
 
 A real Sparkle update then moved the installed signed app from 0.11.0 build 21
 to 0.11.1 build 22 through the native UI without Terminal or Homebrew. The app

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -34,16 +34,17 @@ class ReleaseWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("git push", workflow)
 
-    def test_tap_verifier_checks_write_scope_without_moving_the_ref(self) -> None:
+    def test_tap_verifier_creates_and_removes_a_temporary_ref(self) -> None:
         verifier = (ROOT / "scripts" / "verify-homebrew-tap-access.sh").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("gh api --method PATCH", verifier)
-        self.assertIn("git/refs/heads/main", verifier)
+        self.assertIn("gh api --method POST", verifier)
+        self.assertIn("gh api --method DELETE", verifier)
+        self.assertIn("burrow-release-access-probe-", verifier)
+        self.assertIn('-f ref="$probe_ref"', verifier)
         self.assertIn('-f sha="$current_sha"', verifier)
-        self.assertNotIn('git -C "$tap_dir" push --dry-run', verifier)
-        self.assertNotIn("git clone", verifier)
+        self.assertNotIn("--method PATCH", verifier)
 
     def test_xcode_27_preview_lane_is_advisory_and_runs_the_full_suite(self) -> None:
         workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -21,7 +21,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
             workflow[verify_tap:build_release],
         )
 
-    def test_manual_tap_check_is_read_only_and_uses_the_same_verifier(self) -> None:
+    def test_manual_tap_check_uses_the_same_isolated_verifier(self) -> None:
         workflow = (WORKFLOWS / "homebrew-tap-credential-check.yml").read_text(
             encoding="utf-8"
         )
@@ -32,19 +32,34 @@ class ReleaseWorkflowTests(unittest.TestCase):
             "run: bash scripts/verify-homebrew-tap-access.sh",
             workflow,
         )
-        self.assertNotIn("git push", workflow)
+        self.assertIn("persist-credentials: false", workflow)
 
-    def test_tap_verifier_creates_and_removes_a_temporary_ref(self) -> None:
+    def test_tap_verifier_pushes_and_removes_a_temporary_ref(self) -> None:
         verifier = (ROOT / "scripts" / "verify-homebrew-tap-access.sh").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("gh api --method POST", verifier)
-        self.assertIn("gh api --method DELETE", verifier)
         self.assertIn("burrow-release-access-probe-", verifier)
-        self.assertIn('-f ref="$probe_ref"', verifier)
-        self.assertIn('-f sha="$current_sha"', verifier)
-        self.assertNotIn("--method PATCH", verifier)
+        self.assertIn('push --quiet origin "HEAD:$probe_ref"', verifier)
+        self.assertIn('push --quiet origin ":$probe_ref"', verifier)
+        self.assertNotIn('push --dry-run origin "HEAD:$probe_ref"', verifier)
+
+    def test_release_does_not_leak_engine_credentials_into_tap_push(self) -> None:
+        workflow = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+        tap_start = workflow.index(
+            "- name: Bump Homebrew cask in caezium/homebrew-tap"
+        )
+        tap_step = workflow[tap_start:]
+
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("export GIT_CONFIG_COUNT=1", workflow)
+        self.assertNotIn("git config --global url.", workflow)
+        self.assertIn(
+            'export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/burrow-tap-gitconfig"',
+            tap_step,
+        )
+        self.assertIn('(cd "$RUNNER_TEMP" && git clone', tap_step)
+        self.assertIn('cd "$TAP_DIR"', tap_step)
 
     def test_xcode_27_preview_lane_is_advisory_and_runs_the_full_suite(self) -> None:
         workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")

--- a/scripts/tests/test_verify_homebrew_tap_access.py
+++ b/scripts/tests/test_verify_homebrew_tap_access.py
@@ -15,43 +15,26 @@ class VerifyHomebrewTapAccessTests(unittest.TestCase):
         self,
         *,
         token: str | None = "test-token",
+        auth_exit: int = 0,
+        clone_exit: int = 0,
         create_exit: int = 0,
-        create_ref: str = "",
         delete_exit: int = 0,
-        read_exit: int = 0,
-    ) -> tuple[subprocess.CompletedProcess[str], str, bool]:
+        remote_sha: str = TAP_SHA,
+    ) -> tuple[subprocess.CompletedProcess[str], str, str, bool]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             fake_bin = root / "bin"
             fake_bin.mkdir()
-            call_log = root / "gh-calls.txt"
+            gh_call_log = root / "gh-calls.txt"
+            git_call_log = root / "git-calls.txt"
             ref_state = root / "probe-ref-exists"
 
             fake_gh = fake_bin / "gh"
             fake_gh.write_text(
                 """#!/bin/bash
 printf '%s\\n' "$*" >> "$GH_CALL_LOG"
-if [[ "$*" == *"--method POST"* ]]; then
-  [ "$GH_CREATE_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GH_CREATE_EXIT"; }
-  requested_ref=""
-  for argument in "$@"; do
-    case "$argument" in
-      ref=*) requested_ref="${argument#ref=}" ;;
-    esac
-  done
-  touch "$GH_REF_STATE"
-  printf '%s\\n' "${GH_CREATE_REF:-$requested_ref}"
-  exit 0
-fi
-if [[ "$*" == *"--method DELETE"* ]]; then
-  [ "$GH_DELETE_EXIT" -eq 0 ] || { echo "HTTP 500" >&2; exit "$GH_DELETE_EXIT"; }
-  rm -f "$GH_REF_STATE"
-  exit 0
-fi
-if [[ "$*" == *"git/ref/heads/main"* ]]; then
-  [ "$GH_READ_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GH_READ_EXIT"; }
-  printf '%s\\n' "$GH_READ_SHA"
-  exit 0
+if [ "$1" = "auth" ] && [ "${2:-}" = "setup-git" ]; then
+  exit "$GH_AUTH_EXIT"
 fi
 exit 99
 """,
@@ -59,21 +42,60 @@ exit 99
             )
             fake_gh.chmod(0o755)
 
+            fake_git = fake_bin / "git"
+            fake_git.write_text(
+                """#!/bin/bash
+printf '%s\\n' "$*" >> "$GIT_CALL_LOG"
+if [ "$1" = "clone" ]; then
+  [ "$GIT_CLONE_EXIT" -eq 0 ] || exit "$GIT_CLONE_EXIT"
+  destination="${!#}"
+  mkdir -p "$destination"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "${3:-}" = "rev-parse" ]; then
+  printf '%s\\n' "$GIT_HEAD_SHA"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "${3:-}" = "push" ]; then
+  refspec="${!#}"
+  if [[ "$refspec" == :refs/heads/* ]]; then
+    [ "$GIT_DELETE_EXIT" -eq 0 ] || { echo "HTTP 500" >&2; exit "$GIT_DELETE_EXIT"; }
+    rm -f "$GIT_REF_STATE"
+    exit 0
+  fi
+  [ "$GIT_CREATE_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GIT_CREATE_EXIT"; }
+  touch "$GIT_REF_STATE"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "${3:-}" = "ls-remote" ]; then
+  [ -f "$GIT_REF_STATE" ] || exit 2
+  printf '%s\\t%s\\n' "$GIT_REMOTE_SHA" "${!#}"
+  exit 0
+fi
+exit 99
+""",
+                encoding="utf-8",
+            )
+            fake_git.chmod(0o755)
+
             env = os.environ.copy()
             env.pop("GH_TOKEN", None)
             env.pop("GITHUB_TOKEN", None)
             env.update(
                 {
-                    "GH_CALL_LOG": str(call_log),
-                    "GH_CREATE_EXIT": str(create_exit),
-                    "GH_CREATE_REF": create_ref,
-                    "GH_DELETE_EXIT": str(delete_exit),
-                    "GH_READ_EXIT": str(read_exit),
-                    "GH_READ_SHA": TAP_SHA,
-                    "GH_REF_STATE": str(ref_state),
+                    "GH_AUTH_EXIT": str(auth_exit),
+                    "GH_CALL_LOG": str(gh_call_log),
+                    "GIT_CALL_LOG": str(git_call_log),
+                    "GIT_CLONE_EXIT": str(clone_exit),
+                    "GIT_CREATE_EXIT": str(create_exit),
+                    "GIT_DELETE_EXIT": str(delete_exit),
+                    "GIT_HEAD_SHA": TAP_SHA,
+                    "GIT_REF_STATE": str(ref_state),
+                    "GIT_REMOTE_SHA": remote_sha,
                     "GITHUB_RUN_ATTEMPT": "2",
                     "GITHUB_RUN_ID": "123",
                     "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+                    "RUNNER_TEMP": str(root),
                 }
             )
             if token is not None:
@@ -85,78 +107,89 @@ exit 99
                 text=True,
                 env=env,
             )
-            calls = (
-                call_log.read_text(encoding="utf-8")
-                if call_log.exists()
+            gh_calls = (
+                gh_call_log.read_text(encoding="utf-8")
+                if gh_call_log.exists()
                 else ""
             )
-            return result, calls, ref_state.exists()
+            git_calls = (
+                git_call_log.read_text(encoding="utf-8")
+                if git_call_log.exists()
+                else ""
+            )
+            return result, gh_calls, git_calls, ref_state.exists()
 
-    def test_accepts_token_with_contents_write_access(self) -> None:
-        result, calls, ref_exists = self.run_verifier()
+    def test_accepts_token_with_actual_git_push_access(self) -> None:
+        result, gh_calls, git_calls, ref_exists = self.run_verifier()
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("write access verified", result.stdout)
-        self.assertIn("git/ref/heads/main --jq .object.sha", calls)
-        self.assertIn("--method POST", calls)
-        self.assertIn("git/refs", calls)
+        self.assertEqual(gh_calls.splitlines(), ["auth setup-git"])
         self.assertIn(
-            "-f ref=refs/heads/burrow-release-access-probe-123-2",
-            calls,
+            "clone --quiet --depth 1 https://github.com/caezium/homebrew-tap.git",
+            git_calls,
         )
-        self.assertIn(f"-f sha={TAP_SHA}", calls)
-        self.assertIn("--method DELETE", calls)
         self.assertIn(
-            "git/refs/heads/burrow-release-access-probe-123-2",
-            calls,
+            "push --quiet origin HEAD:refs/heads/burrow-release-access-probe-123-2",
+            git_calls,
         )
+        self.assertIn(
+            "push --quiet origin :refs/heads/burrow-release-access-probe-123-2",
+            git_calls,
+        )
+        self.assertNotIn("--dry-run", git_calls)
         self.assertFalse(ref_exists)
 
-    def test_rejects_missing_token_before_calling_github(self) -> None:
-        result, calls, ref_exists = self.run_verifier(token=None)
+    def test_rejects_missing_token_before_calling_tools(self) -> None:
+        result, gh_calls, git_calls, ref_exists = self.run_verifier(token=None)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TAP_PAT is missing", result.stderr)
-        self.assertEqual(calls, "")
+        self.assertEqual(gh_calls, "")
+        self.assertEqual(git_calls, "")
         self.assertFalse(ref_exists)
 
-    def test_rejects_token_that_can_read_but_cannot_write(self) -> None:
-        result, calls, ref_exists = self.run_verifier(create_exit=1)
+    def test_reports_git_auth_setup_failure_before_cloning(self) -> None:
+        result, _, git_calls, ref_exists = self.run_verifier(auth_exit=1)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unable to configure Git authentication", result.stderr)
+        self.assertEqual(git_calls, "")
+        self.assertFalse(ref_exists)
+
+    def test_reports_clone_failure(self) -> None:
+        result, _, git_calls, ref_exists = self.run_verifier(clone_exit=1)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot clone", result.stderr)
+        self.assertIn("clone --quiet --depth 1", git_calls)
+        self.assertFalse(ref_exists)
+
+    def test_rejects_token_that_can_clone_but_cannot_push(self) -> None:
+        result, _, git_calls, ref_exists = self.run_verifier(create_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("HTTP 403", result.stderr)
-        self.assertIn(
-            "TAP_PAT cannot create a temporary ref",
-            result.stderr,
-        )
-        self.assertIn("--method POST", calls)
-        self.assertNotIn("--method DELETE", calls)
+        self.assertIn("TAP_PAT cannot push", result.stderr)
+        self.assertIn("push --quiet origin HEAD:", git_calls)
         self.assertFalse(ref_exists)
 
-    def test_reports_reference_read_failure(self) -> None:
-        result, calls, ref_exists = self.run_verifier(read_exit=1)
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("TAP_PAT cannot read caezium/homebrew-tap", result.stderr)
-        self.assertNotIn("--method POST", calls)
-        self.assertFalse(ref_exists)
-
-    def test_rejects_unexpected_create_response_and_removes_probe(self) -> None:
-        result, calls, ref_exists = self.run_verifier(
-            create_ref="refs/heads/unexpected"
+    def test_rejects_unexpected_remote_sha_and_removes_probe(self) -> None:
+        result, _, git_calls, ref_exists = self.run_verifier(
+            remote_sha="0" * 40
         )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("created an unexpected ref", result.stderr)
-        self.assertIn("--method DELETE", calls)
+        self.assertIn("unexpected ref SHA", result.stderr)
+        self.assertIn("push --quiet origin :refs/heads/", git_calls)
         self.assertFalse(ref_exists)
 
     def test_fails_closed_when_probe_cannot_be_removed(self) -> None:
-        result, calls, ref_exists = self.run_verifier(delete_exit=1)
+        result, _, git_calls, ref_exists = self.run_verifier(delete_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("could not remove it", result.stderr)
-        self.assertIn("--method DELETE", calls)
+        self.assertIn("push --quiet origin :refs/heads/", git_calls)
         self.assertTrue(ref_exists)
 
 

--- a/scripts/tests/test_verify_homebrew_tap_access.py
+++ b/scripts/tests/test_verify_homebrew_tap_access.py
@@ -15,23 +15,37 @@ class VerifyHomebrewTapAccessTests(unittest.TestCase):
         self,
         *,
         token: str | None = "test-token",
+        create_exit: int = 0,
+        create_ref: str = "",
+        delete_exit: int = 0,
         read_exit: int = 0,
-        write_exit: int = 0,
-        write_sha: str = TAP_SHA,
-    ) -> tuple[subprocess.CompletedProcess[str], str]:
+    ) -> tuple[subprocess.CompletedProcess[str], str, bool]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             fake_bin = root / "bin"
             fake_bin.mkdir()
             call_log = root / "gh-calls.txt"
+            ref_state = root / "probe-ref-exists"
 
             fake_gh = fake_bin / "gh"
             fake_gh.write_text(
                 """#!/bin/bash
 printf '%s\\n' "$*" >> "$GH_CALL_LOG"
-if [[ "$*" == *"--method PATCH"* ]]; then
-  [ "$GH_WRITE_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GH_WRITE_EXIT"; }
-  printf '%s\\n' "$GH_WRITE_SHA"
+if [[ "$*" == *"--method POST"* ]]; then
+  [ "$GH_CREATE_EXIT" -eq 0 ] || { echo "HTTP 403" >&2; exit "$GH_CREATE_EXIT"; }
+  requested_ref=""
+  for argument in "$@"; do
+    case "$argument" in
+      ref=*) requested_ref="${argument#ref=}" ;;
+    esac
+  done
+  touch "$GH_REF_STATE"
+  printf '%s\\n' "${GH_CREATE_REF:-$requested_ref}"
+  exit 0
+fi
+if [[ "$*" == *"--method DELETE"* ]]; then
+  [ "$GH_DELETE_EXIT" -eq 0 ] || { echo "HTTP 500" >&2; exit "$GH_DELETE_EXIT"; }
+  rm -f "$GH_REF_STATE"
   exit 0
 fi
 if [[ "$*" == *"git/ref/heads/main"* ]]; then
@@ -51,10 +65,14 @@ exit 99
             env.update(
                 {
                     "GH_CALL_LOG": str(call_log),
+                    "GH_CREATE_EXIT": str(create_exit),
+                    "GH_CREATE_REF": create_ref,
+                    "GH_DELETE_EXIT": str(delete_exit),
                     "GH_READ_EXIT": str(read_exit),
                     "GH_READ_SHA": TAP_SHA,
-                    "GH_WRITE_EXIT": str(write_exit),
-                    "GH_WRITE_SHA": write_sha,
+                    "GH_REF_STATE": str(ref_state),
+                    "GITHUB_RUN_ATTEMPT": "2",
+                    "GITHUB_RUN_ID": "123",
                     "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
                 }
             )
@@ -72,49 +90,74 @@ exit 99
                 if call_log.exists()
                 else ""
             )
-            return result, calls
+            return result, calls, ref_state.exists()
 
     def test_accepts_token_with_contents_write_access(self) -> None:
-        result, calls = self.run_verifier()
+        result, calls, ref_exists = self.run_verifier()
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("write access verified", result.stdout)
         self.assertIn("git/ref/heads/main --jq .object.sha", calls)
-        self.assertIn("--method PATCH", calls)
-        self.assertIn("git/refs/heads/main", calls)
+        self.assertIn("--method POST", calls)
+        self.assertIn("git/refs", calls)
+        self.assertIn(
+            "-f ref=refs/heads/burrow-release-access-probe-123-2",
+            calls,
+        )
         self.assertIn(f"-f sha={TAP_SHA}", calls)
-        self.assertIn("-F force=false", calls)
+        self.assertIn("--method DELETE", calls)
+        self.assertIn(
+            "git/refs/heads/burrow-release-access-probe-123-2",
+            calls,
+        )
+        self.assertFalse(ref_exists)
 
     def test_rejects_missing_token_before_calling_github(self) -> None:
-        result, calls = self.run_verifier(token=None)
+        result, calls, ref_exists = self.run_verifier(token=None)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TAP_PAT is missing", result.stderr)
         self.assertEqual(calls, "")
+        self.assertFalse(ref_exists)
 
     def test_rejects_token_that_can_read_but_cannot_write(self) -> None:
-        result, calls = self.run_verifier(write_exit=1)
+        result, calls, ref_exists = self.run_verifier(create_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("HTTP 403", result.stderr)
         self.assertIn(
-            "TAP_PAT cannot push to caezium/homebrew-tap",
+            "TAP_PAT cannot create a temporary ref",
             result.stderr,
         )
-        self.assertIn("--method PATCH", calls)
+        self.assertIn("--method POST", calls)
+        self.assertNotIn("--method DELETE", calls)
+        self.assertFalse(ref_exists)
 
     def test_reports_reference_read_failure(self) -> None:
-        result, calls = self.run_verifier(read_exit=1)
+        result, calls, ref_exists = self.run_verifier(read_exit=1)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("TAP_PAT cannot read caezium/homebrew-tap", result.stderr)
-        self.assertNotIn("--method PATCH", calls)
+        self.assertNotIn("--method POST", calls)
+        self.assertFalse(ref_exists)
 
-    def test_rejects_unexpected_write_response(self) -> None:
-        result, _ = self.run_verifier(write_sha="0" * 40)
+    def test_rejects_unexpected_create_response_and_removes_probe(self) -> None:
+        result, calls, ref_exists = self.run_verifier(
+            create_ref="refs/heads/unexpected"
+        )
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("unexpected ref SHA", result.stderr)
+        self.assertIn("created an unexpected ref", result.stderr)
+        self.assertIn("--method DELETE", calls)
+        self.assertFalse(ref_exists)
+
+    def test_fails_closed_when_probe_cannot_be_removed(self) -> None:
+        result, calls, ref_exists = self.run_verifier(delete_exit=1)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("could not remove it", result.stderr)
+        self.assertIn("--method DELETE", calls)
+        self.assertTrue(ref_exists)
 
 
 if __name__ == "__main__":

--- a/scripts/verify-homebrew-tap-access.sh
+++ b/scripts/verify-homebrew-tap-access.sh
@@ -7,18 +7,15 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
-if ! current_sha="$(
-  gh api repos/caezium/homebrew-tap/git/ref/heads/main --jq '.object.sha'
-)"; then
-  echo "::error::TAP_PAT cannot read caezium/homebrew-tap." >&2
-  exit 1
-fi
-
 # The repository API's `.permissions.push` field describes the account's role,
 # `git push --dry-run` sends no update, and a same-SHA ref update is treated as
-# a no-op. Create a unique temporary ref so GitHub must authorize a real write,
-# then remove it before continuing. No commit is created and a successful probe
-# leaves the tap exactly as it found it.
+# a no-op. Push a unique temporary ref through the same Git transport used by
+# the release, verify it, then remove it before continuing. No commit is created
+# and a successful probe leaves the tap exactly as it found it.
+probe_root="$(
+  mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/burrow-tap-write.XXXXXX"
+)"
+tap_dir="$probe_root/tap"
 probe_branch="burrow-release-access-probe-${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}"
 probe_ref="refs/heads/$probe_branch"
 probe_created=false
@@ -28,37 +25,68 @@ cleanup_probe() {
     return 0
   fi
 
-  if ! gh api --method DELETE \
-    "repos/caezium/homebrew-tap/git/refs/heads/$probe_branch" >/dev/null; then
+  if ! delete_output="$(
+    git -C "$tap_dir" push --quiet origin ":$probe_ref" 2>&1
+  )"; then
+    printf '%s\n' "$delete_output" >&2
     echo "::error::Created $probe_ref but could not remove it from caezium/homebrew-tap." >&2
     return 1
   fi
 
   probe_created=false
 }
-trap cleanup_probe EXIT
 
-if ! created_ref="$(
-  gh api --method POST \
-    repos/caezium/homebrew-tap/git/refs \
-    -f ref="$probe_ref" \
-    -f sha="$current_sha" \
-    --jq '.ref'
+cleanup_all() {
+  cleanup_status=0
+  cleanup_probe || cleanup_status=1
+  rm -rf "$probe_root"
+  return "$cleanup_status"
+}
+trap cleanup_all EXIT
+
+export GIT_CONFIG_GLOBAL="$probe_root/gitconfig"
+touch "$GIT_CONFIG_GLOBAL"
+
+if ! gh auth setup-git; then
+  echo "::error::Unable to configure Git authentication from TAP_PAT." >&2
+  exit 1
+fi
+
+if ! (cd "$probe_root" && git clone --quiet --depth 1 \
+  https://github.com/caezium/homebrew-tap.git tap); then
+  echo "::error::TAP_PAT cannot clone caezium/homebrew-tap." >&2
+  exit 1
+fi
+
+current_sha="$(git -C "$tap_dir" rev-parse HEAD)"
+if ! push_output="$(
+  git -C "$tap_dir" push --quiet origin "HEAD:$probe_ref" 2>&1
 )"; then
-  echo "::error::TAP_PAT cannot create a temporary ref in caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
+  printf '%s\n' "$push_output" >&2
+  if git -C "$tap_dir" ls-remote --exit-code --refs \
+    origin "$probe_ref" >/dev/null 2>&1; then
+    probe_created=true
+  fi
+  echo "::error::TAP_PAT cannot push to caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
   exit 1
 fi
 probe_created=true
 
-if [ "$created_ref" != "$probe_ref" ]; then
-  echo "::error::Homebrew tap write probe created an unexpected ref." >&2
+remote_sha="$(
+  git -C "$tap_dir" ls-remote --exit-code --refs origin "$probe_ref" \
+    | awk 'NR == 1 { print $1 }'
+)"
+if [ "$remote_sha" != "$current_sha" ]; then
+  echo "::error::Homebrew tap write probe returned an unexpected ref SHA." >&2
   exit 1
 fi
 
 if ! cleanup_probe; then
   trap - EXIT
+  rm -rf "$probe_root"
   exit 1
 fi
 trap - EXIT
+rm -rf "$probe_root"
 
 echo "Homebrew tap write access verified; the temporary ref was removed."

--- a/scripts/verify-homebrew-tap-access.sh
+++ b/scripts/verify-homebrew-tap-access.sh
@@ -15,24 +15,50 @@ if ! current_sha="$(
 fi
 
 # The repository API's `.permissions.push` field describes the account's role,
-# and `git push --dry-run` does not send an update for GitHub to authorize.
-# GitHub documents the Update a reference endpoint as requiring fine-grained
-# Contents: write. Pointing main at its exact current SHA exercises that write
-# endpoint without moving the ref, creating a commit, or triggering a release.
-if ! verified_sha="$(
-  gh api --method PATCH \
-    repos/caezium/homebrew-tap/git/refs/heads/main \
+# `git push --dry-run` sends no update, and a same-SHA ref update is treated as
+# a no-op. Create a unique temporary ref so GitHub must authorize a real write,
+# then remove it before continuing. No commit is created and a successful probe
+# leaves the tap exactly as it found it.
+probe_branch="burrow-release-access-probe-${GITHUB_RUN_ID:-local-$$}-${GITHUB_RUN_ATTEMPT:-0}"
+probe_ref="refs/heads/$probe_branch"
+probe_created=false
+
+cleanup_probe() {
+  if [ "$probe_created" != true ]; then
+    return 0
+  fi
+
+  if ! gh api --method DELETE \
+    "repos/caezium/homebrew-tap/git/refs/heads/$probe_branch" >/dev/null; then
+    echo "::error::Created $probe_ref but could not remove it from caezium/homebrew-tap." >&2
+    return 1
+  fi
+
+  probe_created=false
+}
+trap cleanup_probe EXIT
+
+if ! created_ref="$(
+  gh api --method POST \
+    repos/caezium/homebrew-tap/git/refs \
+    -f ref="$probe_ref" \
     -f sha="$current_sha" \
-    -F force=false \
-    --jq '.object.sha'
+    --jq '.ref'
 )"; then
-  echo "::error::TAP_PAT cannot push to caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
+  echo "::error::TAP_PAT cannot create a temporary ref in caezium/homebrew-tap. Replace it with a fine-grained token scoped only to that repository with Contents: Read and write." >&2
+  exit 1
+fi
+probe_created=true
+
+if [ "$created_ref" != "$probe_ref" ]; then
+  echo "::error::Homebrew tap write probe created an unexpected ref." >&2
   exit 1
 fi
 
-if [ "$verified_sha" != "$current_sha" ]; then
-  echo "::error::Homebrew tap write probe returned an unexpected ref SHA." >&2
+if ! cleanup_probe; then
+  trap - EXIT
   exit 1
 fi
+trap - EXIT
 
-echo "Homebrew tap write access verified without moving its main ref."
+echo "Homebrew tap write access verified; the temporary ref was removed."


### PR DESCRIPTION
## Summary

- replace false-positive tap permission probes with an actual temporary Git push, verification, and deletion
- scope the private-engine URL rewrite to the build process instead of writing it to the runner's global Git config
- isolate the Homebrew tap clone and credential helper from the source checkout and every other release credential
- preserve fail-closed behavior when the probe push, verification, or cleanup fails
- document the confirmed v0.11.1 root cause and credential verification

## Root cause

The v0.11.1 build configured a global `insteadOf` rewrite so Cargo could fetch the private engine with `ENGINE_PAT`. That rewrite survived past the build and replaced the credentials in the final `caezium/homebrew-tap` URL, so the tap push used the engine-only token instead of `TAP_PAT` and GitHub returned HTTP 403. The stored `TAP_PAT` was valid; API role checks, a Git dry run, and a same-SHA API update had all failed to exercise the release's real Git authentication path.

## Verification

- `bash -n scripts/verify-homebrew-tap-access.sh`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 30 tests passed
- `git diff --check`
- local real push/delete with the owner credential; no probe ref remained
- [Actions credential check with the stored `TAP_PAT`](https://github.com/caezium/Burrow/actions/runs/30766229249) passed a real Git push/delete; no probe ref remained
