### PR TITLE
fix(macos): harden updater and status-item diagnostics

### DIFF
--- a/.github/workflows/sentry-issues.yml
+++ b/.github/workflows/sentry-issues.yml
@@ -14,8 +14,13 @@ name: sentry-issues
 # needs a trip to the Sentry dashboard. Best-effort: if the trace can't be
 # fetched/parsed the issue is still filed, just without the trace block.
 #
+# App-Hang groups are collected into one rolling weekly digest instead of
+# opening one GitHub issue per sampled top frame. The digest still carries
+# every Sentry short-id, release/build tags, and a bounded stack trace, so hangs
+# stay visible without flooding the tracker.
+#
 # Dedup is by a hidden marker line ("sentry-id: <short-id>") in the body of
-# every issue we file. Before filing, we read back the short-ids of all
+# every issue or digest we file. Before filing, we read back the short-ids of all
 # existing `sentry`-labelled issues (open AND closed) and skip any we've
 # already filed — so a given Sentry issue is filed exactly once, even after
 # its GitHub issue is closed.
@@ -66,6 +71,14 @@ jobs:
       LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '168' }}
       # Cap creations per run so a backlog can't open hundreds of issues at once.
       MAX_PER_RUN: "25"
+      # Bound each App-Hang batch so its table, traces, and markers fit inside
+      # GitHub's 65,536-character issue-body limit with room to append safely.
+      MAX_HANG_GROUPS_PER_RUN: "20"
+      MAX_HANG_TRACE_CHARS: "1200"
+      MAX_ISSUE_BODY_BYTES: "60000"
+      # Defensive ceiling against a malformed cursor loop. Normal runs exhaust
+      # the Sentry result set long before this (100 pages × 50 groups).
+      MAX_SENTRY_PAGES_PER_PROJECT: "100"
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -88,6 +101,10 @@ jobs:
             --json body --jq '.[].body' 2>/dev/null \
             | grep -oE 'sentry-id: [^ <]+' | awk '{print $2}' | sort -u > "$seen" || true
           echo "Already filed: $(wc -l < "$seen" | tr -d ' ') Sentry issue(s)."
+          hang_rows="$(mktemp)"
+          hang_details="$(mktemp)"
+          hang_markers="$(mktemp)"
+          hang_count=0
 
           # jq program that distils a Sentry event into a compact stack trace.
           # Prefers the crashed/current thread (the right one for App Hang/ANR
@@ -111,22 +128,84 @@ jobs:
           | reverse | .[0:30] | map(fmtframe) | join("\n")
           JQ
 
