### PR TITLE
fix(site): preserve cookieless hashing input

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,12 +101,13 @@ This is the part people rightly scrutinize in cleaners. Burrow's model:
   **[TELEMETRY.md](TELEMETRY.md)**.
 - **The public website uses separate cookieless analytics.** On the exact
   `burrow.henryzh.dev` production host, PostHog records page views/leaves,
-  scroll depth, CLS/INP/LCP, and fixed download/Homebrew-copy events. It stores
-  no browser identifier, creates no person profile, strips URL queries and
-  fragments, honors Do Not Track, and disables replay, generic click capture,
-  exceptions, console/network capture, surveys, and flags. Requests go directly
-  to PostHog so content blockers remain effective; the exact fields and
-  server-side daily-hash behavior are in **[TELEMETRY.md](TELEMETRY.md)**.
+  scroll depth, CLS/INP/LCP, and fixed download/Homebrew-copy events. It sets no
+  browser identifier in client storage, creates no person profile, strips URL
+  queries and fragments, honors Do Not Track, and disables replay, generic
+  click capture, exceptions, console/network capture, surveys, and flags.
+  Requests go directly to PostHog so content blockers remain effective; the
+  exact fields and server-side daily-hash behavior are in
+  **[TELEMETRY.md](TELEMETRY.md)**.
 - **Telemetry stays off the UI thread.** macOS PostHog delivery uses Burrow's
   own serial background transport rather than the SDK timer that previously
   ran on AppKit's main run loop. A local 64-event sanitized outbox retries one

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -193,11 +193,11 @@ directly is unsupported because it bypasses that guard.
 The site uses PostHog's **stateful cookieless mode**. It sets no PostHog cookie,
 local-storage value, or session-storage value, never calls `identify`, and
 creates no person profile. PostHog derives a rotating daily hash from the
-request IP, user agent, and site domain, uses temporary server-side state for a
-30-minute session boundary, then strips the raw IP before event processing; the
-project's separate **Discard client IP data** setting remains enabled as a
-second guard. The daily hash is unrelated to either app's random install ID and
-cannot follow a browser across days.
+request IP, the SDK's raw user-agent field, and the site domain, then removes
+both raw inputs before writing the event. It uses temporary server-side state
+for a 30-minute session boundary; the project's separate **Discard client IP
+data** setting remains enabled as a second guard. The daily hash is unrelated
+to either app's random install ID and cannot follow a browser across days.
 
 The captured website events and fields are:
 
@@ -211,10 +211,10 @@ The captured website events and fields are:
 PostHog also attaches ordinary web context: browser and OS family/version,
 device type, language/time zone, viewport and screen dimensions, page host/path
 and title, sanitized referrer, and PostHog library version. URL query strings
-and fragments are removed before sending, the complete raw user-agent event
-property is discarded, campaign-parameter persistence is off, and Do Not Track
-is honored. PostHog still receives the user-agent request header needed for the
-rotating cookieless hash described above.
+and fragments are removed before sending. The SDK transmits its raw user-agent
+field only because cookieless preprocessing requires it; PostHog removes that
+field after deriving the rotating hash described above. Campaign-parameter
+persistence is off, and Do Not Track is honored.
 
 Generic element autocapture, session replay, heatmaps, rage/dead-click capture,
 JavaScript exception capture, console capture, network timing, person profiles,

--- a/docs/analytics.js
+++ b/docs/analytics.js
@@ -21,11 +21,8 @@
   function sanitizeEvent(event) {
     if (!event || !event.properties) return event;
 
-    // PostHog can attach the complete browser user-agent string as an event
-    // property. The server may still use the request header to derive its
-    // rotating cookieless identifier, but the raw value is not retained with
-    // Burrow's analytics events.
-    delete event.properties.$raw_user_agent;
+    // Keep PostHog's $raw_user_agent input: cookieless ingestion requires it
+    // to derive the rotating hash, then removes it before storing the event.
 
     ['$current_url', '$initial_current_url', '$referrer', '$initial_referrer'].forEach(function (name) {
       if (!(name in event.properties)) return;

--- a/scripts/tests/test_site_analytics.mjs
+++ b/scripts/tests/test_site_analytics.mjs
@@ -118,7 +118,7 @@ test('production analytics is cookieless and limited to the approved features', 
         },
     })
 
-    assert.equal('$raw_user_agent' in event.properties, false)
+    assert.equal(event.properties.$raw_user_agent, 'PrivateBrowser/1.0 exact-build-details')
     assert.equal(event.properties.$current_url, 'https://burrow.henryzh.dev/')
     assert.equal(event.properties.$initial_current_url, 'https://burrow.henryzh.dev/releases.html')
     assert.equal(event.properties.$referrer, 'https://search.example/results')


### PR DESCRIPTION
## What changed

- Preserve PostHog's `$raw_user_agent` field through the browser sanitizer because stateful cookieless ingestion requires it to derive the rotating identifier.
- Keep the existing cookie, browser-storage, person-profile, replay, and autocapture restrictions unchanged.
- Add a regression assertion that fails if the required input is stripped again.
- Correct `TELEMETRY.md` and `SECURITY.md` to explain that the SDK sends the raw input for cookieless preprocessing and PostHog removes both the raw user agent and IP before event storage.

## Why

PR #334 deleted `$raw_user_agent` before sending. PostHog's stateful cookieless processor treats that field as required and drops the entire event when it is missing, so production website analytics could never ingest an event. The server uses the field only while deriving its rotating daily hash, then strips it before writing the event.

## Verification

- 30 Python release-safety tests
- 7 website analytics boundary tests
- shellcheck and Bash syntax checks
- actionlint
- generated-site consistency check
- `git diff --check`
- Greenlight preflight: GREENLIT
- Independent standards review: 0 findings
- Independent spec review: 0 findings
