### PR TITLE
docs(release): include CPU sampling fix in 0.11.2

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,10 +2,10 @@
 
 # Burrow 0.11.2
 
-An updater and launch-reliability patch. This release stops expected Sparkle
-conditions from looking like product defects, gives AppKit a settled launch turn
-before creating the menu-bar item, and makes sampled app hangs reliably reach
-the issue tracker with bounded diagnostic context.
+A system-metrics, updater, and launch-reliability patch. This release corrects
+CPU sampling, stops expected Sparkle conditions from looking like product
+defects, gives AppKit a settled launch turn before creating the menu-bar item,
+and makes sampled app hangs reliably reach the issue tracker.
 
 > **Affected macOS 27 beta users:** please install 0.11.2 and report the result
 > in [#319](https://github.com/caezium/Burrow/issues/319). The exact Beta 4
@@ -13,6 +13,13 @@ the issue tracker with bounded diagnostic context.
 > notarized build is verified on a Mac that reproduced the freeze.
 
 ## Fixed
+- **CPU usage now reflects a representative sampling interval.** The bundled
+  engine keeps a tick baseline across refreshes, samples before the other
+  collectors fan out, and derives total usage from summed tick deltas. This
+  removes the roughly doubled readings and coarse per-core fractions reported in
+  [#335](https://github.com/caezium/Burrow/issues/335). A cold one-shot status
+  command can take about 600 ms longer; ongoing GUI sampling reuses its existing
+  refresh interval and adds no wait. ([#340](https://github.com/caezium/Burrow/pull/340))
 - **Updater failures now mean what they say.** Running from a disk image or a
   translocated location, ordinary network failures, and user cancellation remain
   measurable in PostHog without opening Sentry issues. Sparkle keeps ownership of

--- a/docs/index.html
+++ b/docs/index.html
@@ -397,23 +397,23 @@
 
     <div class="grid3 wn-grid">
       <article class="tcard" style="--c: var(--green)">
+        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5-7 4 14 2.5-7h5"/></svg></div><div class="nm">CPU usage matches the sampling window</div></div>
+        <p class="ds">The bundled engine keeps a baseline across refreshes, samples before collector fan-out, and sums tick deltas instead of reporting the collector's own burst.</p>
+      </article>
+      <article class="tcard" style="--c: var(--azure)">
         <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l1.8 4.6L18 10l-4.2 1.4L12 16l-1.8-4.6L6 10l4.2-1.4z"/><path d="M18.5 15.5l.9 2.1 2.1.9-2.1.9-.9 2.1-.9-2.1-2.1-.9 2.1-.9z"/></svg></div><div class="nm">Updates report the right outcome</div></div>
         <p class="ds">Translocation, ordinary network failures, and cancellation stay measurable without becoming Sentry defects; actionable failures still produce one scrubbed diagnostic.</p>
       </article>
-      <article class="tcard" style="--c: var(--azure)">
+      <article class="tcard" style="--c: var(--lilac)">
         <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 4.5-3 8-7 10-4-2-7-5.5-7-10V6z"/><path d="M9.5 11.5l2 2 3.5-3.5"/></svg></div><div class="nm">AppKit gets a settled launch turn</div></div>
         <p class="ds">Normal menu-bar creation waits one second after launch before entering its existing stability window, while the exact macOS 27 Beta 4 safeguard remains in place.</p>
-      </article>
-      <article class="tcard" style="--c: var(--lilac)">
-        <div class="top"><div class="ico"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h4l2.5-7 4 14 2.5-7h5"/></svg></div><div class="nm">Hang evidence reaches the tracker</div></div>
-        <p class="ds">The Sentry bridge paginates older groups and rolls bounded weekly App-Hang digests instead of silently dropping them.</p>
       </article>
     </div>
 
     <div class="extra-label mono">// also tightened in 0.11.2</div>
     <div class="wn-chips">
       <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Sparkle keeps its native move-to-Applications and retry UI</span>
-      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>Expected updater conditions are PostHog-only; actionable failures create one Sentry diagnostic</span>
+      <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>App-Hang digests paginate and roll over instead of dropping older groups</span>
       <span class="wn-chip"><svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg><a href="https://github.com/caezium/Burrow/issues/319" target="_blank" rel="noopener">#319</a> stays open until an affected macOS 27 Mac verifies the notarized build</span>
     </div>
     <!-- WN:END -->

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -135,10 +135,11 @@
         <a class="gh mono" href="https://github.com/caezium/Burrow/releases/tag/v0.11.2" target="_blank" rel="noopener">full notes ↗</a>
       </div>
       <div class="sbody">
-        <p class="lead">An updater and launch-reliability patch with accurate Sparkle outcomes, a settled AppKit status-item start, and hang reports that reliably reach the issue tracker.</p>
+        <p class="lead">A system-metrics, updater, and launch-reliability patch with accurate CPU sampling, accurate Sparkle outcomes, a settled AppKit start, and reliable hang reports.</p>
         <div class="sblock">
           <div class="slabel mono">fixed</div>
           <ul class="slist">
+            <li><b>CPU usage now reflects a representative sampling interval.</b> The bundled engine keeps a tick baseline across refreshes, samples before the other collectors fan out, and derives total usage from summed tick deltas. This removes the roughly doubled readings and coarse per-core fractions reported in <a href="https://github.com/caezium/Burrow/issues/335" target="_blank" rel="noopener">#335</a>. A cold one-shot status command can take about 600 ms longer; ongoing GUI sampling reuses its existing refresh interval and adds no wait. (<a href="https://github.com/caezium/Burrow/pull/340" target="_blank" rel="noopener">#340</a>)</li>
             <li><b>Updater failures now mean what they say.</b> Running from a disk image or translocated location, ordinary network failures, and user cancellation remain measurable in PostHog without opening Sentry issues. Sparkle keeps ownership of its native move-to-Applications and scheduled-retry UI. Configuration, signature, installation, and unknown failures still create exactly one scrubbed Sentry diagnostic per cycle. (<a href="https://github.com/caezium/Burrow/pull/339" target="_blank" rel="noopener">#339</a>)</li>
             <li><b>The normal menu-bar path no longer races the first AppKit launch turn.</b> Burrow waits one second before creating its status item, then retains the existing 30-second stability window. The safeguard for macOS 27 Beta 4 build <code>26A5388g</code> remains exact-build-only; a later macOS build returns to the normal guarded path automatically. (<a href="https://github.com/caezium/Burrow/pull/339" target="_blank" rel="noopener">#339</a>)</li>
           </ul>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -5,36 +5,37 @@
       "version": "0.11.2",
       "date": "2026-08-05",
       "tag": "v0.11.2",
-      "tagline": "An updater and launch-reliability patch with accurate Sparkle outcomes, a settled AppKit status-item start, and hang reports that reliably reach the issue tracker.",
+      "tagline": "A system-metrics, updater, and launch-reliability patch with accurate CPU sampling, accurate Sparkle outcomes, a settled AppKit start, and reliable hang reports.",
       "highlights": [
         {
-          "icon": "sparkle",
+          "icon": "pulse",
           "color": "green",
+          "title": "CPU usage matches the sampling window",
+          "line": "The bundled engine keeps a baseline across refreshes, samples before collector fan-out, and sums tick deltas instead of reporting the collector's own burst."
+        },
+        {
+          "icon": "sparkle",
+          "color": "azure",
           "title": "Updates report the right outcome",
           "line": "Translocation, ordinary network failures, and cancellation stay measurable without becoming Sentry defects; actionable failures still produce one scrubbed diagnostic."
         },
         {
           "icon": "shield",
-          "color": "azure",
+          "color": "lilac",
           "title": "AppKit gets a settled launch turn",
           "line": "Normal menu-bar creation waits one second after launch before entering its existing stability window, while the exact macOS 27 Beta 4 safeguard remains in place."
-        },
-        {
-          "icon": "pulse",
-          "color": "lilac",
-          "title": "Hang evidence reaches the tracker",
-          "line": "The Sentry bridge paginates older groups and rolls bounded weekly App-Hang digests instead of silently dropping them."
         }
       ],
       "chips": [
         "Sparkle keeps its native move-to-Applications and retry UI",
-        "Expected updater conditions are PostHog-only; actionable failures create one Sentry diagnostic",
+        "App-Hang digests paginate and roll over instead of dropping older groups",
         "[#319](https://github.com/caezium/Burrow/issues/319) stays open until an affected macOS 27 Mac verifies the notarized build"
       ],
       "sections": [
         {
           "label": "fixed",
           "items": [
+            "**CPU usage now reflects a representative sampling interval.** The bundled engine keeps a tick baseline across refreshes, samples before the other collectors fan out, and derives total usage from summed tick deltas. This removes the roughly doubled readings and coarse per-core fractions reported in [#335](https://github.com/caezium/Burrow/issues/335). A cold one-shot status command can take about 600 ms longer; ongoing GUI sampling reuses its existing refresh interval and adds no wait. ([#340](https://github.com/caezium/Burrow/pull/340))",
             "**Updater failures now mean what they say.** Running from a disk image or translocated location, ordinary network failures, and user cancellation remain measurable in PostHog without opening Sentry issues. Sparkle keeps ownership of its native move-to-Applications and scheduled-retry UI. Configuration, signature, installation, and unknown failures still create exactly one scrubbed Sentry diagnostic per cycle. ([#339](https://github.com/caezium/Burrow/pull/339))",
             "**The normal menu-bar path no longer races the first AppKit launch turn.** Burrow waits one second before creating its status item, then retains the existing 30-second stability window. The safeguard for macOS 27 Beta 4 build `26A5388g` remains exact-build-only; a later macOS build returns to the normal guarded path automatically. ([#339](https://github.com/caezium/Burrow/pull/339))"
           ]


### PR DESCRIPTION
## Summary

Update the prepared 0.11.2 release notes after merging #340 so the release accurately includes the CPU sampling correction from engine commit `a6d1a98`.

- make CPU accuracy a primary 0.11.2 highlight
- explain the baseline, pre-fan-out sampling, and summed-tick fix
- disclose the roughly 600 ms cost for cold one-shot status commands and that continuous GUI sampling adds no wait
- regenerate the homepage and release history

The first `v0.11.2` run was canceled during compilation, before signing, notarization, GitHub release creation, appcast publication, or Homebrew publication. The unpublished tag was removed and will be recreated only after this PR merges.

## Verification

- engine `go test ./...`
- `python3 -m unittest discover -s scripts/tests` (36 tests)
- `node --test scripts/tests/test_site_analytics.mjs` (7 tests)
- `greenlight preflight macos --exit-code` (GREENLIT)
- `python3 scripts/site-release.py --check`
- `plutil -lint macos/Resources/Info.plist`
- `git diff --check`