### PR TITLE
feat(site): add cookieless PostHog analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: greenlight preflight macos --exit-code
       - name: Test release safety helpers
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+      - name: Test website analytics boundaries
+        run: node --test scripts/tests/test_site_analytics.mjs
 
   test:
     runs-on: macos-15

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -8,7 +8,7 @@ name: Deploy site to burrow.henryzh.dev
 on:
   push:
     branches: [main]
-    paths: ['docs/**', 'wrangler.jsonc', '.github/workflows/deploy-site.yml']
+    paths: ['docs/**', 'scripts/deploy-site.sh', 'scripts/inject-site-analytics.sh', 'scripts/prepare-site-assets.sh', 'wrangler.jsonc', '.github/workflows/deploy-site.yml']
   workflow_dispatch:
 
 permissions:
@@ -24,6 +24,7 @@ jobs:
     # secrets.* is not usable in step `if:` conditions; hoist presence into env.
     env:
       HAS_DEPLOY_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+      HAS_POSTHOG_KEY: ${{ secrets.POSTHOG_API_KEY != '' }}
     steps:
       # Actions pinned to commit SHAs (not floating tags): a moved tag would
       # otherwise run unreviewed third-party code in a job that holds a
@@ -31,8 +32,18 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Note when the deploy token is missing
         if: ${{ env.HAS_DEPLOY_TOKEN == 'false' }}
-        run: echo "::notice::CLOUDFLARE_API_TOKEN secret not set — skipping deploy (run 'npx wrangler deploy' locally instead)."
+        run: echo "::notice::CLOUDFLARE_API_TOKEN secret not set — skipping deploy. For a credentialed local deploy, set POSTHOG_API_KEY and run 'bash scripts/deploy-site.sh'."
+      - name: Require website analytics key
+        if: ${{ env.HAS_DEPLOY_TOKEN == 'true' && env.HAS_POSTHOG_KEY == 'false' }}
+        run: |
+          echo "::error::POSTHOG_API_KEY must be set before the instrumented site can deploy."
+          exit 1
+      - name: Prepare website assets
+        if: ${{ env.HAS_DEPLOY_TOKEN == 'true' && env.HAS_POSTHOG_KEY == 'true' }}
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+        run: bash scripts/prepare-site-assets.sh .site-deploy
       - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        if: ${{ env.HAS_DEPLOY_TOKEN == 'true' }}
