### PR TITLE
fix(release): verify repaired archive digest

### DIFF
--- a/.github/workflows/repair-sparkle-release-notes.yml
+++ b/.github/workflows/repair-sparkle-release-notes.yml
@@ -129,8 +129,6 @@ jobs:
           TAG: ${{ steps.target.outputs.tag }}
           VERSION: ${{ steps.target.outputs.version }}
           BUILD_NUMBER: ${{ steps.archive.outputs.build_number }}
-          ASSET_NAME: ${{ steps.target.outputs.asset_name }}
-          EXPECTED_DIGEST: ${{ steps.target.outputs.asset_digest }}
           INFO_PLIST: ${{ steps.archive.outputs.info_plist }}
         run: |
           set -euo pipefail
@@ -186,6 +184,8 @@ jobs:
           TAG: ${{ steps.target.outputs.tag }}
           VERSION: ${{ steps.target.outputs.version }}
           BUILD_NUMBER: ${{ steps.archive.outputs.build_number }}
+          ASSET_NAME: ${{ steps.target.outputs.asset_name }}
+          EXPECTED_DIGEST: ${{ steps.target.outputs.asset_digest }}
         run: |
           set -euo pipefail
           PUBLISHED="$RUNNER_TEMP/published"

--- a/scripts/tests/test_release_workflows.py
+++ b/scripts/tests/test_release_workflows.py
@@ -89,7 +89,18 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("--notes-file RELEASES.md", workflow)
         self.assertNotIn('gh release upload "$TAG" "$ZIP"', workflow)
         self.assertIn('sign_update" --verify', workflow)
-        self.assertIn('if [ "$PUBLISHED_DIGEST" != "$EXPECTED_DIGEST" ]', workflow)
+
+        verify_start = workflow.index("- name: Verify the published repair")
+        verify_step = workflow[verify_start:]
+        self.assertIn(
+            "ASSET_NAME: ${{ steps.target.outputs.asset_name }}", verify_step
+        )
+        self.assertIn(
+            "EXPECTED_DIGEST: ${{ steps.target.outputs.asset_digest }}", verify_step
+        )
+        self.assertIn(
+            'if [ "$PUBLISHED_DIGEST" != "$EXPECTED_DIGEST" ]', verify_step
+        )
 
     def test_xcode_27_preview_lane_is_advisory_and_runs_the_full_suite(self) -> None:
         workflow = (WORKFLOWS / "ci.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
Move the published archive digest inputs into the post-publication verification step, where they are consumed.

The first repair run successfully replaced and verified the signed appcast, but this final unchanged-ZIP assertion exited on an unbound variable. The workflow test now scopes its assertions to the verification step so this wiring error cannot recur.

Verification:
- `actionlint .github/workflows/repair-sparkle-release-notes.yml`
- `python3 -m unittest scripts.tests.test_release_workflows`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`