### PR TITLE
release(macos): prepare 0.11.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,55 +1,52 @@
 <!-- Latest release ONLY. This file is the GitHub release body (release.yml --notes-file), so it must contain just the newest version. OVERWRITE it each release; do not accumulate. Full prose history lives in docs/releases.json → docs/releases.html (the site Releases page). -->
 
-# Burrow 0.11.1
+# Burrow 0.11.2
 
-A guarded-startup and diagnostics patch for the system-wide input freeze
-reported on macOS 27 Beta 4. This release reduces the risky launch surface on
-the affected build and records enough redacted state to isolate any remaining
-failure without collecting screen contents or user files.
+An updater and launch-reliability patch. This release stops expected Sparkle
+conditions from looking like product defects, gives AppKit a settled launch turn
+before creating the menu-bar item, and makes sampled app hangs reliably reach
+the issue tracker with bounded diagnostic context.
 
-> **Affected macOS 27 beta users:** please install 0.11.1 and report the result
-> in [#319](https://github.com/caezium/Burrow/issues/319). The issue remains open
-> until the notarized release is verified on a Mac that reproduced the freeze.
+> **Affected macOS 27 beta users:** please install 0.11.2 and report the result
+> in [#319](https://github.com/caezium/Burrow/issues/319). The exact Beta 4
+> compatibility guard remains in place, and the issue stays open until a
+> notarized build is verified on a Mac that reproduced the freeze.
 
 ## Fixed
-- **The affected macOS 27 beta gets a safer launch path.** On Beta 4 build
-  `26A5388g`, Burrow starts with a Dock icon instead of creating its menu-bar
-  status item. The fallback is deliberately limited to that exact build; a new
-  macOS build restores the normal guarded path. Manual update checks remain
-  available even when automatic Sparkle startup is paused.
-- **Interrupted launches recover one component at a time.** A durable launch
-  journal gives the status item and Sparkle separate 30-second stability
-  windows. If launch is interrupted, the next run suppresses only the component
-  whose window was active, shows a recovery alert, and offers a one-click
-  redacted diagnostic report. ([#321](https://github.com/caezium/Burrow/pull/321))
+- **Updater failures now mean what they say.** Running from a disk image or a
+  translocated location, ordinary network failures, and user cancellation remain
+  measurable in PostHog without opening Sentry issues. Sparkle keeps ownership of
+  its native move-to-Applications and scheduled-retry UI. Configuration,
+  signature, installation, and unknown failures still create exactly one
+  scrubbed Sentry diagnostic per cycle. ([#339](https://github.com/caezium/Burrow/pull/339))
+- **The normal menu-bar path no longer races the first AppKit launch turn.**
+  Burrow waits one second before creating its status item, then retains the
+  existing 30-second stability window. The safeguard for macOS 27 Beta 4 build
+  `26A5388g` remains exact-build-only; a later macOS build returns to the normal
+  guarded path automatically. ([#339](https://github.com/caezium/Burrow/pull/339))
 
 ## Improved
-- **Sentry can now explain hangs that never become crashes.** Release-health
-  sessions, hang tracking, low-memory context, fixed-name sampled performance
-  spans, and coarse launch/updater state cover the failure modes that a normal
-  crash report misses. Outbound data is scrubbed fail closed, with no
-  screenshots, view hierarchies, user paths, URLs, request bodies, or automatic
-  UI, file, database, and network tracing.
-- **PostHog analytics no longer bring an AppKit-facing SDK into startup.** Burrow
-  still sends the same opt-out semantic product, screen, and operation events to
-  PostHog, but a small background HTTPS transport replaces `posthog-ios`. It has
-  a bounded serialized retry queue and no session replay, autocapture, remote
-  feature flags, AppKit timer, or main-thread disk I/O. Existing 0.11.0 anonymous
-  identities are migrated once so release-to-release funnels remain accurate.
-- **The first signed Sparkle successor passed a real update.** An installed
-  Developer ID-signed 0.11.0 copy found, downloaded, installed, and relaunched
-  0.11.1 through Sparkle's native UI without Terminal or Homebrew. The updated
-  app then passed strict signing, stapler, and Gatekeeper checks, completing
-  [#281](https://github.com/caezium/Burrow/issues/281).
+- **App-hang evidence can no longer disappear at the Sentry bridge.** Sampled
+  hangs are collected into bounded weekly GitHub digests instead of being
+  silently skipped. Cursor pagination reaches older unseen groups, full digests
+  roll into numbered parts, and deferred groups remain eligible for the next
+  run. ([#339](https://github.com/caezium/Burrow/pull/339))
+- **Launch and updater health now have explicit lifecycle outcomes.** Fixed-name
+  scheduled, stabilizing, and stable milestones include bounded app release,
+  macOS build, launch phase, and status-item state, so future failures can be
+  separated without collecting free text or user data.
 
 ## Privacy
 - **Telemetry remains optional, unlinked, and non-tracking.** One Settings
-  switch disables both PostHog analytics and Sentry diagnostics. The privacy
-  manifest continues to declare Product Interaction, Other Usage, Crash,
-  Performance, and Other Diagnostic data; this release adds no signing-specific
-  telemetry and records no screen content.
+  switch disables both PostHog analytics and Sentry diagnostics. Updater
+  diagnostics contain fixed categories and bounded error domains/codes—never
+  descriptions, URLs, response bodies, network names, paths, screen content, or
+  files. The privacy manifest remains unchanged and accurate.
 
 ## Security
-- **The release chain remains fail closed.** The tag cannot publish unless the
-  app is Developer ID signed, notarized, stapled, accepted by Gatekeeper, and
-  both the update archive and appcast pass Sparkle signature verification.
+- **Publishing still fails closed, including the external Homebrew tap.** Before
+  any release build begins, CI requires every signing, notarization, Sparkle,
+  and tap credential, then proves the tap token with a reversible Git
+  write. The tap credential is isolated from the engine checkout so a successful
+  notarized release cannot fail at the final cask push because the wrong token
+  was left in Git configuration.

--- a/docs/index.html
+++ b/docs/index.html
@@ -324,7 +324,7 @@
 
   <!-- ===== HERO ===== -->
   <header class="hero">
-    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.11.1</span>
+    <span class="brandline">Open source · <b>github.com/caezium/Burrow</b> · v0.11.2</span>
     <h1>Burrow
       <svg class="mark" viewBox="0 0 100 100" aria-hidden="true"><path d="M14 74 a36 36 0 0 1 72 0 Z" fill="#F3ECDD"/><rect x="38" y="74" width="24" height="7" rx="3.5" fill="#121217"/></svg>
     </h1>
@@ -390,31 +390,31 @@
     <div class="sec-head wn-head">
       <div>
         <span class="sec-num">What's new · August 2026</span>
-        <h2 class="sec-title">New in 0.11.1</h2>
+        <h2 class="sec-title">New in 0.11.2</h2>
       </div>
       <a class="btn btn-out btn-sm" href="releases.html">All releases</a>
     </div>
 
     <div class="grid3 wn-grid">
       <article class="tcard" style="--c: var(--green)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">Safer on the affected macOS beta</div></div>
-        <p class="ds">On macOS 27 Beta 4 build <code>26A5388g</code>, Burrow starts in Dock-based compatibility mode instead of creating the menu-bar status item; a new macOS build restores the normal guarded path.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l1.8 4.6L18 10l-4.2 1.4L12 16l-1.8-4.6L6 10l4.2-1.4z"/><path d="M18.5 15.5l.9 2.1 2.1.9-2.1.9-.9 2.1-.9-2.1-2.1-.9 2.1-.9z"/></svg></div><div class="nm">Updates report the right outcome</div></div>
+        <p class="ds">Translocation, ordinary network failures, and cancellation stay measurable without becoming Sentry defects; actionable failures still produce one scrubbed diagnostic.</p>
       </article>
       <article class="tcard" style="--c: var(--azure)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5-7 4 14 2.5-7h5"/></svg></div><div class="nm">Startup tells us where it stopped</div></div>
-        <p class="ds">A durable launch journal isolates the status item and Sparkle behind separate stability windows, then suppresses only the component implicated by an interrupted launch.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">AppKit gets a settled launch turn</div></div>
+        <p class="ds">Normal menu-bar creation waits one second after launch before entering its existing stability window, while the exact macOS 27 Beta 4 safeguard remains in place.</p>
       </article>
       <article class="tcard" style="--c: var(--lilac)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M4.5 9.5A8 8 0 0120 12"/><path d="M7 12a5 5 0 0110 0c0 3-1 6-2.5 8"/><path d="M12 12c0 3-.6 5.5-1.8 7.6"/></svg></div><div class="nm">Useful diagnostics, tighter privacy</div></div>
-        <p class="ds">Sentry can detect hangs and PostHog keeps semantic product analytics, while both exclude screen contents, user files, paths, replay, autocapture, and automatic UI or network tracing.</p>
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5-7 4 14 2.5-7h5"/></svg></div><div class="nm">Hang evidence reaches the tracker</div></div>
+        <p class="ds">The Sentry bridge paginates older groups and rolls bounded weekly App-Hang digests instead of silently dropping them.</p>
       </article>
     </div>
 
-    <div class="extra-label mono">// also tightened in 0.11.1</div>
+    <div class="extra-label mono">// also tightened in 0.11.2</div>
     <div class="wn-chips">
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Manual update checks remain available when automatic Sparkle startup is paused</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Existing PostHog anonymous identities are preserved; no session replay or autocapture</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg><a href="https://github.com/caezium/Burrow/issues/319" target="_blank" rel="noopener">#319</a> stays open until the affected macOS beta is verified</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Sparkle keeps its native move-to-Applications and retry UI</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Expected updater conditions are PostHog-only; actionable failures create one Sentry diagnostic</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg><a href="https://github.com/caezium/Burrow/issues/319" target="_blank" rel="noopener">#319</a> stays open until an affected macOS 27 Mac verifies the notarized build</span>
     </div>
     <!-- WN:END -->
   </section>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -124,13 +124,50 @@
 <header class="hero page">
   <h1>Changelog</h1>
   <p>Every version at a glance — what it added, changed, and fixed. Full notes for each live on GitHub.</p>
-  <p class="count">22 releases · latest 0.11.1 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
+  <p class="count">23 releases · latest 0.11.2 · <a href="https://github.com/caezium/Burrow/releases" target="_blank" rel="noopener">GitHub releases ↗</a></p>
 </header>
 
 <main class="page">
+    <article class="entry" id="v0.11.2">
+      <div class="ver-col">
+        <h2 class="ver">0.11.2<span class="latest">latest</span></h2>
+        <span class="date mono">Aug 5, 2026</span>
+        <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.11.2" target="_blank" rel="noopener">full notes ↗</a>
+      </div>
+      <div class="sbody">
+        <p class="lead">An updater and launch-reliability patch with accurate Sparkle outcomes, a settled AppKit status-item start, and hang reports that reliably reach the issue tracker.</p>
+        <div class="sblock">
+          <div class="slabel mono">fixed</div>
+          <ul class="slist">
+            <li><b>Updater failures now mean what they say.</b> Running from a disk image or translocated location, ordinary network failures, and user cancellation remain measurable in PostHog without opening Sentry issues. Sparkle keeps ownership of its native move-to-Applications and scheduled-retry UI. Configuration, signature, installation, and unknown failures still create exactly one scrubbed Sentry diagnostic per cycle. (<a href="https://github.com/caezium/Burrow/pull/339" target="_blank" rel="noopener">#339</a>)</li>
+            <li><b>The normal menu-bar path no longer races the first AppKit launch turn.</b> Burrow waits one second before creating its status item, then retains the existing 30-second stability window. The safeguard for macOS 27 Beta 4 build <code>26A5388g</code> remains exact-build-only; a later macOS build returns to the normal guarded path automatically. (<a href="https://github.com/caezium/Burrow/pull/339" target="_blank" rel="noopener">#339</a>)</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">improved</div>
+          <ul class="slist">
+            <li><b>App-hang evidence can no longer disappear at the Sentry bridge.</b> Sampled hangs are collected into bounded weekly GitHub digests instead of being silently skipped. Cursor pagination reaches older unseen groups, full digests roll into numbered parts, and deferred groups remain eligible for the next run. (<a href="https://github.com/caezium/Burrow/pull/339" target="_blank" rel="noopener">#339</a>)</li>
+            <li><b>Launch and updater health now have explicit lifecycle outcomes.</b> Fixed-name scheduled, stabilizing, and stable milestones include bounded app release, macOS build, launch phase, and status-item state, so future failures can be separated without collecting free text or user data.</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">privacy</div>
+          <ul class="slist">
+            <li><b>Telemetry remains optional, unlinked, and non-tracking.</b> One Settings switch disables both PostHog analytics and Sentry diagnostics. Updater diagnostics contain fixed categories and bounded error domains/codes—never descriptions, URLs, response bodies, network names, paths, screen content, or files. The privacy manifest remains unchanged and accurate.</li>
+          </ul>
+        </div>
+        <div class="sblock">
+          <div class="slabel mono">security</div>
+          <ul class="slist">
+            <li><b>Publishing still fails closed, including the external Homebrew tap.</b> Before any release build begins, CI requires every signing, notarization, Sparkle, and tap credential, then proves the tap token with a reversible Git write. The tap credential is isolated from the engine checkout so a successful notarized release cannot fail at the final cask push because the wrong token was left in Git configuration.</li>
+          </ul>
+        </div>
+      </div>
+    </article>
+
     <article class="entry" id="v0.11.1">
       <div class="ver-col">
-        <h2 class="ver">0.11.1<span class="latest">latest</span></h2>
+        <h2 class="ver">0.11.1</h2>
         <span class="date mono">Aug 3, 2026</span>
         <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.11.1" target="_blank" rel="noopener">full notes ↗</a>
       </div>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -2,6 +2,65 @@
   "_comment": "Source of truth for the site's release history. Newest first. Edit this, then run `python3 scripts/site-release.py` to regenerate the homepage 'New in X' section and releases.html. Icons/colors: run `python3 scripts/site-release.py --list-icons`.",
   "releases": [
     {
+      "version": "0.11.2",
+      "date": "2026-08-05",
+      "tag": "v0.11.2",
+      "tagline": "An updater and launch-reliability patch with accurate Sparkle outcomes, a settled AppKit status-item start, and hang reports that reliably reach the issue tracker.",
+      "highlights": [
+        {
+          "icon": "sparkle",
+          "color": "green",
+          "title": "Updates report the right outcome",
+          "line": "Translocation, ordinary network failures, and cancellation stay measurable without becoming Sentry defects; actionable failures still produce one scrubbed diagnostic."
+        },
+        {
+          "icon": "shield",
+          "color": "azure",
+          "title": "AppKit gets a settled launch turn",
+          "line": "Normal menu-bar creation waits one second after launch before entering its existing stability window, while the exact macOS 27 Beta 4 safeguard remains in place."
+        },
+        {
+          "icon": "pulse",
+          "color": "lilac",
+          "title": "Hang evidence reaches the tracker",
+          "line": "The Sentry bridge paginates older groups and rolls bounded weekly App-Hang digests instead of silently dropping them."
+        }
+      ],
+      "chips": [
+        "Sparkle keeps its native move-to-Applications and retry UI",
+        "Expected updater conditions are PostHog-only; actionable failures create one Sentry diagnostic",
+        "[#319](https://github.com/caezium/Burrow/issues/319) stays open until an affected macOS 27 Mac verifies the notarized build"
+      ],
+      "sections": [
+        {
+          "label": "fixed",
+          "items": [
+            "**Updater failures now mean what they say.** Running from a disk image or translocated location, ordinary network failures, and user cancellation remain measurable in PostHog without opening Sentry issues. Sparkle keeps ownership of its native move-to-Applications and scheduled-retry UI. Configuration, signature, installation, and unknown failures still create exactly one scrubbed Sentry diagnostic per cycle. ([#339](https://github.com/caezium/Burrow/pull/339))",
+            "**The normal menu-bar path no longer races the first AppKit launch turn.** Burrow waits one second before creating its status item, then retains the existing 30-second stability window. The safeguard for macOS 27 Beta 4 build `26A5388g` remains exact-build-only; a later macOS build returns to the normal guarded path automatically. ([#339](https://github.com/caezium/Burrow/pull/339))"
+          ]
+        },
+        {
+          "label": "improved",
+          "items": [
+            "**App-hang evidence can no longer disappear at the Sentry bridge.** Sampled hangs are collected into bounded weekly GitHub digests instead of being silently skipped. Cursor pagination reaches older unseen groups, full digests roll into numbered parts, and deferred groups remain eligible for the next run. ([#339](https://github.com/caezium/Burrow/pull/339))",
+            "**Launch and updater health now have explicit lifecycle outcomes.** Fixed-name scheduled, stabilizing, and stable milestones include bounded app release, macOS build, launch phase, and status-item state, so future failures can be separated without collecting free text or user data."
+          ]
+        },
+        {
+          "label": "privacy",
+          "items": [
+            "**Telemetry remains optional, unlinked, and non-tracking.** One Settings switch disables both PostHog analytics and Sentry diagnostics. Updater diagnostics contain fixed categories and bounded error domains/codes—never descriptions, URLs, response bodies, network names, paths, screen content, or files. The privacy manifest remains unchanged and accurate."
+          ]
+        },
+        {
+          "label": "security",
+          "items": [
+            "**Publishing still fails closed, including the external Homebrew tap.** Before any release build begins, CI requires every signing, notarization, Sparkle, and tap credential, then proves the tap token with a reversible Git write. The tap credential is isolated from the engine checkout so a successful notarized release cannot fail at the final cask push because the wrong token was left in Git configuration."
+          ]
+        }
+      ]
+    },
+    {
       "version": "0.11.1",
       "date": "2026-08-03",
       "tag": "v0.11.1",

--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.1</string>
+	<string>0.11.2</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSUIElement</key>

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -51,8 +51,8 @@ targets:
       properties:
         LSUIElement: true   # menu-bar agent, no Dock icon
         CFBundleDisplayName: Burrow
-        CFBundleShortVersionString: "0.11.1"
-        CFBundleVersion: "22"
+        CFBundleShortVersionString: "0.11.2"
+        CFBundleVersion: "23"
         NSHumanReadableCopyright: "MIT License. Mole CLI © tw93. Independent, not affiliated with mole.fit."
         # Burrow uses only exempt encryption supplied by macOS (for example,
         # URLSession HTTPS); it contains no proprietary or non-exempt crypto.


### PR DESCRIPTION
## Summary

Prepare Burrow 0.11.2 (build 23) for the updater and launch-reliability fixes merged in #339.

- bump the macOS bundle version to 0.11.2 (23)
- publish accurate latest-only GitHub release notes
- add 0.11.2 to the website release history and regenerate the homepage
- preserve the existing privacy manifest and non-exempt encryption declaration
- document the fail-closed signing, notarization, Sparkle, and Homebrew tap gates accurately

## Verification

- `xcodebuild test -project macos/Burrow.xcodeproj -scheme Burrow -destination platform=macOS CODE_SIGNING_ALLOWED=NO -quiet`
- `python3 -m unittest discover -s scripts/tests` (36 tests)
- `node --test scripts/tests/test_site_analytics.mjs` (7 tests)
- `greenlight preflight macos --exit-code` (GREENLIT)
- `python3 scripts/site-release.py --check`
- `plutil -lint macos/Resources/Info.plist`
- `git diff --check`

After this PR merges, pushing tag `v0.11.2` will run the fail-closed signed, notarized, Sparkle, GitHub, and Homebrew release pipeline.