+          # Populate four globals from a latest-event payload. Burrow's
+          # beforeSend policy already bounds these fields; sanitize again
+          # before copying them into a public GitHub issue.
+          populate_event_context() {
+            local event_json="${1:-{}}"
+            release=$(jq -r '
+              if (.release | type) == "object" then (.release.version // "unknown")
+              elif (.release | type) == "string" then .release
+              else "unknown"
+              end
+            ' <<<"$event_json" 2>/dev/null || echo unknown)
+            osBuild=$(jq -r '[.tags[]? | select(.key=="os_build") | .value][0] // "unknown"' <<<"$event_json" 2>/dev/null || echo unknown)
+            launchPhase=$(jq -r '[.tags[]? | select(.key=="launch_phase") | .value][0] // "unknown"' <<<"$event_json" 2>/dev/null || echo unknown)
+            statusItem=$(jq -r '[.tags[]? | select(.key=="status_item_state") | .value][0] // "unknown"' <<<"$event_json" 2>/dev/null || echo unknown)
+            release=$(printf '%s' "$release" | tr -cd 'A-Za-z0-9._:+-' | cut -c1-80)
+            osBuild=$(printf '%s' "$osBuild" | tr -cd 'A-Za-z0-9._:+-' | cut -c1-80)
+            launchPhase=$(printf '%s' "$launchPhase" | tr -cd 'A-Za-z0-9._:+-' | cut -c1-80)
+            statusItem=$(printf '%s' "$statusItem" | tr -cd 'A-Za-z0-9._:+-' | cut -c1-80)
+            [ -n "$release" ] || release=unknown
+            [ -n "$osBuild" ] || osBuild=unknown
+            [ -n "$launchPhase" ] || launchPhase=unknown
+            [ -n "$statusItem" ] || statusItem=unknown
+          }
+
           filed=0
           for project in $SENTRY_PROJECTS; do
+            # $q below is jq syntax, not a shell variable.
+            # shellcheck disable=SC2016
             q=$(jq -rn --arg q "$SENTRY_QUERY" '$q | @uri')
             url="${SENTRY_HOST}/api/0/projects/${SENTRY_ORG}/${project}/issues/?query=${q}&sort=new&limit=50"
+            response_rows="$(mktemp)"
+            page_url="$url"
+            page_count=0
+            fetched=0
 
-            resp=$(curl -fsS -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" "$url") || {
-              echo "::warning::Sentry API request failed for project '${project}' — skipping."
-              continue
-            }
+            # Sentry's issue endpoint is cursor-paginated through its Link
+            # response header. Collect every page so unresolved groups that
+            # have fallen past the newest 50 cannot be starved by already-seen
+            # groups at the front of the result set.
+            while [ -n "$page_url" ]; do
+              headers="$(mktemp)"
+              page="$(mktemp)"
+              if ! curl -fsS -D "$headers" -o "$page" \
+                   -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" "$page_url"; then
+                echo "::warning::Sentry API request failed for project '${project}' page $((page_count + 1)); processing pages already fetched."
+                break
+              fi
 
-            fetched=$(jq 'if type=="array" then length else -1 end' <<<"$resp" 2>/dev/null || echo -1)
-            if [ "$fetched" = "-1" ]; then
-              echo "::warning::Sentry returned a non-array response for '${project}' — skipping. Head: $(head -c 160 <<<"$resp")"
+              page_fetched=$(jq 'if type=="array" then length else -1 end' "$page" 2>/dev/null || echo -1)
+              if [ "$page_fetched" = "-1" ]; then
+                echo "::warning::Sentry returned a non-array response for '${project}' page $((page_count + 1)); processing pages already fetched. Head: $(head -c 160 "$page")"
+                break
+              fi
+              jq -c '.[]' "$page" >> "$response_rows"
+              fetched=$((fetched + page_fetched))
+              page_count=$((page_count + 1))
+
+              page_url=""
+              link_header=$(tr -d '\r' < "$headers" | sed -n 's/^[Ll]ink:[[:space:]]*//p' || true)
+              while IFS= read -r link; do
+                if [[ "$link" == *'rel="next"'* && "$link" == *'results="true"'* ]]; then
+                  candidate="${link#*<}"
+                  page_url="${candidate%%>*}"
+                  break
+                fi
+              done < <(printf '%s' "$link_header" | tr ',' '\n')
+
+              if [ "$page_count" -ge "$MAX_SENTRY_PAGES_PER_PROJECT" ] && [ -n "$page_url" ]; then
+                echo "::warning::Stopped Sentry pagination for '${project}' at ${page_count} pages to avoid a malformed cursor loop."
+                page_url=""
+              fi
+            done
+
+            if [ "$page_count" -eq 0 ]; then
+              echo "::warning::No valid Sentry issue page was fetched for '${project}' — skipping."
               continue
             fi
-            echo "project ${project}: fetched ${fetched} unresolved issue(s)."
+            echo "project ${project}: fetched ${fetched} unresolved issue(s) across ${page_count} page(s)."
             skipped_seen=0
             skipped_old=0
 
@@ -149,20 +228,52 @@ jobs:
                 continue
               fi
 
-              # Skip App-Hang (ANR) issues. One 2 s main-thread stall fans out
-              # into many Sentry issues — the hang sampler's top frame differs
-              # each time (swift_release, StackLayout.explicitAlignment, langid_…),
-              # all the same underlying event — so filing one GitHub issue per
-              # short-id floods the tracker for a single hang. They're also low
-              # signal here: the memory-starved majority (Burrow runs on RAM-
-              # pressured Macs) is already dropped client-side in
-              # CrashReporter.isMemoryStarvedAppHang, and a genuine hang is better
-              # triaged in Sentry, where its fan-out is grouped. Match on
-              # issueType/title so it's robust to exact wording.
+              # A single sampled stall may fan out across several Sentry groups
+              # when their top frames differ. Keep every group visible, but add
+              # it to one weekly digest instead of opening one GitHub issue per
+              # short-id. Match on issueType/title so this survives wording
+              # changes between Sentry Cocoa SDK versions.
               issueType=$(jq -r '.issueType // empty' <<<"$issue")
               titleProbe=$(jq -r '.title // .metadata.value // empty' <<<"$issue")
               if printf '%s %s' "$issueType" "$titleProbe" | grep -qiE 'app[ _-]?hang|hanging'; then
-                echo "Skipping App-Hang issue ${shortId} (ANR fan-out — not auto-filed)."
+                if [ "$hang_count" -ge "$MAX_HANG_GROUPS_PER_RUN" ]; then
+                  echo "Deferring App-Hang ${shortId}: this run's bounded digest batch is full."
+                  continue
+                fi
+                count=$(jq -r '.count // "?"' <<<"$issue")
+                lastSeen=$(jq -r '.lastSeen // "?"' <<<"$issue")
+                permalink=$(jq -r '.permalink // empty' <<<"$issue")
+                issueId=$(jq -r '.id // empty' <<<"$issue")
+                ev=""
+                trace=""
+                if [ -n "$issueId" ]; then
+                  ev=$(curl -fsS -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
+                        "${SENTRY_HOST}/api/0/organizations/${SENTRY_ORG}/issues/${issueId}/events/latest/" 2>/dev/null) || ev=""
+                  [ -n "$ev" ] && trace=$(jq -r "$TRACE_JQ" <<<"$ev" 2>/dev/null || true)
+                fi
+                if [ "${#trace}" -gt "$MAX_HANG_TRACE_CHARS" ]; then
+                  trace="$(printf '%s' "$trace" | cut -c1-"$MAX_HANG_TRACE_CHARS")
+          … trace truncated by the Sentry bridge"
+                fi
+
+                populate_event_context "$ev"
+
+                # Backticks are literal Markdown delimiters.
+                # shellcheck disable=SC2016
+                printf '| [%s](%s) | `%s` | %s | `%s` | `%s` | `%s` | %s | %s |\n' \
+                  "$shortId" "$permalink" "$project" "$count" "$release" "$osBuild" \
+                  "$launchPhase" "$statusItem" "$lastSeen" >> "$hang_rows"
+                if [ -n "$trace" ]; then
+                  {
+                    printf '\n<details>\n<summary>%s latest stack trace</summary>\n\n```\n' "$shortId"
+                    printf '%s\n' "$trace"
+                    printf '```\n\n</details>\n'
+                  } >> "$hang_details"
+                fi
+                printf '<sub>sentry-id: %s — managed marker, do not edit or remove.</sub>\n' "$shortId" >> "$hang_markers"
+                echo "$shortId" >> "$seen"
+                hang_count=$((hang_count + 1))
+                echo "Queued App-Hang ${shortId} for the weekly digest."
                 continue
               fi
 
@@ -183,12 +294,14 @@ jobs:
               # issue, network blip) or an empty jq result just files the issue
               # without a trace block, exactly as before.
               issueId=$(jq -r '.id // empty' <<<"$issue")
+              ev=""
               trace=""
               if [ -n "$issueId" ]; then
                 ev=$(curl -fsS -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
                       "${SENTRY_HOST}/api/0/organizations/${SENTRY_ORG}/issues/${issueId}/events/latest/" 2>/dev/null) || ev=""
                 [ -n "$ev" ] && trace=$(jq -r "$TRACE_JQ" <<<"$ev" 2>/dev/null || true)
               fi
+              populate_event_context "$ev"
 
               printf -v body '%s\n' \
                 "Auto-filed from Sentry by the \`sentry-issues\` workflow." \
@@ -199,6 +312,10 @@ jobs:
                 "| **Project** | \`${project}\` |" \
                 "| **Level** | ${level} |" \
                 "| **Events** | ${count} |" \
+                "| **Release** | \`${release}\` |" \
+                "| **OS build** | \`${osBuild}\` |" \
+                "| **Launch phase** | \`${launchPhase}\` |" \
+                "| **Status item** | \`${statusItem}\` |" \
                 "| **First seen** | ${firstSeen} |" \
                 "| **Last seen** | ${lastSeen} |"
 
@@ -230,8 +347,72 @@ jobs:
               else
                 echo "::warning::Failed to create GitHub issue for ${shortId}."
               fi
-            done < <(jq -c '.[]' <<<"$resp")
+            done < "$response_rows"
             echo "project ${project}: ${skipped_seen} already filed, ${skipped_old} outside lookback."
           done
 
-          echo "Done. Filed ${filed} new issue(s) this run."
+          if [ "$hang_count" -gt 0 ]; then
+            digest_week=$(date -u +'%G-W%V')
+            digest_base_title="[Sentry] App-Hang digest — ${digest_week}"
+            digest_section="$(mktemp)"
+            {
+              printf '\n## New groups observed %s\n\n' "$(date -u '+%Y-%m-%d %H:%M UTC')"
+              printf '| Sentry | Project | Events | Release | OS build | Launch phase | Status item | Last seen |\n'
+              printf '|---|---|---:|---|---|---|---|---|\n'
+              cat "$hang_rows"
+              cat "$hang_details"
+              printf '\n'
+              cat "$hang_markers"
+            } > "$digest_section"
+
+            digest_list=$(gh issue list --repo "$GH_REPO" --label sentry --state open --limit 100 \
+              --json number,title)
+            digest_part=1
+            digest_title="$digest_base_title"
+            digest_number=""
+            while :; do
+              # $title below is jq syntax, not a shell variable.
+              # shellcheck disable=SC2016
+              candidate_number=$(jq -r --arg title "$digest_title" \
+                '.[] | select(.title == $title) | .number' <<<"$digest_list" | head -n 1)
+              [ -n "$candidate_number" ] || break
+              digest_number="$candidate_number"
+              digest_part=$((digest_part + 1))
+              digest_title="${digest_base_title} — part ${digest_part}"
+            done
+
+            # If the latest open part still has room, append there. Otherwise,
+            # create the next numbered part. The per-run group/trace bounds
+            # above guarantee a fresh part stays below the body limit.
+            if [ -n "$digest_number" ]; then
+              digest_body="$(mktemp)"
+              gh issue view "$digest_number" --repo "$GH_REPO" --json body --jq '.body' > "$digest_body"
+              existing_bytes=$(wc -c < "$digest_body" | tr -d ' ')
+              section_bytes=$(wc -c < "$digest_section" | tr -d ' ')
+              if [ $((existing_bytes + section_bytes)) -le "$MAX_ISSUE_BODY_BYTES" ]; then
+                cat "$digest_section" >> "$digest_body"
+                gh issue edit "$digest_number" --repo "$GH_REPO" --body-file "$digest_body" >/dev/null
+                echo "Updated App-Hang digest #${digest_number} with ${hang_count} new group(s)."
+                digest_number="updated"
+              else
+                digest_number=""
+                echo "Rolling App-Hang digest into part ${digest_part}; the prior part is ${existing_bytes} bytes."
+              fi
+            fi
+
+            if [ -z "$digest_number" ]; then
+              digest_body="$(mktemp)"
+              {
+                # Backticks are literal Markdown delimiters.
+                # shellcheck disable=SC2016
+                printf '%s\n\n' 'Auto-filed from Sentry by the `sentry-issues` workflow.'
+                printf '%s\n' 'App-Hang samples can split into several Sentry groups when their top frames differ. This weekly digest keeps every group visible without opening one GitHub issue per sampled frame.'
+                cat "$digest_section"
+              } > "$digest_body"
+              gh issue create --repo "$GH_REPO" --title "$digest_title" --label sentry \
+                --body-file "$digest_body" >/dev/null
+              echo "Created App-Hang digest part ${digest_part} with ${hang_count} new group(s)."
+            fi
+          fi
+
+          echo "Done. Filed ${filed} regular issue(s); recorded ${hang_count} App-Hang group(s)."

--- a/README.md
+++ b/README.md
@@ -364,9 +364,11 @@ Burrow** — or turn the menu-bar icon off in Settings to run it as a Dock app.
 If a macOS build freezes while Burrow creates that status item, the next launch
 stays in Dock-based compatibility mode on the same OS build and offers a
 one-click redacted diagnostic report. Automatic Sparkle startup waits until
-the status item is stable; if the updater then fails its own stability window,
+the initial AppKit launch turn has settled and the status item is stable; if
+the updater then fails its own stability window,
 later automatic checks pause for that app/OS build while manual checks remain
-available. Updating Burrow or macOS retries the guarded path.
+available. A new macOS build retries a guarded status item; a new Burrow or
+macOS build retries an updater that previously failed its stability window.
 
 ### Windows preview build
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,8 +14,8 @@ failure without collecting screen contents or user files.
 ## Fixed
 - **The affected macOS 27 beta gets a safer launch path.** On Beta 4 build
   `26A5388g`, Burrow starts with a Dock icon instead of creating its menu-bar
-  status item. The fallback is deliberately limited to that exact build and is
-  retried after either Burrow or macOS changes. Manual update checks remain
+  status item. The fallback is deliberately limited to that exact build; a new
+  macOS build restores the normal guarded path. Manual update checks remain
   available even when automatic Sparkle startup is paused.
 - **Interrupted launches recover one component at a time.** A durable launch
   journal gives the status item and Sparkle separate 30-second stability

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -31,7 +31,9 @@ release ZIP; Burrow adds no identifier or device profile to those requests.
 Burrow separately records fixed-name update milestones such as
 `update_found`, `update_download_failed`, and `update_install_started` through
 the opt-out telemetry pipeline. Depending on the milestone, properties contain
-only the update version, check source, result, and error domain/code. Sparkle
+only the update version, check source, result, fixed failure category/recovery,
+and bounded outer/underlying error domain/code. Error descriptions, request
+URLs, response bodies, and network names are never sent. Sparkle
 system profiling is explicitly disabled with `SUEnableSystemProfiling=false`;
 GitHub necessarily sees the request IP at the network layer. Signing and
 notarization themselves add no telemetry and require no additional
@@ -98,7 +100,7 @@ so no IP is attached to events either.
 
 | Events | Properties |
 |---|---|
-| `app_opened`, `app_ready`, `app_terminated` | cold-start; menu-bar availability; compatibility-mode boolean |
+| `app_opened`, `app_ready`, `app_terminated` | cold-start; menu-bar availability; compatibility-mode boolean and fixed status-item state |
 | `app_updated` | previous/current app version and build |
 | `engine_missing`, `install_window_ready`, `onboarding_completed` | none |
 | `telemetry_opt_in_changed` | enabled boolean |
@@ -106,14 +108,15 @@ so no IP is attached to events either.
 | `feature_operation_started`, `feature_operation_completed` | `clean`/`optimize`, dry-run/elevated booleans, fixed result, bucketed duration |
 | `previous_launch_incomplete` | previous phase, app version/build, OS build, bucketed elapsed time |
 | `compatibility_fallback_activated`, `compatibility_fallback_reaffirmed` | fixed reason, OS build, menu-bar mode |
+| `status_item_creation_scheduled`, `status_item_stability_started`, `status_item_stabilized` | fixed `launch` or `settings` source |
 | `diagnostic_report_copied` | fixed recovery reason |
-| `updater_started`, `updater_stabilized` | `automatic`, `manual`, or `settings` source on start; none on stabilization |
+| `updater_started`, `updater_stabilized` | `automatic`, `manual`, or `settings` source |
 | `automatic_updater_suppressed` | fixed recovery reason, app build, and OS build |
 | `update_check_started` | `manual` source |
-| `update_found`, `update_not_found` | target version on `update_found`; none on `update_not_found` |
-| `update_download_started`, `update_download_completed`, `update_download_failed` | target version; failures add error domain/code |
+| `update_found`, `update_not_found` | target version on `update_found`; fixed manual/automatic source on `update_not_found` |
+| `update_download_started`, `update_download_completed`, `update_download_failed` | target version; failures add fixed category/recovery and bounded outer/underlying error domain/code |
 | `update_install_started`, `update_choice_made` | target version, fixed choice, numeric Sparkle stage |
-| `update_cycle_completed`, `update_cycle_failed` | source, fixed result/update-found boolean; failures add error domain/code |
+| `update_cycle_completed`, `update_cycle_failed` | source, fixed result/update-found boolean; failures add fixed category/recovery and bounded outer/underlying error domain/code |
 
 Sentry captures crashes, unhandled errors, and app hangs automatically. Release
 health sessions are enabled and the fixed-name launch trace is sampled at 10%.
@@ -125,6 +128,17 @@ Burrow adds at most 50 fixed-name manual breadcrumbs and fixed-name
 warning/error logs. Automatic network breadcrumbs, failed-request capture,
 file I/O tracing, Core Data tracing, UI tracing, screenshots, and view-hierarchy
 capture remain disabled.
+
+Expected updater conditions do not become Sentry issues. Sparkle's
+running-translocated/running-from-disk-image errors stay in PostHog with the
+fixed `move_to_applications` recovery, ordinary network download failures stay
+in PostHog with `sparkle_scheduled_retry`, and user cancellations are recorded
+as completed cycles. Configuration, signature/validation, installation, and
+otherwise unknown failures still create a scrubbed Sentry diagnostic. The
+GitHub bridge includes bounded release, OS-build, launch-phase, status-item,
+count, and stack information on every new issue. App-Hang groups are aggregated
+into a weekly digest instead of being silently skipped or opening one issue per
+sampled frame.
 
 Automatic Sparkle startup begins only after the status item has remained
 responsive for 30 seconds, then receives a separate 30-second durable

--- a/docs/index.html
+++ b/docs/index.html
@@ -398,7 +398,7 @@
     <div class="grid3 wn-grid">
       <article class="tcard" style="--c: var(--green)">
         <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Safer on the affected macOS beta</div></div>
-        <p class="ds">On macOS 27 Beta 4 build <code>26A5388g</code>, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; normal behavior is retried after Burrow or macOS changes.</p>
+        <p class="ds">On macOS 27 Beta 4 build <code>26A5388g</code>, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; a new macOS build restores the normal guarded path.</p>
       </article>
       <article class="tcard" style="--c: var(--azure)">
         <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5-7 4 14 2.5-7h5"/></svg></div><div class="nm">Startup tells us where it stopped</div></div>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -139,7 +139,7 @@
         <div class="sblock">
           <div class="slabel mono">fixed</div>
           <ul class="slist">
-            <li><b>The affected macOS 27 beta gets a safer launch path.</b> On Beta 4 build <code>26A5388g</code>, Burrow starts with a Dock icon instead of creating its menu-bar status item. The fallback is limited to that exact build and is retried after either Burrow or macOS changes. Manual update checks remain available even when automatic Sparkle startup is paused.</li>
+            <li><b>The affected macOS 27 beta gets a safer launch path.</b> On Beta 4 build <code>26A5388g</code>, Burrow starts with a Dock icon instead of creating its menu-bar status item. The fallback is limited to that exact build; a new macOS build restores the normal guarded path. Manual update checks remain available even when automatic Sparkle startup is paused.</li>
             <li><b>Interrupted launches recover one component at a time.</b> A durable launch journal gives the status item and Sparkle separate 30-second stability windows. If launch is interrupted, the next run suppresses only the component whose window was active, shows a recovery alert, and offers a one-click redacted diagnostic report. (<a href="https://github.com/caezium/Burrow/pull/321" target="_blank" rel="noopener">#321</a>)</li>
           </ul>
         </div>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -11,7 +11,7 @@
           "icon": "shield",
           "color": "green",
           "title": "Safer on the affected macOS beta",
-          "line": "On macOS 27 Beta 4 build `26A5388g`, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; normal behavior is retried after Burrow or macOS changes."
+          "line": "On macOS 27 Beta 4 build `26A5388g`, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; a new macOS build restores the normal guarded path."
         },
         {
           "icon": "pulse",
@@ -35,7 +35,7 @@
         {
           "label": "fixed",
           "items": [
-            "**The affected macOS 27 beta gets a safer launch path.** On Beta 4 build `26A5388g`, Burrow starts with a Dock icon instead of creating its menu-bar status item. The fallback is limited to that exact build and is retried after either Burrow or macOS changes. Manual update checks remain available even when automatic Sparkle startup is paused.",
+            "**The affected macOS 27 beta gets a safer launch path.** On Beta 4 build `26A5388g`, Burrow starts with a Dock icon instead of creating its menu-bar status item. The fallback is limited to that exact build; a new macOS build restores the normal guarded path. Manual update checks remain available even when automatic Sparkle startup is paused.",
             "**Interrupted launches recover one component at a time.** A durable launch journal gives the status item and Sparkle separate 30-second stability windows. If launch is interrupted, the next run suppresses only the component whose window was active, shows a recovery alert, and offers a one-click redacted diagnostic report. ([#321](https://github.com/caezium/Burrow/pull/321))"
           ]
         },

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -55,6 +55,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var safeModeActive = false
     private var recoveryNoticePresented = false
     private var launchCompleted = false
+    private var initialStatusItemCreationTask: Task<Void, Never>?
     private var statusItemStabilityTask: Task<Void, Never>?
     private var statusItemStabilityGeneration = 0
     private var statusItemStabilitySpan: DiagnosticSpan?
@@ -221,13 +222,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
 
         safeModeActive = Store.showMenuBarIcon && recoveryReason != nil
-        if Store.showMenuBarIcon, !safeModeActive {
-            markLaunch(.statusItemCreating)
-            let statusItemSpan = CrashReporter.startLaunchSpan("status_item_create")
-            self.statusBar = StatusBarController(db: db, producer: producer, delegate: self)
-            statusItemSpan?.finish()
-            markLaunch(.statusItemReady)
-            scheduleStatusItemStabilityMarker()
+        if StatusItemStartupPolicy.shouldScheduleInitialCreation(
+            showMenuBarIcon: Store.showMenuBarIcon,
+            recoveryReason: recoveryReason
+        ) {
+            scheduleInitialStatusItemCreation(db: db, producer: producer)
         } else if safeModeActive, let recoveryReason {
             CrashReporter.setStatusItemState(.compatibilityMode)
             NSApp.setActivationPolicy(.regular)
@@ -383,6 +382,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        initialStatusItemCreationTask?.cancel()
+        initialStatusItemCreationTask = nil
         statusItemStabilityTask?.cancel()
         statusItemStabilityTask = nil
         statusItemStabilitySpan?.finish()
@@ -538,16 +539,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                     openMainWindow(initial: .home)
                 }
                 Telemetry.capture("compatibility_fallback_reaffirmed", [
+                    "reason": recoveryReason?.rawValue ?? "unknown",
                     "os_build": runtimeEnvironment.osBuild,
+                    "menu_bar_mode": Store.menuBarDisplayMode.rawValue,
                 ])
                 presentRecoveryNoticeIfNeeded()
                 return
             }
-            if statusBar == nil {
-                markLaunch(.statusItemCreating)
-                statusBar = StatusBarController(db: db, producer: producer, delegate: self)
-                markLaunch(.statusItemReady)
-                scheduleStatusItemStabilityMarker()
+            if statusBar == nil, initialStatusItemCreationTask == nil {
+                createStatusItem(db: db, producer: producer, source: "settings")
             } else {
                 statusBar?.applyDisplayMode()   // Icon ↔ Metrics flip
             }
@@ -571,7 +571,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         CrashReporter.setLaunchPhase(phase)
     }
 
-    private func scheduleStatusItemStabilityMarker() {
+    private func scheduleInitialStatusItemCreation(db: DB, producer: SnapshotProducer) {
+        initialStatusItemCreationTask?.cancel()
+        CrashReporter.setStatusItemState(.scheduled)
+        Telemetry.capture("status_item_creation_scheduled", ["source": "launch"])
+        initialStatusItemCreationTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(
+                    nanoseconds: StatusItemStartupPolicy.initialDelayNanoseconds
+                )
+            } catch {
+                return
+            }
+            guard let self else { return }
+            self.initialStatusItemCreationTask = nil
+            guard Store.showMenuBarIcon,
+                  self.recoveryReason == nil,
+                  self.statusBar == nil else {
+                if self.launchCompleted { CrashReporter.finishLaunchTrace() }
+                return
+            }
+            self.createStatusItem(db: db, producer: producer, source: "launch")
+        }
+    }
+
+    private func createStatusItem(
+        db: DB,
+        producer: SnapshotProducer,
+        source: String
+    ) {
+        markLaunch(.statusItemCreating)
+        let statusItemSpan = CrashReporter.startLaunchSpan("status_item_create")
+        statusBar = StatusBarController(db: db, producer: producer, delegate: self)
+        statusItemSpan?.finish()
+        markLaunch(.statusItemReady)
+        scheduleStatusItemStabilityMarker(source: source)
+    }
+
+    private func scheduleStatusItemStabilityMarker(source: String) {
         statusItemStabilityTask?.cancel()
         statusItemStabilitySpan?.finish()
         if automaticUpdaterSchedulingArmed {
@@ -584,6 +621,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let generation = statusItemStabilityGeneration
         statusItemStabilitySpan = CrashReporter.startLaunchSpan("status_item_stabilizing")
         CrashReporter.setStatusItemState(.stabilizing)
+        Telemetry.capture("status_item_stability_started", ["source": source])
 
         statusItemStabilityTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 30_000_000_000)
@@ -598,6 +636,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             self.statusItemStabilitySpan = nil
             CrashReporter.setStatusItemState(.stable)
             CrashReporter.breadcrumb("status_item_stable", category: "launch")
+            Telemetry.capture("status_item_stabilized", ["source": source])
             if self.launchCompleted { CrashReporter.finishLaunchTrace() }
             if self.automaticUpdaterSchedulingArmed {
                 self.scheduleAutomaticUpdaterStart(afterNanoseconds: 0)
@@ -606,6 +645,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     }
 
     private func cancelStatusItemStabilityMarker(state: StatusItemDiagnosticState) {
+        initialStatusItemCreationTask?.cancel()
+        initialStatusItemCreationTask = nil
         statusItemStabilityGeneration += 1
         statusItemStabilityTask?.cancel()
         statusItemStabilityTask = nil
@@ -667,10 +708,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // A menu-bar launch is not considered healthy until AppKit's status
         // item has survived 30 responsive seconds. Its child span and separate
         // status_item_state tag remain live across this app_ready phase.
-        if statusItemStabilityTask == nil { CrashReporter.finishLaunchTrace() }
+        if statusItemStabilityTask == nil, initialStatusItemCreationTask == nil {
+            CrashReporter.finishLaunchTrace()
+        }
+        let statusItemState: String
+        if safeModeActive {
+            statusItemState = StatusItemDiagnosticState.compatibilityMode.rawValue
+        } else if initialStatusItemCreationTask != nil {
+            statusItemState = StatusItemDiagnosticState.scheduled.rawValue
+        } else if statusBar == nil {
+            statusItemState = StatusItemDiagnosticState.notRequested.rawValue
+        } else {
+            statusItemState = StatusItemDiagnosticState.stabilizing.rawValue
+        }
         Telemetry.capture("app_ready", [
             "menu_bar_available": statusBar != nil,
             "compatibility_mode": safeModeActive,
+            "status_item_state": statusItemState,
         ])
         if presentRecoveryNotice {
             DispatchQueue.main.async { [weak self] in self?.presentRecoveryNoticeIfNeeded() }

--- a/macos/Sources/CrashReporter.swift
+++ b/macos/Sources/CrashReporter.swift
@@ -49,6 +49,7 @@ struct AppHangRateLimiter {
 enum StatusItemDiagnosticState: String {
     case notRequested = "not_requested"
     case compatibilityMode = "compatibility_mode"
+    case scheduled
     case stabilizing
     case stable
     case disabled
@@ -90,6 +91,15 @@ enum CrashReporter {
     private static var appHangLimiter = AppHangRateLimiter()
     private static var launchPhase = LaunchPhase.launchStarted.rawValue
     private static var launchTransaction: (any Span)?
+
+    /// Bounded updater and launch fields that may leave the Mac in a Sentry
+    /// diagnostic context. Free-form descriptions and URLs remain excluded.
+    static let diagnosticContextFields: Set<String> = [
+        "attempt", "elapsed_bucket", "error_code", "error_domain",
+        "failure_category", "phase", "reason", "recovery", "source", "state",
+        "status", "target_version", "underlying_error_code",
+        "underlying_error_domain", "update_found", "update_source",
+    ]
 
     /// Run a synchronous, USER-PACED block (a modal confirm, an auth prompt)
     /// without Sentry's app-hang monitor flagging the expected main-thread
@@ -431,11 +441,7 @@ enum CrashReporter {
             "burrow_runtime": [
                 "app_build", "app_version", "architecture", "os_build", "os_version",
             ],
-            "diagnostic": [
-                "attempt", "elapsed_bucket", "error_code", "error_domain", "phase",
-                "reason", "source", "state", "status", "target_version", "update_found",
-                "update_source",
-            ],
+            "diagnostic": diagnosticContextFields,
             // Preserve only the identifiers needed to connect a captured
             // error to Burrow's fixed-name custom launch trace.
             "trace": [

--- a/macos/Sources/LaunchDiagnostics.swift
+++ b/macos/Sources/LaunchDiagnostics.swift
@@ -294,6 +294,21 @@ enum LaunchRecovery {
     }
 }
 
+enum StatusItemStartupPolicy {
+    /// `applicationDidFinishLaunching` runs before AppKit processes the first
+    /// event. Leave that launch turn before asking AppKit/WindowServer to wake
+    /// the status-item scene; this reduces coupling menu-bar scene creation to
+    /// unrelated launch-time remote views (Sentry BURROW-9V).
+    static let initialDelayNanoseconds: UInt64 = 1_000_000_000
+
+    static func shouldScheduleInitialCreation(
+        showMenuBarIcon: Bool,
+        recoveryReason: LaunchRecoveryReason?
+    ) -> Bool {
+        showMenuBarIcon && recoveryReason == nil
+    }
+}
+
 enum DiagnosticPrivacy {
     private static let blockedKeys: Set<String> = [
         "api_key", "token", "authorization", "password", "secret",

--- a/macos/Sources/UpdateCheck.swift
+++ b/macos/Sources/UpdateCheck.swift
@@ -16,6 +16,175 @@ enum UpdateStartPolicy {
     static func shouldStartForAutomaticChecks(enabled: Bool) -> Bool { enabled }
 }
 
+enum UpdateFailureCategory: String, Equatable {
+    case appTranslocation = "app_translocation"
+    case transientDownload = "transient_download"
+    case noUpdate = "no_update"
+    case cancelled
+    case configuration
+    case signatureValidation = "signature_validation"
+    case installation
+    case other
+}
+
+enum UpdateFailureRecovery: String, Equatable {
+    case moveToApplications = "move_to_applications"
+    case sparkleScheduledRetry = "sparkle_scheduled_retry"
+    case none
+}
+
+struct UpdateFailureDisposition: Equatable {
+    let category: UpdateFailureCategory
+    let recovery: UpdateFailureRecovery
+    let shouldCaptureInSentry: Bool
+}
+
+enum UpdateFailurePolicy {
+    // Sparkle 2.9.4 SUErrors.h: SURunningTranslocated. Keep this explicit so
+    // the policy is testable even though Swift does not import SUError cases.
+    private static let runningTranslocatedCode = 1005
+    private static let runningFromDiskImageCode = 1003
+    private static let noUpdateCode = 1001
+    private static let downloadErrorCode = 2001
+    private static let installationCancelledCodes: Set<Int> = [4007, 4008]
+    private static let developerActionableURLCodes: Set<Int> = [
+        NSURLErrorBadURL,
+        NSURLErrorUnsupportedURL,
+        NSURLErrorRedirectToNonExistentLocation,
+        NSURLErrorBadServerResponse,
+        NSURLErrorUserAuthenticationRequired,
+        NSURLErrorZeroByteResource,
+        NSURLErrorCannotDecodeRawData,
+        NSURLErrorCannotDecodeContentData,
+        NSURLErrorCannotParseResponse,
+        NSURLErrorAppTransportSecurityRequiresSecureConnection,
+        NSURLErrorFileDoesNotExist,
+        NSURLErrorNoPermissionsToReadFile,
+        NSURLErrorSecureConnectionFailed,
+        NSURLErrorServerCertificateHasBadDate,
+        NSURLErrorServerCertificateUntrusted,
+        NSURLErrorServerCertificateHasUnknownRoot,
+        NSURLErrorServerCertificateNotYetValid,
+        NSURLErrorClientCertificateRejected,
+        NSURLErrorClientCertificateRequired,
+    ]
+
+    static func classify(_ error: NSError) -> UpdateFailureDisposition {
+        let underlying = deepestUnderlyingError(in: error)
+        let sparkleInstallationCancelled = error.domain == SUSparkleErrorDomain
+            && installationCancelledCodes.contains(error.code)
+        let underlyingRequestCancelled = underlying?.domain == NSURLErrorDomain
+            && underlying?.code == NSURLErrorCancelled
+        if sparkleInstallationCancelled || underlyingRequestCancelled {
+            return UpdateFailureDisposition(
+                category: .cancelled,
+                recovery: .none,
+                shouldCaptureInSentry: false
+            )
+        }
+        if error.domain == SUSparkleErrorDomain, error.code == noUpdateCode {
+            return UpdateFailureDisposition(
+                category: .noUpdate,
+                recovery: .none,
+                shouldCaptureInSentry: false
+            )
+        }
+        if error.domain == SUSparkleErrorDomain,
+           error.code == runningTranslocatedCode || error.code == runningFromDiskImageCode {
+            return UpdateFailureDisposition(
+                category: .appTranslocation,
+                recovery: .moveToApplications,
+                shouldCaptureInSentry: false
+            )
+        }
+        if error.domain == SUSparkleErrorDomain, error.code == downloadErrorCode {
+            if let underlying,
+               underlying.domain == NSURLErrorDomain,
+               developerActionableURLCodes.contains(underlying.code) {
+                return UpdateFailureDisposition(
+                    category: .configuration,
+                    recovery: .none,
+                    shouldCaptureInSentry: true
+                )
+            }
+            return UpdateFailureDisposition(
+                category: .transientDownload,
+                recovery: .sparkleScheduledRetry,
+                shouldCaptureInSentry: false
+            )
+        }
+        if error.domain == NSURLErrorDomain {
+            if developerActionableURLCodes.contains(error.code) {
+                return UpdateFailureDisposition(
+                    category: .configuration,
+                    recovery: .none,
+                    shouldCaptureInSentry: true
+                )
+            }
+            return UpdateFailureDisposition(
+                category: error.code == NSURLErrorCancelled ? .cancelled : .transientDownload,
+                recovery: error.code == NSURLErrorCancelled ? .none : .sparkleScheduledRetry,
+                shouldCaptureInSentry: false
+            )
+        }
+        if error.domain == SUSparkleErrorDomain, (1...7).contains(error.code) {
+            return UpdateFailureDisposition(
+                category: .configuration,
+                recovery: .none,
+                shouldCaptureInSentry: true
+            )
+        }
+        if error.domain == SUSparkleErrorDomain, (3001...3002).contains(error.code) {
+            return UpdateFailureDisposition(
+                category: .signatureValidation,
+                recovery: .none,
+                shouldCaptureInSentry: true
+            )
+        }
+        if error.domain == SUSparkleErrorDomain, (4000...4012).contains(error.code) {
+            return UpdateFailureDisposition(
+                category: .installation,
+                recovery: .none,
+                shouldCaptureInSentry: true
+            )
+        }
+        return UpdateFailureDisposition(
+            category: .other,
+            recovery: .none,
+            shouldCaptureInSentry: true
+        )
+    }
+
+    /// Sparkle wraps URLSession failures. Preserve only bounded domains/codes;
+    /// descriptions and failing URLs can contain private network information.
+    static func telemetryProperties(for error: NSError) -> [String: Any] {
+        let disposition = classify(error)
+        var properties: [String: Any] = [
+            "error_domain": error.domain,
+            "error_code": error.code,
+            "failure_category": disposition.category.rawValue,
+            "recovery": disposition.recovery.rawValue,
+        ]
+        if let underlying = deepestUnderlyingError(in: error),
+           underlying.domain != error.domain || underlying.code != error.code {
+            properties["underlying_error_domain"] = underlying.domain
+            properties["underlying_error_code"] = underlying.code
+        }
+        return properties
+    }
+
+    private static func deepestUnderlyingError(in error: NSError) -> NSError? {
+        var current = error
+        var visited = Set<ObjectIdentifier>()
+        while let next = current.userInfo[NSUnderlyingErrorKey] as? NSError {
+            let identity = ObjectIdentifier(next)
+            guard visited.insert(identity).inserted else { break }
+            current = next
+        }
+        return current === error ? nil : current
+    }
+}
+
 @MainActor
 final class AppUpdate: NSObject, SPUUpdaterDelegate {
     static let shared = AppUpdate()
@@ -29,6 +198,7 @@ final class AppUpdate: NSObject, SPUUpdaterDelegate {
     private var updateFoundInCycle = false
     private var noUpdateInCycle = false
     private var stabilityTask: Task<Void, Never>?
+    private var startSource = "automatic"
 
     private override init() {
         super.init()
@@ -52,6 +222,7 @@ final class AppUpdate: NSObject, SPUUpdaterDelegate {
         }
         controller.startUpdater()
         started = true
+        startSource = source
         Telemetry.capture("updater_started", ["source": source])
         scheduleStabilityMarker()
         return true
@@ -66,7 +237,7 @@ final class AppUpdate: NSObject, SPUUpdaterDelegate {
             LaunchJournal.live.markAutomaticUpdaterStable()
             LaunchJournal.live.mark(.updaterReady)
             CrashReporter.setLaunchPhase(.updaterReady)
-            Telemetry.capture("updater_stabilized")
+            Telemetry.capture("updater_stabilized", ["source": self.startSource])
         }
     }
 
@@ -103,7 +274,11 @@ final class AppUpdate: NSObject, SPUUpdaterDelegate {
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
         noUpdateInCycle = true
-        Telemetry.capture("update_not_found")
+        let nsError = error as NSError
+        let userInitiated = nsError.userInfo[SPUNoUpdateFoundUserInitiatedKey] as? Bool ?? false
+        Telemetry.capture("update_not_found", [
+            "source": userInitiated ? "manual" : "automatic",
+        ])
     }
 
     func updater(
@@ -124,16 +299,11 @@ final class AppUpdate: NSObject, SPUUpdaterDelegate {
 
     func updater(_ updater: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: Error) {
         let nsError = error as NSError
-        let properties: [String: Any] = [
-            "target_version": item.displayVersionString,
-            "error_domain": nsError.domain,
-            "error_code": nsError.code,
-        ]
+        var properties = UpdateFailurePolicy.telemetryProperties(for: nsError)
+        properties["target_version"] = item.displayVersionString
         Telemetry.capture("update_download_failed", properties)
-        CrashReporter.logError("update_download_failed", data: properties)
-        CrashReporter.captureDiagnostic("update_download_failed", error: error, data: [
-            "target_version": item.displayVersionString,
-        ])
+        // Sentry receives only one actionable diagnostic at cycle completion.
+        // Expected network/translocation failures remain PostHog-only.
     }
 
     func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
@@ -174,18 +344,25 @@ final class AppUpdate: NSObject, SPUUpdaterDelegate {
         }
         if let error, !noUpdateInCycle {
             let nsError = error as NSError
-            let properties: [String: Any] = [
-                "source": source,
-                "update_found": updateFoundInCycle,
-                "error_domain": nsError.domain,
-                "error_code": nsError.code,
-            ]
-            Telemetry.capture("update_cycle_failed", properties)
-            CrashReporter.logError("update_cycle_failed", data: properties)
-            CrashReporter.captureDiagnostic("update_cycle_failed", error: error, data: [
-                "source": source,
-                "update_found": updateFoundInCycle,
-            ])
+            let disposition = UpdateFailurePolicy.classify(nsError)
+            if disposition.category == .cancelled {
+                Telemetry.capture("update_cycle_completed", [
+                    "source": source,
+                    "result": "cancelled",
+                ])
+            } else {
+                var properties = UpdateFailurePolicy.telemetryProperties(for: nsError)
+                properties["source"] = source
+                properties["update_found"] = updateFoundInCycle
+                Telemetry.capture("update_cycle_failed", properties)
+                if disposition.shouldCaptureInSentry {
+                    CrashReporter.captureDiagnostic(
+                        "update_cycle_failed",
+                        error: error,
+                        data: properties
+                    )
+                }
+            }
         } else {
             Telemetry.capture("update_cycle_completed", [
                 "source": source,

--- a/macos/Tests/CrashReporterPolicyTests.swift
+++ b/macos/Tests/CrashReporterPolicyTests.swift
@@ -62,4 +62,13 @@ final class CrashReporterPolicyTests: XCTestCase {
         XCTAssertTrue(LaunchTraceEndReason.completed.shouldFinish)
         XCTAssertFalse(LaunchTraceEndReason.telemetryDisabled.shouldFinish)
     }
+
+    func testUpdaterDiagnosticContextKeepsOnlyBoundedClassificationFields() {
+        XCTAssertTrue(CrashReporter.diagnosticContextFields.contains("failure_category"))
+        XCTAssertTrue(CrashReporter.diagnosticContextFields.contains("recovery"))
+        XCTAssertTrue(CrashReporter.diagnosticContextFields.contains("underlying_error_domain"))
+        XCTAssertTrue(CrashReporter.diagnosticContextFields.contains("underlying_error_code"))
+        XCTAssertFalse(CrashReporter.diagnosticContextFields.contains("description"))
+        XCTAssertFalse(CrashReporter.diagnosticContextFields.contains("url"))
+    }
 }

--- a/macos/Tests/LaunchDiagnosticsTests.swift
+++ b/macos/Tests/LaunchDiagnosticsTests.swift
@@ -36,6 +36,34 @@ final class LaunchDiagnosticsTests: XCTestCase {
         XCTAssertNil(LaunchRecovery.reason(environment: environment, previous: nil))
     }
 
+    func testNormalInitialStatusItemCreationIsDeferredPastTheLaunchTurn() {
+        XCTAssertTrue(
+            StatusItemStartupPolicy.shouldScheduleInitialCreation(
+                showMenuBarIcon: true,
+                recoveryReason: nil
+            )
+        )
+        XCTAssertGreaterThanOrEqual(
+            StatusItemStartupPolicy.initialDelayNanoseconds,
+            1_000_000_000
+        )
+    }
+
+    func testCompatibilityAndIconDisabledLaunchesDoNotScheduleAStatusItem() {
+        XCTAssertFalse(
+            StatusItemStartupPolicy.shouldScheduleInitialCreation(
+                showMenuBarIcon: false,
+                recoveryReason: nil
+            )
+        )
+        XCTAssertFalse(
+            StatusItemStartupPolicy.shouldScheduleInitialCreation(
+                showMenuBarIcon: true,
+                recoveryReason: .macOS27Beta4
+            )
+        )
+    }
+
     func testInterruptedStatusItemCreationUsesSafeModeOnNextLaunch() {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("burrow-launch-\(UUID().uuidString).json")

--- a/macos/Tests/UpdateCheckTests.swift
+++ b/macos/Tests/UpdateCheckTests.swift
@@ -8,6 +8,7 @@
 //
 
 import XCTest
+import Sparkle
 @testable import Burrow
 
 final class UpdateCheckTests: XCTestCase {
@@ -28,6 +29,96 @@ final class UpdateCheckTests: XCTestCase {
     func testAutomaticCheckToggleStartsUpdaterOnlyWhenEnabled() {
         XCTAssertFalse(UpdateStartPolicy.shouldStartForAutomaticChecks(enabled: false))
         XCTAssertTrue(UpdateStartPolicy.shouldStartForAutomaticChecks(enabled: true))
+    }
+
+    func testTranslocatedSparkleFailureRequiresMovingTheAppWithoutCreatingASentryIssue() {
+        let error = NSError(domain: SUSparkleErrorDomain, code: 1005)
+
+        let failure = UpdateFailurePolicy.classify(error)
+
+        XCTAssertEqual(failure.category, .appTranslocation)
+        XCTAssertEqual(failure.recovery, .moveToApplications)
+        XCTAssertFalse(failure.shouldCaptureInSentry)
+    }
+
+    func testOfflineDownloadFailureUsesSparklesScheduledRetryAndKeepsOnlyBoundedCauseFields() {
+        let underlying = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorNotConnectedToInternet,
+            userInfo: [NSLocalizedDescriptionKey: "private network detail"]
+        )
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 2001,
+            userInfo: [NSUnderlyingErrorKey: underlying]
+        )
+
+        let failure = UpdateFailurePolicy.classify(error)
+        let properties = UpdateFailurePolicy.telemetryProperties(for: error)
+
+        XCTAssertEqual(failure.category, .transientDownload)
+        XCTAssertEqual(failure.recovery, .sparkleScheduledRetry)
+        XCTAssertFalse(failure.shouldCaptureInSentry)
+        XCTAssertEqual(properties["underlying_error_domain"] as? String, NSURLErrorDomain)
+        XCTAssertEqual(properties["underlying_error_code"] as? Int, NSURLErrorNotConnectedToInternet)
+        XCTAssertEqual(properties["failure_category"] as? String, "transient_download")
+        XCTAssertEqual(properties["recovery"] as? String, "sparkle_scheduled_retry")
+        XCTAssertNil(properties["description"])
+    }
+
+    func testUserCancelledUpdateDoesNotCreateASentryIssue() {
+        let error = NSError(domain: SUSparkleErrorDomain, code: 4007)
+
+        let failure = UpdateFailurePolicy.classify(error)
+
+        XCTAssertEqual(failure.category, .cancelled)
+        XCTAssertEqual(failure.recovery, .none)
+        XCTAssertFalse(failure.shouldCaptureInSentry)
+    }
+
+    func testNonSparkleErrorWithCancellationCodeRemainsActionable() {
+        let error = NSError(domain: "ExampleDomain", code: 4007)
+
+        let failure = UpdateFailurePolicy.classify(error)
+
+        XCTAssertEqual(failure.category, .other)
+        XCTAssertEqual(failure.recovery, .none)
+        XCTAssertTrue(failure.shouldCaptureInSentry)
+    }
+
+    func testSignatureFailureRemainsADeveloperActionableSentryIssue() {
+        let error = NSError(domain: SUSparkleErrorDomain, code: 3001)
+
+        let failure = UpdateFailurePolicy.classify(error)
+
+        XCTAssertEqual(failure.category, .signatureValidation)
+        XCTAssertEqual(failure.recovery, .none)
+        XCTAssertTrue(failure.shouldCaptureInSentry)
+    }
+
+    func testInvalidDownloadConfigurationStillCreatesASentryIssue() {
+        let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
+        let error = NSError(
+            domain: SUSparkleErrorDomain,
+            code: 2001,
+            userInfo: [NSUnderlyingErrorKey: underlying]
+        )
+
+        let failure = UpdateFailurePolicy.classify(error)
+
+        XCTAssertEqual(failure.category, .configuration)
+        XCTAssertEqual(failure.recovery, .none)
+        XCTAssertTrue(failure.shouldCaptureInSentry)
+    }
+
+    func testDirectInvalidURLFailureIsConfigurationRatherThanTransientNetwork() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
+
+        let failure = UpdateFailurePolicy.classify(error)
+
+        XCTAssertEqual(failure.category, .configuration)
+        XCTAssertEqual(failure.recovery, .none)
+        XCTAssertTrue(failure.shouldCaptureInSentry)
     }
 
 }

--- a/scripts/tests/test_sentry_issues_workflow.py
+++ b/scripts/tests/test_sentry_issues_workflow.py
@@ -1,0 +1,60 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "sentry-issues.yml"
+
+
+class SentryIssuesWorkflowTests(unittest.TestCase):
+    def test_app_hangs_are_aggregated_instead_of_silently_skipped(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertNotIn("Skipping App-Hang issue", workflow)
+        self.assertIn("[Sentry] App-Hang digest", workflow)
+        self.assertIn("gh issue edit", workflow)
+        self.assertIn("sentry-id: ${shortId}", workflow)
+
+    def test_hang_digests_are_bounded_and_roll_into_numbered_parts(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('MAX_HANG_GROUPS_PER_RUN: "20"', workflow)
+        self.assertIn('MAX_HANG_TRACE_CHARS: "1200"', workflow)
+        self.assertIn('MAX_ISSUE_BODY_BYTES: "60000"', workflow)
+        self.assertIn('digest_title="${digest_base_title} — part ${digest_part}"', workflow)
+        self.assertIn("existing_bytes + section_bytes", workflow)
+
+    def test_sentry_issue_poll_follows_cursor_pagination(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('MAX_SENTRY_PAGES_PER_PROJECT: "100"', workflow)
+        self.assertIn('-D "$headers" -o "$page"', workflow)
+        self.assertIn("'rel=\"next\"'", workflow)
+        self.assertIn("'results=\"true\"'", workflow)
+        self.assertIn('done < "$response_rows"', workflow)
+
+    def test_hang_digest_carries_bounded_release_and_launch_context(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('select(.key=="os_build")', workflow)
+        self.assertIn('select(.key=="launch_phase")', workflow)
+        self.assertIn('select(.key=="status_item_state")', workflow)
+        self.assertIn(".release.version", workflow)
+
+    def test_regular_issues_carry_the_same_launch_context(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(r'| **Release** | \`${release}\` |', workflow)
+        self.assertIn(r'| **OS build** | \`${osBuild}\` |', workflow)
+        self.assertIn(r'| **Launch phase** | \`${launchPhase}\` |', workflow)
+        self.assertIn(r'| **Status item** | \`${statusItem}\` |', workflow)
+
+    def test_release_shape_is_checked_before_reading_its_version(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn('if (.release | type) == "object"', workflow)
+        self.assertIn('elif (.release | type) == "string"', workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Classifies Sparkle outcomes by recovery path so translocation, ordinary network failures, and cancellations remain measurable in PostHog without becoming Sentry issues.
- Keeps configuration, signature, installation, and unknown updater failures actionable through one scrubbed Sentry diagnostic per failed cycle.
- Defers first status-item creation until after the initial AppKit launch turn, while preserving the exact-build macOS 27 compatibility guard and automatic retry on a new OS build.
- Makes App-Hang groups visible through bounded weekly digests and adds release/build/launch/status context to Sentry-created GitHub issues.
- Updates telemetry, recovery, release, README, and generated website copy to match the shipped behavior.

## Changes

### Updater diagnostics

- Adds a tested Sparkle failure taxonomy and fixed recovery categories.
- Preserves Sparkle's native move-to-Applications and retry UI.
- Sends only bounded error domains/codes; no descriptions, URLs, response bodies, paths, or network names.
- Prevents duplicate Sentry records and scopes Sparkle cancellation codes to the Sparkle error domain.

### macOS launch recovery

- Schedules normal status-item creation one second after launch services are ready.
- Records scheduled, stabilizing, and stable lifecycle milestones in the existing opt-out telemetry pipeline.
- Keeps the macOS 27 Beta 4 exact-build fallback and learned interrupted-launch recovery unchanged.
- Does not add a manual menu-bar compatibility override.

### Sentry bridge

- Aggregates App-Hang groups into weekly digests instead of silently dropping them.
- Cursor-paginates unresolved Sentry groups so older unseen reports cannot be starved behind the newest 50.
- Caps per-run groups and trace size, rolls full digests into numbered parts, and leaves deferred groups eligible for a later run.
- Adds bounded release, OS build, launch phase, status-item state, count, and stack context to regular issues and hang digests.

### Documentation

- Documents the exact PostHog/Sentry routing and privacy allowlist.
- Corrects the status-item retry rule: a new macOS build retries it; an app or OS build change retries a suppressed updater.
- Regenerates the release website artifacts.

## Test plan

- [x] 32 focused macOS tests passed: updater, launch recovery, and crash-reporting privacy policy.
- [x] 36 Python helper/workflow tests passed.
- [x] 7 website analytics tests passed.
- [x] `actionlint .github/workflows/sentry-issues.yml`
- [x] Extracted workflow shell passes `bash -n`.
- [x] `python3 scripts/site-release.py --check`
- [x] `greenlight preflight macos --exit-code` — GREENLIT.
- [x] Full macOS run executed 782 tests; one existing timing-sensitive metrics test failed once and passed on immediate isolated rerun: `FeedsTests.testMetricSparklines_identicalWindow_suppressesRepublish`. This branch intentionally does not change CPU/metrics code.

Addresses #328, #330, and #337.
Refs #319.

The CPU accuracy report in #335 is intentionally out of scope.