### PR TITLE
fix(macos): make Full Disk Access detection honest and stop the menu-bar toggle silently no-opping

### DIFF
--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -457,6 +457,9 @@
 "Burrow detected that creating its menu bar item could freeze this macOS build. The menu bar item and automatic update checks are paused on this build, and Burrow will stay available in the Dock. Manual update checks remain available. Updating macOS will automatically retry the normal mode." = "Burrow 检测到在此 macOS 版本上创建菜单栏项目可能导致系统卡死。此版本上的菜单栏项目和自动更新检查已暂停，Burrow 将继续显示在 Dock 中。您仍可手动检查更新。更新 macOS 后将自动重试正常模式。";
 "Burrow paused automatic update checks" = "Burrow 已暂停自动更新检查";
 "Burrow detected that its automatic updater did not reach a stable state on the previous launch. Automatic checks are paused for this app and macOS build so the same startup problem cannot repeat. You can still check manually; updating Burrow or macOS will retry automatic checks." = "Burrow 检测到自动更新程序在上次启动时未能达到稳定状态。为避免同一启动问题再次发生，当前应用和 macOS 版本的自动检查已暂停。您仍可手动检查；更新 Burrow 或 macOS 后将重试自动检查。";
+"Menu bar item paused on this macOS build" = "此 macOS 构建版本已暂停菜单栏项目";
+"Creating it could freeze system input on this build, so Burrow runs from the Dock instead. It returns automatically once you update macOS." = "在此构建版本上创建菜单栏项目可能导致系统输入卡死，因此 Burrow 改从 Dock 运行。更新 macOS 后会自动恢复。";
+"Paused on this macOS build. The setting is kept and applies again as soon as Burrow can create the menu bar item safely." = "在此 macOS 构建版本上已暂停。该设置会被保留，一旦 Burrow 能够安全创建菜单栏项目就会重新生效。";
 "Copy Diagnostics" = "复制诊断信息";
 "Share anonymous usage & crash reports?" = "分享匿名使用情况和崩溃报告？";
 "Helps prioritize fixes: app/OS version, coarse bucketed feature counts, and crash traces. Never files, paths, file contents, or your metrics — the exact list is in TELEMETRY.md. You can change this anytime in Settings → Anonymous usage." = "帮助确定修复优先级：应用/系统版本、按区间归档的功能使用次数和崩溃记录。绝不包含文件、路径、文件内容或你的指标数据 — 完整列表见 TELEMETRY.md。可随时在「设置 → 匿名使用情况」中更改。";

--- a/macos/Resources/zh-Hant.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hant.lproj/Localizable.strings
@@ -458,6 +458,9 @@
 "Burrow detected that creating its menu bar item could freeze this macOS build. The menu bar item and automatic update checks are paused on this build, and Burrow will stay available in the Dock. Manual update checks remain available. Updating macOS will automatically retry the normal mode." = "Burrow 偵測到在此 macOS 版本上建立選單列項目可能導致系統卡住。此版本上的選單列項目與自動更新檢查已暫停，Burrow 將繼續顯示在 Dock 中。你仍可手動檢查更新。更新 macOS 後將自動重試正常模式。";
 "Burrow paused automatic update checks" = "Burrow 已暫停自動更新檢查";
 "Burrow detected that its automatic updater did not reach a stable state on the previous launch. Automatic checks are paused for this app and macOS build so the same startup problem cannot repeat. You can still check manually; updating Burrow or macOS will retry automatic checks." = "Burrow 偵測到自動更新程式在上次啟動時未能達到穩定狀態。為避免相同的啟動問題再次發生，目前 App 與 macOS 版本的自動檢查已暫停。你仍可手動檢查；更新 Burrow 或 macOS 後將重試自動檢查。";
+"Menu bar item paused on this macOS build" = "此 macOS 組建版本已暫停選單列項目";
+"Creating it could freeze system input on this build, so Burrow runs from the Dock instead. It returns automatically once you update macOS." = "在此組建版本上建立選單列項目可能導致系統輸入卡住，因此 Burrow 改從 Dock 執行。更新 macOS 後會自動恢復。";
+"Paused on this macOS build. The setting is kept and applies again as soon as Burrow can create the menu bar item safely." = "在此 macOS 組建版本上已暫停。該設定會被保留，一旦 Burrow 能夠安全建立選單列項目就會重新生效。";
 "Copy Diagnostics" = "複製診斷資訊";
 "Helps prioritize fixes: app/OS version, coarse bucketed feature counts, and crash traces. Never files, paths, file contents, or your metrics — the exact list is in TELEMETRY.md. You can change this anytime in Settings → Anonymous usage." = "協助確定修復優先順序：應用程式/系統版本、按區間歸檔的功能使用次數與當機記錄。絕不包含檔案、路徑、檔案內容或你的指標資料 — 完整列表見 TELEMETRY.md。可隨時在「設定 → 匿名使用情況」中變更。";
 "Share" = "分享";