+        if: ${{ env.HAS_DEPLOY_TOKEN == 'true' && env.HAS_POSTHOG_KEY == 'true' }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ macos/vendor/Sentry.xcframework/
 macos/vendor/.sentry-*.ok
 macos/vendor/Sparkle.framework/
 macos/vendor/.sparkle-cache/
+.site-deploy/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -99,6 +99,14 @@ This is the part people rightly scrutinize in cleaners. Burrow's model:
   [`windows/Services/AppTelemetry.cs`](windows/Services/AppTelemetry.cs), keys
   injected via `BURROWWIN_SENTRY_DSN` / `BURROWWIN_POSTHOG_API_KEY` — see
   **[TELEMETRY.md](TELEMETRY.md)**.
+- **The public website uses separate cookieless analytics.** On the exact
+  `burrow.henryzh.dev` production host, PostHog records page views/leaves,
+  scroll depth, CLS/INP/LCP, and fixed download/Homebrew-copy events. It stores
+  no browser identifier, creates no person profile, strips URL queries and
+  fragments, honors Do Not Track, and disables replay, generic click capture,
+  exceptions, console/network capture, surveys, and flags. Requests go directly
+  to PostHog so content blockers remain effective; the exact fields and
+  server-side daily-hash behavior are in **[TELEMETRY.md](TELEMETRY.md)**.
 - **Telemetry stays off the UI thread.** macOS PostHog delivery uses Burrow's
   own serial background transport rather than the SDK timer that previously
   ran on AppKit's main run loop. A local 64-event sanitized outbox retries one

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,10 +1,11 @@
-# Burrow telemetry
+# Burrow telemetry and website analytics
 
-Burrow collects **anonymous, opt-out** product analytics and crash reports so we
+Burrow's apps collect **anonymous, opt-out** product analytics and crash reports so we
 can see how many installs stay active, which versions to support, which features
 get used, and when something breaks. This file is the exact, honest list of
 what that means. The privacy summary lives in [SECURITY.md](SECURITY.md); this
-is the detail.
+is the detail. The public website uses a separate cookieless configuration,
+documented below; the app's Settings switch does not control website requests.
 
 ## What and who
 
@@ -176,6 +177,54 @@ so a later re-enable reuses the same anonymous identity. The sanitized PostHog
 outbox also stays on disk but is not read or transmitted until telemetry is
 enabled again. A launch that begins opted out makes no PostHog request. There
 is no server-side deletion call.
+
+## Website analytics
+
+The production site at [`burrow.henryzh.dev`](https://burrow.henryzh.dev)
+loads [`docs/analytics.js`](docs/analytics.js), then PostHog's Web JavaScript
+bundle from `us-assets.i.posthog.com`; events go directly to
+`us.i.posthog.com`. The committed source contains only a placeholder project
+key and runs only on that exact production hostname, so local previews and
+forks are inert. The deploy workflow and `scripts/deploy-site.sh` stage a copy,
+inject the same PostHog project key used by the apps, and fail before publishing
+when that key is unavailable or malformed. Running `npx wrangler deploy`
+directly is unsupported because it bypasses that guard.
+
+The site uses PostHog's **stateful cookieless mode**. It sets no PostHog cookie,
+local-storage value, or session-storage value, never calls `identify`, and
+creates no person profile. PostHog derives a rotating daily hash from the
+request IP, user agent, and site domain, uses temporary server-side state for a
+30-minute session boundary, then strips the raw IP before event processing; the
+project's separate **Discard client IP data** setting remains enabled as a
+second guard. The daily hash is unrelated to either app's random install ID and
+cannot follow a browser across days.
+
+The captured website events and fields are:
+
+| Events | Properties |
+|---|---|
+| `$pageview`, `$pageleave` | Page title, host/path, query- and fragment-free current/referrer URLs, visit duration, and PostHog's scroll-depth percentages/pixel maximums |
+| `$web_vitals` | CLS, INP, and LCP values plus bounded name, value, delta, rating, navigation type, and a query- and fragment-free page URL. Raw browser performance-entry arrays, element data, metric IDs, and nested timestamps are removed |
+| `website_download_clicked` | Fixed `destination: "github_release"`; fixed placement: `navigation`, `hero`, `pricing`, `windows`, `changelog`, or `roadmap` |
+| `website_homebrew_copy_clicked` | Fixed `command: "install"`; fixed placement: `hero` or `install_card` |
+
+PostHog also attaches ordinary web context: browser and OS family/version,
+device type, language/time zone, viewport and screen dimensions, page host/path
+and title, sanitized referrer, and PostHog library version. URL query strings
+and fragments are removed before sending, the complete raw user-agent event
+property is discarded, campaign-parameter persistence is off, and Do Not Track
+is honored. PostHog still receives the user-agent request header needed for the
+rotating cookieless hash described above.
+
+Generic element autocapture, session replay, heatmaps, rage/dead-click capture,
+JavaScript exception capture, console capture, network timing, person profiles,
+surveys, and remote feature flags are all disabled. Only the annotated download
+and Homebrew-copy controls emit interaction events; copied command text is
+represented by the fixed word `install`, not read from the clipboard or DOM.
+The site uses PostHog directly rather than hiding it behind a reverse proxy, so
+browsers and content blockers can block it and aggregate counts can be lower
+than real traffic. Signing and notarization add no website telemetry, and the
+website is outside the macOS app's `PrivacyInfo.xcprivacy` declaration.
 
 ## Windows app
 

--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -1,0 +1,143 @@
+(function (document, window) {
+  'use strict';
+
+  var projectKey = '__POSTHOG_PROJECT_KEY__';
+  if (window.location.hostname !== 'burrow.henryzh.dev' || !/^phc_[A-Za-z0-9]+$/.test(projectKey)) {
+    return;
+  }
+
+  function withoutQueryOrFragment(value) {
+    if (typeof value !== 'string' || value.length === 0) return value;
+    try {
+      var url = new URL(value, window.location.origin);
+      url.search = '';
+      url.hash = '';
+      return url.toString();
+    } catch (_) {
+      return undefined;
+    }
+  }
+
+  function sanitizeEvent(event) {
+    if (!event || !event.properties) return event;
+
+    // PostHog can attach the complete browser user-agent string as an event
+    // property. The server may still use the request header to derive its
+    // rotating cookieless identifier, but the raw value is not retained with
+    // Burrow's analytics events.
+    delete event.properties.$raw_user_agent;
+
+    ['$current_url', '$initial_current_url', '$referrer', '$initial_referrer'].forEach(function (name) {
+      if (!(name in event.properties)) return;
+      var sanitized = withoutQueryOrFragment(event.properties[name]);
+      if (sanitized) event.properties[name] = sanitized;
+      else delete event.properties[name];
+    });
+
+    ['CLS', 'INP', 'LCP'].forEach(function (metric) {
+      var propertyName = '$web_vitals_' + metric + '_event';
+      var detail = event.properties[propertyName];
+      if (!detail || typeof detail !== 'object') return;
+
+      var bounded = { name: metric };
+      if (typeof detail.value === 'number' && Number.isFinite(detail.value)) bounded.value = detail.value;
+      if (typeof detail.delta === 'number' && Number.isFinite(detail.delta)) bounded.delta = detail.delta;
+      if (['good', 'needs-improvement', 'poor'].indexOf(detail.rating) !== -1) bounded.rating = detail.rating;
+      if (['navigate', 'reload', 'back-forward', 'back-forward-cache', 'prerender', 'restore'].indexOf(detail.navigationType) !== -1) {
+        bounded.navigationType = detail.navigationType;
+      }
+      var sanitized = withoutQueryOrFragment(detail.$current_url);
+      if (sanitized) bounded.$current_url = sanitized;
+      event.properties[propertyName] = bounded;
+    });
+
+    return event;
+  }
+
+  // PostHog's official array-loader behavior, reduced to the one queued method
+  // this site uses before the async bundle is ready.
+  function installPostHogLoader(posthog) {
+    if (posthog.__SV || (window.posthog && window.posthog.__loaded)) return;
+
+    function queueMethod(target, methodName) {
+      target[methodName] = function () {
+        target.push([methodName].concat(Array.prototype.slice.call(arguments, 0)));
+      };
+    }
+
+    window.posthog = posthog;
+    posthog._i = [];
+    posthog.init = function (token, config, instanceName) {
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.crossOrigin = 'anonymous';
+      script.async = true;
+      script.src = config.api_host.replace('.i.posthog.com', '-assets.i.posthog.com') + '/static/array.js';
+      var firstScript = document.getElementsByTagName('script')[0];
+      firstScript.parentNode.insertBefore(script, firstScript);
+
+      var instance = posthog;
+      if (instanceName !== undefined) instance = posthog[instanceName] = [];
+      else instanceName = 'posthog';
+      instance.people = instance.people || [];
+      instance.toString = function (asPerson) {
+        var name = instanceName === 'posthog' ? 'posthog' : 'posthog.' + instanceName;
+        if (!asPerson) name += ' (stub)';
+        return name;
+      };
+      instance.people.toString = function () { return instance.toString(true) + '.people (stub)'; };
+      queueMethod(instance, 'capture');
+      posthog._i.push([token, config, instanceName]);
+    };
+    posthog.__SV = 1;
+  }
+
+  installPostHogLoader(window.posthog || []);
+
+  window.posthog.init(projectKey, {
+    api_host: 'https://us.i.posthog.com',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-05-30',
+    cookieless_mode: 'always',
+    person_profiles: 'never',
+    respect_dnt: true,
+    autocapture: false,
+    capture_pageview: true,
+    capture_pageleave: true,
+    disable_scroll_properties: false,
+    capture_performance: {
+      web_vitals: true,
+      web_vitals_allowed_metrics: ['CLS', 'INP', 'LCP'],
+      network_timing: false
+    },
+    disable_session_recording: true,
+    capture_exceptions: false,
+    capture_dead_clicks: false,
+    enable_recording_console_log: false,
+    advanced_disable_flags: true,
+    save_campaign_params: false,
+    mask_personal_data_properties: true,
+    disable_capture_url_hashes: true,
+    before_send: sanitizeEvent
+  });
+
+  var interactions = {
+    'homebrew.hero': ['website_homebrew_copy_clicked', { command: 'install', placement: 'hero' }],
+    'homebrew.install_card': ['website_homebrew_copy_clicked', { command: 'install', placement: 'install_card' }],
+    'download.hero': ['website_download_clicked', { destination: 'github_release', placement: 'hero' }],
+    'download.navigation': ['website_download_clicked', { destination: 'github_release', placement: 'navigation' }],
+    'download.pricing': ['website_download_clicked', { destination: 'github_release', placement: 'pricing' }],
+    'download.windows': ['website_download_clicked', { destination: 'github_release', placement: 'windows' }],
+    'download.changelog': ['website_download_clicked', { destination: 'github_release', placement: 'changelog' }],
+    'download.roadmap': ['website_download_clicked', { destination: 'github_release', placement: 'roadmap' }]
+  };
+
+  document.addEventListener('click', function (event) {
+    if (!event.target || typeof event.target.closest !== 'function') return;
+    var control = event.target.closest('[data-burrow-analytics]');
+    if (!control) return;
+    var interaction = interactions[control.getAttribute('data-burrow-analytics')];
+    if (!interaction) return;
+    window.posthog.capture(interaction[0], interaction[1]);
+  });
+}(document, window));

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
 <meta property="og:image" content="https://burrow.henryzh.dev/burrow-icon-512.png">
 <meta property="og:url" content="https://burrow.henryzh.dev/">
 <meta name="twitter:card" content="summary">
+<script src="/analytics.js" defer></script>
 
 <style>
   /* All fonts self-hosted: a page whose pitch is "your data stays on your
@@ -315,7 +316,7 @@
     <a class="ghosticon" href="https://github.com/caezium/Burrow" target="_blank" rel="noopener" aria-label="GitHub">
       <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5a12 12 0 00-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.3-1.8-1.3-1.8-1.1-.7 0-.7 0-.7 1.2 0 1.9 1.2 1.9 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 016 0C17.3 5 18.3 5.3 18.3 5.3c.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0012 .5z"/></svg>
     </a>
-    <a class="btn btn-fill btn-sm" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener">Download</a>
+    <a class="btn btn-fill btn-sm" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.navigation">Download</a>
   </div>
 </div>
 
@@ -334,9 +335,9 @@
     </div>
     <div class="cta">
       <a class="btn btn-fill" href="#price">Install with Homebrew</a>
-      <a class="btn btn-out" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener">Download&nbsp;.zip</a>
+      <a class="btn btn-out" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.hero">Download&nbsp;.zip</a>
     </div>
-    <button class="hero-cmd" id="brewcmd" type="button" aria-label="Copy install command">
+    <button class="hero-cmd" id="brewcmd" type="button" aria-label="Copy install command" data-burrow-analytics="homebrew.hero">
       <span class="dollar">$</span><span class="txt">brew install --cask caezium/tap/burrow</span>
       <span class="hint">click to copy · Developer ID signed + notarized</span>
     </button>
@@ -481,7 +482,7 @@
     </div>
     <div class="pastel-block">
       <div class="pr"><div class="n">1</div><div><div class="lead">Your data stays on your Mac.</div>
-        <p>No accounts and no user-file uploads — scans, history and metrics stay local, and the MCP server is loopback-only. Burrow sends <b>opt-out anonymous usage and diagnostics</b>, including crash/hang reports and sampled fixed-name performance spans. It never records the screen or sends user files, paths, URLs or metrics; PostHog delivery and its bounded, serialized retry outbox stay off AppKit's main thread, source builds are inert, and one Settings switch stops both services. Startup also gives the menu-bar item and signed updater separate stability windows, so a failed component is paused instead of retried every launch. The exact event list is in <a href="https://github.com/caezium/Burrow/blob/main/TELEMETRY.md" target="_blank" rel="noopener">TELEMETRY.md</a>.</p></div></div>
+        <p>No accounts and no user-file uploads — scans, history and metrics stay local, and the MCP server is loopback-only. Burrow sends <b>opt-out anonymous usage and diagnostics</b>, including crash/hang reports and sampled fixed-name performance spans. It never records the screen or sends user files, paths, URLs or metrics; PostHog delivery and its bounded, serialized retry outbox stay off AppKit's main thread, source builds are inert, and one Settings switch stops both services. Startup also gives the menu-bar item and signed updater separate stability windows, so a failed component is paused instead of retried every launch. This website separately uses cookieless PostHog page, scroll, performance, download, and install-command analytics: it creates no person profile, stores no browser identifier, strips URL queries/fragments, honors Do Not Track, and has no replay or generic click capture. The exact app and website event lists are in <a href="https://github.com/caezium/Burrow/blob/main/TELEMETRY.md" target="_blank" rel="noopener">TELEMETRY.md</a>.</p></div></div>
       <div class="pr"><div class="n">2</div><div><div class="lead">Show before you remove.</div>
         <p>Every action shows the file list and byte count first. You confirm; Burrow acts. Clean is categorized and sorted by what is <b>safest to remove</b>, and nothing is deleted on a single mis-tap.</p></div></div>
       <div class="pr"><div class="n">3</div><div><div class="lead">You approve every elevation.</div>
@@ -499,7 +500,7 @@
     <div class="price-card">
       <div class="price"><span class="cur">$</span>0</div>
       <div class="price-tag">Free, forever. MIT-licensed.</div>
-      <a class="btn btn-fill" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" style="padding:15px 40px; font-size:16px;">Get Burrow</a>
+      <a class="btn btn-fill" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.pricing" style="padding:15px 40px; font-size:16px;">Get Burrow</a>
       <div class="price-lines">All five tools, the menu-bar HUD, history, and the MCP server included.<br>
         <span style="color:var(--ink-3)">or <a class="u" href="#build">build it from source</a></span></div>
       <div class="price-meta">unlimited Macs<span class="dot">·</span>no account<span class="dot">·</span>Developer ID signed + notarized<span class="dot">·</span>official downloads bundle the engine + conductor</div>
@@ -509,7 +510,7 @@
       <div class="inst">
         <h3>Homebrew <span class="ptag">recommended</span></h3>
         <p>Installs the Developer ID-signed and notarized app with its bundled engine. The live cask preserves quarantine so Gatekeeper can validate Apple's ticket; it no longer strips security metadata.</p>
-        <div class="code" data-copy="brew install --cask caezium/tap/burrow"><button class="copy">copy</button><span class="c"># app + bundled engine</span>
+        <div class="code" data-copy="brew install --cask caezium/tap/burrow"><button class="copy" data-burrow-analytics="homebrew.install_card">copy</button><span class="c"># app + bundled engine</span>
 brew install --cask caezium/tap/burrow</div>
       </div>
       <div class="inst">
@@ -529,7 +530,7 @@ bash scripts/release.sh</div>
     </div>
 
     <div class="price-meta" style="margin-top:22px; text-align:center;">
-      <b style="color:var(--accent)">Windows&nbsp;10/11 (beta)</b><span class="dot">·</span>downloadable preview — <a class="u" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener">BurrowWin zip</a> with the <code class="k">burrow.exe</code> conductor + engine bundled (installer coming)
+      <b style="color:var(--accent)">Windows&nbsp;10/11 (beta)</b><span class="dot">·</span>downloadable preview — <a class="u" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.windows">BurrowWin zip</a> with the <code class="k">burrow.exe</code> conductor + engine bundled (installer coming)
     </div>
   </section>
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -13,6 +13,7 @@
 <meta property="og:description" content="Every Burrow release at a glance — what each version added, fixed, and tightened.">
 <meta property="og:image" content="https://burrow.henryzh.dev/burrow-icon-512.png">
 <meta property="og:url" content="https://burrow.henryzh.dev/releases.html">
+<script src="/analytics.js" defer></script>
 <style>
   @font-face { font-family: "Geist"; src: url("assets/fonts/Geist[wght].woff2") format("woff2"); font-weight: 100 900; font-style: normal; font-display: swap; }
   @font-face { font-family: "Geist Mono"; src: url("assets/fonts/GeistMono[wght].woff2") format("woff2"); font-weight: 100 900; font-style: normal; font-display: swap; }
@@ -116,7 +117,7 @@
   <div class="page in">
     <a class="brand" href="./" aria-label="Burrow"><svg class="mk" viewBox="0 0 100 100" aria-hidden="true"><rect x="2" y="2" width="96" height="96" rx="26" fill="#241B12"/><path d="M27 63 a23 23 0 0 1 46 0 Z" fill="#F3ECDD"/><rect x="40" y="63" width="20" height="6" rx="3" fill="#241B12"/></svg><span class="nm">burrow</span></a>
     <nav class="nav"><a href="releases.html" class="on">Changelog</a><a href="roadmap.html">Roadmap</a></nav>
-    <a class="btn" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener">Download</a>
+    <a class="btn" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.changelog">Download</a>
   </div>
 </div>
 

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -13,6 +13,7 @@
 <meta property="og:description" content="What's shipped, building, and being weighed for Burrow — and how to vote.">
 <meta property="og:image" content="https://burrow.henryzh.dev/burrow-icon-512.png">
 <meta property="og:url" content="https://burrow.henryzh.dev/roadmap.html">
+<script src="/analytics.js" defer></script>
 <style>
   @font-face { font-family: "Geist"; src: url("assets/fonts/Geist[wght].woff2") format("woff2"); font-weight: 100 900; font-style: normal; font-display: swap; }
   @font-face { font-family: "Geist Mono"; src: url("assets/fonts/GeistMono[wght].woff2") format("woff2"); font-weight: 100 900; font-style: normal; font-display: swap; }
@@ -97,7 +98,7 @@
   <div class="page in">
     <a class="brand" href="./" aria-label="Burrow"><svg class="mk" viewBox="0 0 100 100" aria-hidden="true"><rect x="2" y="2" width="96" height="96" rx="26" fill="#241B12"/><path d="M27 63 a23 23 0 0 1 46 0 Z" fill="#F3ECDD"/><rect x="40" y="63" width="20" height="6" rx="3" fill="#241B12"/></svg><span class="nm">burrow</span></a>
     <nav class="nav"><a href="releases.html">Changelog</a><a href="roadmap.html" class="on">Roadmap</a></nav>
-    <a class="btn" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener">Download</a>
+    <a class="btn" href="https://github.com/caezium/Burrow/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.roadmap">Download</a>
   </div>
 </div>
 

--- a/scripts/deploy-site.sh
+++ b/scripts/deploy-site.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/burrow-site-deploy.XXXXXX")"
+stage_dir="$temporary_root/assets"
+trap 'rm -rf -- "$temporary_root"' EXIT
+
+bash "$repo_root/scripts/prepare-site-assets.sh" "$stage_dir"
+
+cd "$repo_root"
+npx wrangler deploy --assets "$stage_dir"

--- a/scripts/inject-site-analytics.sh
+++ b/scripts/inject-site-analytics.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:-docs/analytics.js}"
+placeholder='__POSTHOG_PROJECT_KEY__'
+project_key="${POSTHOG_API_KEY:-}"
+
+if [[ ! -f "$target" ]]; then
+  echo "::error::Website analytics source not found: $target" >&2
+  exit 1
+fi
+
+if [[ ! "$project_key" =~ ^phc_[A-Za-z0-9]+$ ]]; then
+  echo "::error::POSTHOG_API_KEY is missing or is not a PostHog project key." >&2
+  exit 1
+fi
+
+placeholder_count="$( (grep -oF "$placeholder" "$target" || true) | wc -l | tr -d '[:space:]')"
+if [[ "$placeholder_count" != "1" ]]; then
+  echo "::error::Expected exactly one website analytics key placeholder; found $placeholder_count." >&2
+  exit 1
+fi
+
+POSTHOG_API_KEY="$project_key" perl -0pi -e \
+  's/\Q__POSTHOG_PROJECT_KEY__\E/$ENV{POSTHOG_API_KEY}/g' "$target"
+
+if grep -qF "$placeholder" "$target"; then
+  echo "::error::Website analytics key injection did not complete." >&2
+  exit 1
+fi
+
+echo "Website analytics key injected."

--- a/scripts/prepare-site-assets.sh
+++ b/scripts/prepare-site-assets.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" != "1" || -z "$1" ]]; then
+  echo "usage: $0 <empty-staging-directory>" >&2
+  exit 2
+fi
+
+stage_dir="$1"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ -e "$stage_dir" ]]; then
+  echo "::error::Website staging path already exists: $stage_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$stage_dir"
+cp -R "$repo_root/docs/." "$stage_dir/"
+bash "$repo_root/scripts/inject-site-analytics.sh" "$stage_dir/analytics.js"

--- a/scripts/site-release.py
+++ b/scripts/site-release.py
@@ -196,6 +196,7 @@ def page_html(*, title, desc, og_url, hero_h1, hero_p, hero_extra, main_html, ex
 <meta property="og:description" content="{desc}">
 <meta property="og:image" content="https://burrow.henryzh.dev/burrow-icon-512.png">
 <meta property="og:url" content="{og_url}">
+<script src="/analytics.js" defer></script>
 <style>
 {SHARED_CSS}{extra_css}</style>
 </head>
@@ -205,7 +206,7 @@ def page_html(*, title, desc, og_url, hero_h1, hero_p, hero_extra, main_html, ex
   <div class="page in">
     <a class="brand" href="./" aria-label="Burrow">{LOGO_SVG}<span class="nm">burrow</span></a>
     {nav}
-    <a class="btn" href="{REPO}/releases/latest" target="_blank" rel="noopener">Download</a>
+    <a class="btn" href="{REPO}/releases/latest" target="_blank" rel="noopener" data-burrow-analytics="download.{active}">Download</a>
   </div>
 </div>
 

--- a/scripts/tests/test_site_analytics.mjs
+++ b/scripts/tests/test_site_analytics.mjs
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import vm from 'node:vm'
+import { fileURLToPath } from 'node:url'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const analyticsPath = path.join(root, 'docs', 'analytics.js')
+const placeholder = '__POSTHOG_PROJECT_KEY__'
+
+function runAnalytics({ hostname = 'burrow.henryzh.dev' } = {}) {
+    const listeners = new Map()
+    let injectedScript = null
+    const firstScript = {
+        parentNode: {
+            insertBefore(script) {
+                injectedScript = script
+            },
+        },
+    }
+    const document = {
+        addEventListener(name, listener) {
+            listeners.set(name, listener)
+        },
+        createElement() {
+            return {}
+        },
+        getElementsByTagName() {
+            return [firstScript]
+        },
+    }
+    const location = {
+        hostname,
+        href: `https://${hostname}/?private=query#private-fragment`,
+        origin: `https://${hostname}`,
+        pathname: '/',
+    }
+    const window = { document, location }
+    window.window = window
+    const context = vm.createContext({ URL, document, location, window })
+    const source = fs.readFileSync(analyticsPath, 'utf8').replace(placeholder, 'phc_Test123')
+
+    vm.runInContext(source, context)
+
+    return { context, injectedScript, listeners }
+}
+
+function clickTarget(analyticsKey) {
+    return {
+        closest(selector) {
+            assert.equal(selector, '[data-burrow-analytics]')
+            return {
+                getAttribute(name) {
+                    assert.equal(name, 'data-burrow-analytics')
+                    return analyticsKey
+                },
+            }
+        },
+    }
+}
+
+test('production analytics is cookieless and limited to the approved features', () => {
+    const { context, injectedScript } = runAnalytics()
+    const [projectKey, config] = context.window.posthog._i[0]
+
+    assert.equal(projectKey, 'phc_Test123')
+    assert.equal(injectedScript.src, 'https://us-assets.i.posthog.com/static/array.js')
+    assert.equal(config.api_host, 'https://us.i.posthog.com')
+    assert.equal(config.ui_host, 'https://us.posthog.com')
+    assert.equal(config.cookieless_mode, 'always')
+    assert.equal(config.person_profiles, 'never')
+    assert.equal(config.autocapture, false)
+    assert.equal(config.capture_pageview, true)
+    assert.equal(config.capture_pageleave, true)
+    assert.equal(config.disable_scroll_properties, false)
+    assert.deepEqual(JSON.parse(JSON.stringify(config.capture_performance)), {
+        network_timing: false,
+        web_vitals: true,
+        web_vitals_allowed_metrics: ['CLS', 'INP', 'LCP'],
+    })
+    assert.equal(config.disable_session_recording, true)
+    assert.equal(config.capture_exceptions, false)
+    assert.equal(config.capture_dead_clicks, false)
+    assert.equal(config.enable_recording_console_log, false)
+    assert.equal(config.advanced_disable_flags, true)
+    assert.equal(config.respect_dnt, true)
+    assert.equal(config.save_campaign_params, false)
+    assert.equal(config.mask_personal_data_properties, true)
+    assert.equal(config.disable_capture_url_hashes, true)
+
+    const event = config.before_send({
+        event: '$pageview',
+        properties: {
+            $raw_user_agent: 'PrivateBrowser/1.0 exact-build-details',
+            $current_url: 'https://burrow.henryzh.dev/?secret=value#private',
+            $initial_current_url: 'https://burrow.henryzh.dev/releases.html?from=email#v0.11.1',
+            $referrer: 'https://search.example/results?q=private#answer',
+            $initial_referrer: 'https://news.example/story?user=private#comments',
+            $web_vitals_LCP_event: {
+                $current_url: 'https://burrow.henryzh.dev/roadmap.html?private=yes#planned',
+                delta: 20,
+                entries: [
+                    {
+                        element: '<img alt="private">',
+                        url: 'https://burrow.henryzh.dev/private.png?token=secret',
+                    },
+                ],
+                id: 'metric-identifier',
+                name: 'LCP',
+                navigationType: 'navigate',
+                rating: 'good',
+                timestamp: 123456789,
+                value: 123,
+            },
+        },
+    })
+
+    assert.equal('$raw_user_agent' in event.properties, false)
+    assert.equal(event.properties.$current_url, 'https://burrow.henryzh.dev/')
+    assert.equal(event.properties.$initial_current_url, 'https://burrow.henryzh.dev/releases.html')
+    assert.equal(event.properties.$referrer, 'https://search.example/results')
+    assert.equal(event.properties.$initial_referrer, 'https://news.example/story')
+    assert.deepEqual(JSON.parse(JSON.stringify(event.properties.$web_vitals_LCP_event)), {
+        $current_url: 'https://burrow.henryzh.dev/roadmap.html',
+        delta: 20,
+        name: 'LCP',
+        navigationType: 'navigate',
+        rating: 'good',
+        value: 123,
+    })
+})
+
+test('analytics stays inert outside the production hostname', () => {
+    const { context, injectedScript, listeners } = runAnalytics({ hostname: 'localhost' })
+
+    assert.equal(context.window.posthog, undefined)
+    assert.equal(injectedScript, null)
+    assert.equal(listeners.size, 0)
+})
+
+test('only fixed download and Homebrew-copy interactions are captured', () => {
+    const { context, listeners } = runAnalytics()
+    const click = listeners.get('click')
+    assert.equal(typeof click, 'function')
+
+    context.window.posthog.length = 0
+    click({ target: clickTarget('homebrew.hero') })
+    click({ target: clickTarget('download.pricing') })
+    click({ target: clickTarget('download.navigation') })
+    click({ target: clickTarget('unknown.future-event') })
+
+    assert.deepEqual(JSON.parse(JSON.stringify(context.window.posthog)), [
+        ['capture', 'website_homebrew_copy_clicked', { command: 'install', placement: 'hero' }],
+        ['capture', 'website_download_clicked', { destination: 'github_release', placement: 'pricing' }],
+        ['capture', 'website_download_clicked', { destination: 'github_release', placement: 'navigation' }],
+    ])
+})
+
+test('every public HTML page loads analytics and generated pages remain reproducible', () => {
+    for (const page of ['index.html', 'releases.html', 'roadmap.html']) {
+        const html = fs.readFileSync(path.join(root, 'docs', page), 'utf8')
+        assert.equal((html.match(/<script src="\/analytics\.js" defer><\/script>/g) || []).length, 1, page)
+    }
+
+    const index = fs.readFileSync(path.join(root, 'docs', 'index.html'), 'utf8')
+    for (const marker of [
+        'data-burrow-analytics="download.hero"',
+        'data-burrow-analytics="download.navigation"',
+        'data-burrow-analytics="download.pricing"',
+        'data-burrow-analytics="download.windows"',
+        'data-burrow-analytics="homebrew.hero"',
+        'data-burrow-analytics="homebrew.install_card"',
+    ]) {
+        assert.match(index, new RegExp(marker))
+    }
+
+    assert.match(
+        fs.readFileSync(path.join(root, 'docs', 'releases.html'), 'utf8'),
+        /data-burrow-analytics="download\.changelog"/
+    )
+    assert.match(
+        fs.readFileSync(path.join(root, 'docs', 'roadmap.html'), 'utf8'),
+        /data-burrow-analytics="download\.roadmap"/
+    )
+
+    execFileSync('python3', ['scripts/site-release.py', '--check'], { cwd: root, stdio: 'pipe' })
+})
+
+test('deployment injection validates the key and replaces exactly one placeholder', (t) => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'burrow-site-analytics-'))
+    t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+    const target = path.join(tempDir, 'analytics.js')
+    fs.copyFileSync(analyticsPath, target)
+
+    const missing = spawnSync('bash', ['scripts/inject-site-analytics.sh', target], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, POSTHOG_API_KEY: '' },
+    })
+    assert.notEqual(missing.status, 0)
+
+    const invalid = spawnSync('bash', ['scripts/inject-site-analytics.sh', target], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, POSTHOG_API_KEY: 'not-a-project-key' },
+    })
+    assert.notEqual(invalid.status, 0)
+
+    const validKey = 'phc_ValidTestKey123'
+    const valid = spawnSync('bash', ['scripts/inject-site-analytics.sh', target], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, POSTHOG_API_KEY: validKey },
+    })
+    assert.equal(valid.status, 0, valid.stderr)
+    assert.doesNotMatch(`${valid.stdout}${valid.stderr}`, new RegExp(validKey))
+
+    const deployed = fs.readFileSync(target, 'utf8')
+    assert.doesNotMatch(deployed, new RegExp(placeholder))
+    assert.match(deployed, new RegExp(validKey))
+
+    const duplicateRun = spawnSync('bash', ['scripts/inject-site-analytics.sh', target], {
+        cwd: root,
+        encoding: 'utf8',
+        env: { ...process.env, POSTHOG_API_KEY: validKey },
+    })
+    assert.notEqual(duplicateRun.status, 0)
+})
+
+test('site deployment fails closed when the analytics key is unavailable', () => {
+    const workflow = fs.readFileSync(path.join(root, '.github', 'workflows', 'deploy-site.yml'), 'utf8')
+    const requireKey = workflow.indexOf('- name: Require website analytics key')
+    const injectKey = workflow.indexOf('- name: Prepare website assets')
+    const deploy = workflow.indexOf('- uses: cloudflare/wrangler-action@')
+
+    assert.notEqual(requireKey, -1)
+    assert.notEqual(injectKey, -1)
+    assert.ok(requireKey < injectKey)
+    assert.ok(injectKey < deploy)
+    assert.match(workflow, /HAS_POSTHOG_KEY: \$\{\{ secrets\.POSTHOG_API_KEY != '' \}\}/)
+    assert.match(workflow, /run: bash scripts\/prepare-site-assets\.sh \.site-deploy/)
+    assert.doesNotMatch(workflow, /cp -R docs/)
+    assert.match(workflow, /'scripts\/inject-site-analytics\.sh'/)
+    assert.match(workflow, /'scripts\/prepare-site-assets\.sh'/)
+    assert.match(workflow, /'scripts\/deploy-site\.sh'/)
+    assert.doesNotMatch(workflow, /run 'npx wrangler deploy' locally/)
+
+    const wrangler = fs.readFileSync(path.join(root, 'wrangler.jsonc'), 'utf8')
+    assert.match(wrangler, /"directory": "\.\/\.site-deploy"/)
+    assert.equal(fs.existsSync(path.join(root, '.site-deploy')), false)
+})
+
+test('local deployment stages injected assets without mutating source', (t) => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'burrow-site-deploy-test-'))
+    t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+    const binDir = path.join(tempDir, 'bin')
+    const argsPath = path.join(tempDir, 'npx-args')
+    const mockNpx = path.join(binDir, 'npx')
+    fs.mkdirSync(binDir)
+    fs.writeFileSync(
+        mockNpx,
+        `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "wrangler" && "$2" == "deploy" && "$3" == "--assets" && -n "\${4:-}" ]]
+grep -qF "$POSTHOG_API_KEY" "$4/analytics.js"
+! grep -qF '${placeholder}' "$4/analytics.js"
+printf '%s\\n' "$@" > "$BURROW_TEST_ARGS"
+`
+    )
+    fs.chmodSync(mockNpx, 0o755)
+
+    const sourceBefore = fs.readFileSync(analyticsPath, 'utf8')
+    const result = spawnSync('bash', ['scripts/deploy-site.sh'], {
+        cwd: root,
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            BURROW_TEST_ARGS: argsPath,
+            PATH: `${binDir}:${process.env.PATH}`,
+            POSTHOG_API_KEY: 'phc_LocalDeployTest123',
+        },
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(fs.readFileSync(analyticsPath, 'utf8'), sourceBefore)
+    const args = fs.readFileSync(argsPath, 'utf8').trim().split('\n')
+    assert.deepEqual(args.slice(0, 3), ['wrangler', 'deploy', '--assets'])
+    assert.match(args[3], /burrow-site-deploy\..*\/assets$/)
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,11 +1,14 @@
 // Cloudflare Worker (static assets only) serving the landing site in docs/
-// at https://burrow.henryzh.dev. Deploy: npx wrangler deploy
+// at https://burrow.henryzh.dev. Deploy only through the GitHub workflow or
+// scripts/deploy-site.sh so the PostHog project key is validated and injected.
 {
   "name": "burrow-site",
   "compatibility_date": "2026-06-11",
   "account_id": "55b0640db6ae7f14ca61ec105d27925c",
   "assets": {
-    "directory": "./docs"
+    // Intentionally absent from a checkout: raw `npx wrangler deploy` fails
+    // closed instead of publishing docs/ with an inert analytics placeholder.
+    "directory": "./.site-deploy"
   },
   "routes": [
     { "pattern": "burrow.henryzh.dev", "custom_domain": true }


### PR DESCRIPTION
## Summary

- add production-only PostHog web analytics for page views, page leaves, scroll depth, CLS/INP/LCP, release-download clicks, and Homebrew command copies
- keep the site cookieless, anonymous, non-replay, non-autocapture, and non-profiling while sanitizing URLs, Web Vitals details, and raw user-agent event data
- make Cloudflare deployment fail closed unless the PostHog project key is present and valid, using one shared staging path for CI and local deploys
- document the exact website data boundary without changing the existing opt-out macOS or Windows telemetry pipelines

## Verification

- 30 Python tests
- 7 website analytics tests
- Greenlight preflight: GREENLIT
- shellcheck and bash syntax checks
- actionlint for the site deployment workflow
- generated site consistency and git diff checks

## PostHog

The production URL and privacy settings are configured in PostHog. The pinned Burrow dashboard now includes website page/session and download/Homebrew-intent panels. These remain empty until the PR deploys and production traffic arrives.