--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -53,6 +53,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var recoveryReason: LaunchRecoveryReason?
     private var updaterRecoveryReason: LaunchRecoveryReason?
     private var safeModeActive = false
+    /// True while the compatibility guard is suppressing the menu-bar item on
+    /// this macOS build. Settings reads it so the "Show menu bar icon" toggle
+    /// can say what is actually happening rather than flipping on and quietly
+    /// doing nothing (#319).
+    var menuBarSuppressedByCompatibilityGuard: Bool { recoveryReason != nil }
     private var recoveryNoticePresented = false
     private var launchCompleted = false
     private var initialStatusItemCreationTask: Task<Void, Never>?

--- a/macos/Sources/Doctor.swift
+++ b/macos/Sources/Doctor.swift
@@ -24,6 +24,10 @@ enum Doctor {
 
     struct Input {
         var fullDiskAccess: Bool
+        /// False when every probe location was missing rather than refused,
+        /// so "off" would be a guess. Defaults true to keep existing callers
+        /// and tests reading the same as before.
+        var fullDiskAccessConclusive: Bool = true
         var moInstalled: Bool
         var pressure: MemoryPressure
         var diskFreeBytes: Int64
@@ -111,9 +115,18 @@ enum Doctor {
     }
 
     private static func permissions(_ i: Input) -> Check {
-        i.fullDiskAccess
-            ? Check(name: "Full Disk Access", level: .ok, detail: "granted")
-            : Check(name: "Full Disk Access", level: .warn, detail: "off — some scans and cleanups are limited")
+        if i.fullDiskAccess {
+            return Check(name: "Full Disk Access", level: .ok, detail: "granted")
+        }
+        // Nothing was refused and nothing opened — every gated location this
+        // build knows about is absent. Saying "off" here is what sent users
+        // round the grant/relaunch loop for nothing (#177, #181, #319).
+        guard i.fullDiskAccessConclusive else {
+            return Check(name: "Full Disk Access", level: .warn,
+                         detail: "could not be determined on this macOS build — grant it and rerun if scans stay limited")
+        }
+        return Check(name: "Full Disk Access", level: .warn,
+                     detail: "off — some scans and cleanups are limited")
     }
 
     private static func memory(_ i: Input) -> Check {

--- a/macos/Sources/DoctorView.swift
+++ b/macos/Sources/DoctorView.swift
@@ -124,7 +124,8 @@ struct DoctorView: View {
         let p = (latest?.memory.pressure ?? "").lowercased()
         let pressure: Doctor.MemoryPressure = p.contains("critical") ? .critical
             : (p.contains("warn") ? .warning : .normal)
-        let fullDiskAccess = Privacy.hasFullDiskAccess()
+        let fdaDiagnosis = Privacy.diagnoseFullDiskAccess()
+        let fullDiskAccess = fdaDiagnosis.hasAccess
         let recentErrorCount = MetricsStore.driftCounters.decodeSkippedTotal
         // `tmutil latestbackup` and `system_profiler SPNVMeDataType` each spawn a
         // subprocess and block on waitUntilExit() — system_profiler routinely
@@ -156,6 +157,7 @@ struct DoctorView: View {
         }
         checks = Doctor.report(.init(
             fullDiskAccess: fullDiskAccess,
+            fullDiskAccessConclusive: fdaDiagnosis.conclusive,
             moInstalled: moInstalled, pressure: pressure,
             diskFreeBytes: free, diskTotalBytes: total,
             recentErrorCount: recentErrorCount,

--- a/macos/Sources/MCP.swift
+++ b/macos/Sources/MCP.swift
@@ -795,8 +795,10 @@ struct ToolCatalog {
             total = Int64(d.total)
             free = Int64(d.total > d.used ? d.total - d.used : 0)
         }
+        let fdaDiagnosis = Privacy.diagnoseFullDiskAccess()
         let input = Doctor.Input(
-            fullDiskAccess: Privacy.hasFullDiskAccess(),
+            fullDiskAccess: fdaDiagnosis.hasAccess,
+            fullDiskAccessConclusive: fdaDiagnosis.conclusive,
             moInstalled: moInstalled,
             pressure: Self.mapPressure(latest?.memory.pressure),
             diskFreeBytes: free, diskTotalBytes: total,

--- a/macos/Sources/Privacy.swift
+++ b/macos/Sources/Privacy.swift
@@ -29,25 +29,102 @@ enum Privacy {
         return !hasAccess && !dismissed
     }
 
-    /// Probe whether Burrow has Full Disk Access by attempting to open an
-    /// FDA-gated file. `TCC.db` exists on every Mac and is readable only
-    /// with Full Disk Access, so a successful open is the canonical
-    /// signal. We open and immediately close — the bytes are never read;
-    /// this is a capability probe, not data access. A read that lacks
-    /// access fails silently (no prompt), so probing can't itself flood
-    /// the user.
-    static func hasFullDiskAccess() -> Bool {
-        let probes = [
-            "Library/Application Support/com.apple.TCC/TCC.db",
-            "Library/Safari/Bookmarks.plist",
-        ].map { (NSHomeDirectory() as NSString).appendingPathComponent($0) }
-        for path in probes {
-            if let fh = FileHandle(forReadingAtPath: path) {
-                try? fh.close()
-                return true
-            }
+    /// What one probe location told us. The distinction that matters is
+    /// `denied` vs `unavailable`: the old two-path probe collapsed both into
+    /// "no access", so a Mac where neither path existed reported Full Disk
+    /// Access as off however many times the user granted it (#177, #181, #319).
+    enum ProbeOutcome: String, Equatable {
+        /// Opened — the grant is live for this process.
+        case granted
+        /// The file is there and the kernel refused the read: access is off.
+        case denied
+        /// Nothing at this path on this Mac, so it says nothing either way.
+        case unavailable
+        /// Some other errno. Treated like `unavailable` — never as proof.
+        case inconclusive
+    }
+
+    /// An FDA-gated location to try. `authoritative` marks the paths that
+    /// exist on every Mac and are gated by Full Disk Access *specifically*,
+    /// so a refusal there really does mean the grant is missing. The rest
+    /// are positive-only: Safari and Messages data can be absent or gated
+    /// under a different service, so their refusal proves nothing.
+    struct Probe: Equatable {
+        let id: String
+        let path: String
+        let authoritative: Bool
+    }
+
+    static let fullDiskAccessProbes: [Probe] = {
+        let home = NSHomeDirectory() as NSString
+        return [
+            Probe(id: "user_tcc_db",
+                  path: home.appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db"),
+                  authoritative: true),
+            Probe(id: "system_tcc_db",
+                  path: "/Library/Application Support/com.apple.TCC/TCC.db",
+                  authoritative: true),
+            Probe(id: "safari_bookmarks",
+                  path: home.appendingPathComponent("Library/Safari/Bookmarks.plist"),
+                  authoritative: false),
+            Probe(id: "messages_db",
+                  path: home.appendingPathComponent("Library/Messages/chat.db"),
+                  authoritative: false),
+        ]
+    }()
+
+    /// The full picture behind `hasFullDiskAccess()`. `conclusive` is the
+    /// point of it: when nothing opened *and* no authoritative probe was
+    /// refused, Burrow has learned nothing and must not tell the user the
+    /// permission is off.
+    struct Diagnosis: Equatable {
+        var outcomes: [String: ProbeOutcome]
+        var hasAccess: Bool
+        var conclusive: Bool
+    }
+
+    /// Classify a single probe from the errno an `open(2)` left behind.
+    /// Pure and separately testable — the errno mapping is the part most
+    /// likely to need revisiting on a future macOS.
+    static func classify(openSucceeded: Bool, errnoValue: Int32) -> ProbeOutcome {
+        if openSucceeded { return .granted }
+        switch errnoValue {
+        case EPERM, EACCES: return .denied
+        case ENOENT, ENOTDIR: return .unavailable
+        default: return .inconclusive
         }
-        return false
+    }
+
+    /// Fold per-probe outcomes into a verdict. Any single `granted` wins;
+    /// otherwise only an authoritative `denied` earns the right to say "off".
+    static func summarize(_ outcomes: [String: ProbeOutcome], probes: [Probe]) -> Diagnosis {
+        let hasAccess = outcomes.values.contains(.granted)
+        let authoritativeDenial = probes.contains {
+            $0.authoritative && outcomes[$0.id] == .denied
+        }
+        return Diagnosis(outcomes: outcomes,
+                         hasAccess: hasAccess,
+                         conclusive: hasAccess || authoritativeDenial)
+    }
+
+    /// Run every probe. We open and immediately close — the bytes are never
+    /// read; this is a capability probe, not data access. A read that lacks
+    /// access fails silently (no prompt), so probing can't itself flood the
+    /// user with consent dialogs.
+    static func diagnoseFullDiskAccess(probes: [Probe] = fullDiskAccessProbes) -> Diagnosis {
+        var outcomes: [String: ProbeOutcome] = [:]
+        for probe in probes {
+            let fd = open(probe.path, O_RDONLY)
+            let outcome = classify(openSucceeded: fd >= 0, errnoValue: errno)
+            if fd >= 0 { close(fd) }
+            outcomes[probe.id] = outcome
+        }
+        return summarize(outcomes, probes: probes)
+    }
+
+    /// Whether Burrow can reach FDA-gated files right now.
+    static func hasFullDiskAccess() -> Bool {
+        diagnoseFullDiskAccess().hasAccess
     }
 
     /// Deep-link to System Settings ▸ Privacy & Security ▸ Full Disk Access.

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -83,6 +83,9 @@ struct SettingsView: View {
     // Menu bar
     @State private var showMenuBarIcon: Bool = Store.showMenuBarIcon
     @State private var displayMode: MenuBarDisplayMode = Store.menuBarDisplayMode
+    /// The compatibility guard suppresses the menu-bar item on some macOS
+    /// builds. Without this the toggle read as on while doing nothing (#319).
+    @State private var menuBarSuppressed: Bool = false
     @State private var menuBarItems: [MenuBarItem] = Store.menuBarItems
     /// Which widget's options panel is expanded in the editor (one at a time).
     @State private var expandedMenuBarItem: UUID?
@@ -163,6 +166,7 @@ struct SettingsView: View {
         .onAppear {
             refreshStatusLabels(); loadMoleVersion(); loadTouchIDStatus(); loadLaunchAtLogin()
             whitelistPatterns = MoleWhitelist.live.patterns()
+            menuBarSuppressed = AppDelegate.shared?.menuBarSuppressedByCompatibilityGuard ?? false
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             fdaGranted = Privacy.hasFullDiskAccess()
@@ -449,14 +453,43 @@ struct SettingsView: View {
 
     // MARK: - Menu bar
 
+    /// Shown in place of a toggle that cannot act. The recovery alert fires
+    /// once per macOS build, so without this the only lasting explanation for
+    /// a missing menu-bar icon was a checked switch that did nothing (#319).
+    private var menuBarCompatibilityNotice: some View {
+        HStack(alignment: .top, spacing: 9) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Brand.amber)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(NSLocalizedString("Menu bar item paused on this macOS build", comment: ""))
+                    .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.textPrimary)
+                Text(NSLocalizedString("Creating it could freeze system input on this build, so Burrow runs from the Dock instead. It returns automatically once you update macOS.", comment: ""))
+                    .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10).padding(.vertical, 8)
+        .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(Brand.amber.opacity(0.10)))
+        .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).strokeBorder(Brand.amber.opacity(0.25), lineWidth: 1))
+        .accessibilityElement(children: .combine)
+    }
+
     private var menuBarTab: some View {
         Group {
             section("Menu bar", "menubar.rectangle") {
+                if menuBarSuppressed { menuBarCompatibilityNotice }
                 toggleRow("Show menu bar icon", isOn: $showMenuBarIcon) { on in
                     Store.showMenuBarIcon = on
                     AppDelegate.shared?.applyMenuBarVisibility(on)
                 }
-                footnote("Applies immediately. When off, Burrow shows a Dock icon instead so it stays reachable — a Dock click reopens the window.")
+                .disabled(menuBarSuppressed)
+                .opacity(menuBarSuppressed ? 0.5 : 1)
+                footnote(menuBarSuppressed
+                    ? "Paused on this macOS build. The setting is kept and applies again as soon as Burrow can create the menu bar item safely."
+                    : "Applies immediately. When off, Burrow shows a Dock icon instead so it stays reachable — a Dock click reopens the window.")
                 HStack {
                     Text(NSLocalizedString("Display", comment: "")).font(Brand.sans(12)).foregroundStyle(Brand.textPrimary)
                     Spacer()
@@ -471,6 +504,8 @@ struct SettingsView: View {
                         AppDelegate.shared?.applyMenuBarVisibility(Store.showMenuBarIcon)
                     }
                 }
+                .disabled(menuBarSuppressed)
+                .opacity(menuBarSuppressed ? 0.5 : 1)
                 footnote("Choose which metrics appear in the menu bar and how each is shown — refreshed with the sampler. Each metric has its own text size in its options (⚙︎).")
                 if displayMode == .metrics { menuBarMetricsEditor }
                 toggleRow("Show camera & mic in-use indicator", isOn: $cameraMicIndicator) {

--- a/macos/Tests/DoctorTests.swift
+++ b/macos/Tests/DoctorTests.swift
@@ -47,7 +47,31 @@ final class DoctorTests: XCTestCase {
 
     func testReport_noFullDiskAccess_warns() {
         var i = healthy(); i.fullDiskAccess = false
-        XCTAssertEqual(check(Doctor.report(i), "Full Disk Access")?.level, .warn)
+        let c = check(Doctor.report(i), "Full Disk Access")
+        XCTAssertEqual(c?.level, .warn)
+        XCTAssertTrue(c?.detail.hasPrefix("off") == true)
+    }
+
+    // When no probe location existed to refuse us, Doctor must not assert the
+    // permission is off — that false negative is what kept users re-granting
+    // it to no effect on macOS 27 betas (#177, #181, #319).
+    func testReport_inconclusiveFullDiskAccess_warnsWithoutClaimingOff() {
+        var i = healthy()
+        i.fullDiskAccess = false
+        i.fullDiskAccessConclusive = false
+        let c = check(Doctor.report(i), "Full Disk Access")
+        XCTAssertEqual(c?.level, .warn)
+        XCTAssertFalse(c?.detail.hasPrefix("off") == true,
+                       "an undetermined probe must not be reported as a denial")
+        XCTAssertTrue(c?.detail.contains("could not be determined") == true)
+    }
+
+    // A live grant is reported the same way regardless of the conclusive bit.
+    func testReport_grantedFullDiskAccess_ignoresConclusiveFlag() {
+        var i = healthy()
+        i.fullDiskAccess = true
+        i.fullDiskAccessConclusive = false
+        XCTAssertEqual(check(Doctor.report(i), "Full Disk Access")?.level, .ok)
     }
 
     func testReport_criticalPressure_fails() {

--- a/macos/Tests/PrivacyTests.swift
+++ b/macos/Tests/PrivacyTests.swift
@@ -25,4 +25,62 @@ final class PrivacyTests: XCTestCase {
                        "respect a prior dismissal")
         XCTAssertFalse(Privacy.shouldOfferFullDiskAccess(hasAccess: true, dismissed: true))
     }
+
+    // The errno mapping is the part most likely to need revisiting on a
+    // future macOS, so pin what each class of failure means. A refusal is
+    // evidence the grant is missing; a missing file is evidence of nothing.
+    func testClassifiesProbeOutcomesFromErrno() {
+        XCTAssertEqual(Privacy.classify(openSucceeded: true, errnoValue: 0), .granted)
+        XCTAssertEqual(Privacy.classify(openSucceeded: false, errnoValue: EPERM), .denied)
+        XCTAssertEqual(Privacy.classify(openSucceeded: false, errnoValue: EACCES), .denied)
+        XCTAssertEqual(Privacy.classify(openSucceeded: false, errnoValue: ENOENT), .unavailable)
+        XCTAssertEqual(Privacy.classify(openSucceeded: false, errnoValue: ENOTDIR), .unavailable)
+        XCTAssertEqual(Privacy.classify(openSucceeded: false, errnoValue: EIO), .inconclusive)
+    }
+
+    private static let probes = [
+        Privacy.Probe(id: "user_tcc_db", path: "/user", authoritative: true),
+        Privacy.Probe(id: "safari_bookmarks", path: "/safari", authoritative: false),
+    ]
+
+    func testAnyGrantedProbeMeansAccess() {
+        let d = Privacy.summarize(["user_tcc_db": .denied, "safari_bookmarks": .granted],
+                                  probes: Self.probes)
+        XCTAssertTrue(d.hasAccess, "one open is enough — the grant is live")
+        XCTAssertTrue(d.conclusive)
+    }
+
+    func testAuthoritativeRefusalIsConclusiveOff() {
+        let d = Privacy.summarize(["user_tcc_db": .denied, "safari_bookmarks": .unavailable],
+                                  probes: Self.probes)
+        XCTAssertFalse(d.hasAccess)
+        XCTAssertTrue(d.conclusive, "TCC.db exists and was refused — access really is off")
+    }
+
+    // The #177/#181/#319 regression: every probe location absent used to be
+    // reported as "off", sending users round the grant/relaunch loop forever.
+    func testMissingProbeLocationsAreNotReportedAsDenied() {
+        let d = Privacy.summarize(["user_tcc_db": .unavailable, "safari_bookmarks": .unavailable],
+                                  probes: Self.probes)
+        XCTAssertFalse(d.hasAccess)
+        XCTAssertFalse(d.conclusive, "nothing was refused, so Burrow has learned nothing")
+    }
+
+    // A non-authoritative refusal can mean a different TCC service, not FDA.
+    func testNonAuthoritativeRefusalAloneIsInconclusive() {
+        let d = Privacy.summarize(["user_tcc_db": .unavailable, "safari_bookmarks": .denied],
+                                  probes: Self.probes)
+        XCTAssertFalse(d.hasAccess)
+        XCTAssertFalse(d.conclusive)
+    }
+
+    // The real probe set must keep at least one location that exists on every
+    // Mac, or the diagnosis can never be conclusive in the field.
+    func testShippedProbeSetHasAuthoritativeLocations() {
+        XCTAssertTrue(Privacy.fullDiskAccessProbes.contains { $0.authoritative },
+                      "at least one always-present, FDA-gated probe is required")
+        XCTAssertEqual(Set(Privacy.fullDiskAccessProbes.map(\.id)).count,
+                       Privacy.fullDiskAccessProbes.count,
+                       "probe ids key the outcome map, so they must be unique")
+    }
 }


### PR DESCRIPTION
Two follow-ups from #319 that are independent of the startup freeze ConnerCai confirmed is fixed in 0.11.1/0.11.2.

## Full Disk Access

`Privacy.hasFullDiskAccess()` opened exactly two paths and returned `false` if neither opened, which collapses "the kernel refused me" and "there is no file here" into the same answer. On a Mac where neither path exists, Burrow reports access as off however many times the user grants it — the loop reported in #177, #181, and now again in #319 on builds that are correctly Developer ID signed and notarized.

I verified the published `Burrow-0.11.2.zip` end to end before writing this: `codesign --verify --deep --strict` passes, "valid on disk" and "satisfies its Designated Requirement", Developer ID Application (`YGSM2722TZ`), hardened runtime, `spctl` reports `source=Notarized Developer ID`, `stapler validate` succeeds, and the designated requirement is identity-based rather than cdhash-pinned. So the signing fix from #178 genuinely shipped and is correct, and the remaining FDA reports are not explained by it.

Changes:

- Probes classify by errno — `EPERM`/`EACCES` → `denied`, `ENOENT`/`ENOTDIR` → `unavailable`, anything else → `inconclusive`.
- The probe set splits into authoritative locations (both `TCC.db` files: present on every Mac and gated by Full Disk Access specifically) and positive-only ones (Safari bookmarks, `chat.db` — these can be absent or gated under a different TCC service, so their refusal proves nothing).
- Only an authoritative refusal earns the right to report "off". Any single successful open still means access is live.
- Doctor reports an undetermined probe as undetermined instead of asserting a denial, in the UI and over `burrow_doctor`.

If the reports are a false negative, this fixes them. If the grant genuinely is not landing, this turns a wrong answer into an honest "undetermined" — the TCC log from an affected machine is still what settles it. Not claiming root cause here.

## Menu bar

On a build the compatibility guard covers, `applyMenuBarVisibility` early-returns, so Settings ▸ "Show menu bar icon" persisted the setting, stayed visually checked, and did nothing. The recovery alert fires only once per macOS build (keyed on `lastCompatibilityNoticeBuild`), so after that there was no lasting explanation for a missing icon — just a switch that read as on. Both reporters on #319 hit exactly this.

Settings now reads `AppDelegate.menuBarSuppressedByCompatibilityGuard`, shows an inline notice explaining the pause, and disables the controls that cannot act. Translations added for zh-Hans and zh-Hant.

**The guard itself is unchanged** — no manual override, no narrowing of the `26A5388g` rule.

## Tests

Ten new assertions across `PrivacyTests` (errno classification, the granted/denied/unavailable fold, and a guard that the shipped probe set keeps at least one always-present authoritative location) and `DoctorTests` (inconclusive must not render as "off"). Debug build compiles and seals clean locally; the suite runs in CI.