### PR TITLE
fix(macos): derive the window's minimum height from the rail

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -449,7 +449,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         window.isMovableByWindowBackground = true
         window.center()
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 940, height: 640)
+        // Derived from the rail's own height — see WindowMetrics. The window
+        // uses fullSizeContentView, so the frame minimum IS the content
+        // minimum; there is no title bar to subtract.
+        window.minSize = NSSize(width: WindowMetrics.minimumSize.width,
+                                height: WindowMetrics.minimumSize.height)
         window.delegate = self
 
         // Show a Dock icon (and Cmd-Tab presence) while the dashboard is

--- a/macos/Sources/FloatingRail.swift
+++ b/macos/Sources/FloatingRail.swift
@@ -12,11 +12,44 @@
 
 import SwiftUI
 
+/// The rail's fixed geometry, in one place.
+///
+/// These were inline literals, and the window's minimum height was a separate
+/// hand-picked number. Adding tools to `Tool.navOrder` grew the rail past that
+/// minimum, so the foot of it — Settings — fell off the bottom of the window
+/// with nothing failing to say so. Deriving the minimum from the same numbers
+/// the layout uses means the next tool moves both together.
+enum RailMetrics {
+    static let width: CGFloat = 60
+    static let buttonSize: CGFloat = 44
+    static let itemSpacing: CGFloat = 8
+    static let dividerThickness: CGFloat = 1
+    static let dividerPadding: CGFloat = 2
+    static let topPadding: CGFloat = 20
+    static let bottomPadding: CGFloat = 8
+    /// The rail keeps at least this much air above Settings.
+    static let footGap: CGFloat = 8
+
+    /// Height the rail needs before anything is clipped, for `toolCount`
+    /// tools. Mirrors the VStack below exactly: Monitor, a divider, the
+    /// tools, the spacer, Settings — with `itemSpacing` between every pair.
+    static func intrinsicHeight(toolCount: Int) -> CGFloat {
+        let children = 1 + 1 + toolCount + 1 + 1     // monitor, divider, tools, spacer, settings
+        let gaps = CGFloat(max(children - 1, 0)) * itemSpacing
+        let divider = dividerThickness + dividerPadding * 2
+        let buttons = buttonSize * CGFloat(toolCount + 2)  // tools + monitor + settings
+        return topPadding + buttons + divider + footGap + gaps + bottomPadding
+    }
+
+    /// Height for the tools actually shipping.
+    static var intrinsicHeight: CGFloat { intrinsicHeight(toolCount: Tool.navOrder.count) }
+}
+
 struct FloatingRail: View {
     @Binding var selected: Pane
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: RailMetrics.itemSpacing) {
             RailButton(label: NSLocalizedString("Monitor", comment: ""),
                        isOn: selected == .home, accent: nil, gradient: false,
                        action: { select(.home) }) {
@@ -24,8 +57,8 @@ struct FloatingRail: View {
             }
 
             Rectangle().fill(Brand.hairline)
-                .frame(width: 22, height: 1)
-                .padding(.vertical, 2)
+                .frame(width: 22, height: RailMetrics.dividerThickness)
+                .padding(.vertical, RailMetrics.dividerPadding)
 
             ForEach(Tool.navOrder) { tool in
                 let on = selected == .tool(tool)
@@ -37,7 +70,7 @@ struct FloatingRail: View {
                 }
             }
 
-            Spacer(minLength: 8)
+            Spacer(minLength: RailMetrics.footGap)
 
             RailButton(label: NSLocalizedString("Settings", comment: ""),
                        isOn: selected == .settings, accent: Brand.accent, gradient: false,
@@ -50,9 +83,9 @@ struct FloatingRail: View {
         // Panel runs near the window top; the top inset is just enough to
         // clear the traffic lights that the OS pins over this corner.
         .padding(.horizontal, 8)
-        .padding(.top, 20)
-        .padding(.bottom, 8)
-        .frame(width: 60)
+        .padding(.top, RailMetrics.topPadding)
+        .padding(.bottom, RailMetrics.bottomPadding)
+        .frame(width: RailMetrics.width)
         .frame(maxHeight: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 22, style: .continuous)

--- a/macos/Sources/RootView.swift
+++ b/macos/Sources/RootView.swift
@@ -133,12 +133,13 @@ struct RootView: View {
                 // in place of a top tab bar. Padded clear of the traffic lights
                 // and drawn over the content.
                 FloatingRail(selected: $pane)
-                    .padding(.leading, 14)
-                    .padding(.top, 10)
-                    .padding(.bottom, 14)
+                    .padding(.leading, WindowMetrics.railLeading)
+                    .padding(.top, WindowMetrics.railTop)
+                    .padding(.bottom, WindowMetrics.railBottom)
             }
         }
-        .frame(minWidth: 940, minHeight: 640)
+        .frame(minWidth: WindowMetrics.minimumSize.width,
+               minHeight: WindowMetrics.minimumSize.height)
         .animation(.easeInOut(duration: 0.22), value: pane)
         // Sample fast only while a live metrics pane is on screen.
         .onAppear {

--- a/macos/Sources/WindowMetrics.swift
+++ b/macos/Sources/WindowMetrics.swift
@@ -1,0 +1,43 @@
+//
+//  WindowMetrics.swift
+//  Burrow
+//
+//  One definition of how small the main window may get.
+//
+//  This exists because the number drifted. The minimum was a hand-picked
+//  940×640 written in two places — RootView's `.frame(minHeight:)` and
+//  AppDelegate's `window.minSize` — while the left rail's height is a
+//  function of how many tools are in `Tool.navOrder`. Tools were added over
+//  several releases, the rail grew past 640, and Settings fell off the bottom
+//  of the window. Nothing failed: SwiftUI just clipped it.
+//
+//  So the height is derived from the rail rather than chosen. Add a tool and
+//  the minimum moves with it, and `WindowMetricsTests` fails if the two ever
+//  come apart again.
+//
+
+import CoreGraphics
+
+enum WindowMetrics {
+    // Rail placement inside RootView's ZStack.
+    static let railLeading: CGFloat = 14
+    static let railTop: CGFloat = 10
+    static let railBottom: CGFloat = 14
+
+    /// The narrowest the window may be.
+    ///
+    /// Width is a content judgement, not a derived one — the widest panes
+    /// (Analyze's treemap, the process tables) stop being readable below
+    /// this — so it stays a deliberate constant.
+    static let minimumWidth: CGFloat = 940
+
+    /// The shortest the window may be: exactly enough for the rail, which is
+    /// the tallest fixed-height thing in the window. Everything else scrolls.
+    static var minimumHeight: CGFloat {
+        RailMetrics.intrinsicHeight + railTop + railBottom
+    }
+
+    static var minimumSize: CGSize {
+        CGSize(width: minimumWidth, height: minimumHeight)
+    }
+}

--- a/macos/Tests/WindowMetricsTests.swift
+++ b/macos/Tests/WindowMetricsTests.swift
@@ -1,0 +1,83 @@
+//
+//  WindowMetricsTests.swift
+//  BurrowTests
+//
+//  The window may never be allowed to get shorter than the rail.
+//
+//  This is a regression test for a silent failure. The minimum window height
+//  was a hand-picked 940×640 duplicated in RootView and AppDelegate, while the
+//  left rail's height grows with `Tool.navOrder`. Tools were added across
+//  several releases, the rail passed 640 points, and Settings was clipped off
+//  the bottom of the window. SwiftUI doesn't complain when it clips, so the
+//  only signal was someone noticing on a small display.
+//
+//  These assert the relationship rather than the number, so adding a tool
+//  either moves the minimum with it or fails here.
+//
+
+import XCTest
+@testable import Burrow
+
+final class WindowMetricsTests: XCTestCase {
+
+    /// The whole point: the window's minimum must fit the rail plus the
+    /// padding RootView puts around it.
+    func testMinimumHeightFitsTheRailAndItsPadding() {
+        let needed = RailMetrics.intrinsicHeight + WindowMetrics.railTop + WindowMetrics.railBottom
+        XCTAssertGreaterThanOrEqual(
+            WindowMetrics.minimumHeight, needed,
+            "the window may not be shorter than the rail — Settings would be clipped")
+    }
+
+    /// The bug that shipped: with the tools we have today, the old hardcoded
+    /// 640 is genuinely too short. If this ever stops holding, the rail shrank
+    /// and the minimum could be reconsidered — but it should be a decision,
+    /// not a surprise.
+    func testTodaysRailWouldNotFitTheOldHardcodedMinimum() {
+        XCTAssertGreaterThan(WindowMetrics.minimumHeight, 640,
+                             "the rail outgrew the old 640pt minimum; that's why this exists")
+    }
+
+    /// Adding a tool must grow the requirement. If this fails, the height
+    /// stopped depending on the tool count and the guard above is decorative.
+    func testHeightGrowsWithEachTool() {
+        let current = RailMetrics.intrinsicHeight(toolCount: Tool.navOrder.count)
+        let oneMore = RailMetrics.intrinsicHeight(toolCount: Tool.navOrder.count + 1)
+        XCTAssertGreaterThan(oneMore, current)
+        XCTAssertEqual(oneMore - current, RailMetrics.buttonSize + RailMetrics.itemSpacing,
+                       "one more tool costs exactly one button plus one gap")
+    }
+
+    /// The rail height is arithmetic over the layout's own constants, so pin
+    /// the composition — a stray edit to the VStack that forgets one of these
+    /// would otherwise silently change what "fits" means.
+    func testIntrinsicHeightMatchesTheRailComposition() {
+        let tools = 4
+        let expected =
+            RailMetrics.topPadding
+            + RailMetrics.buttonSize * CGFloat(tools + 2)                 // tools + Monitor + Settings
+            + (RailMetrics.dividerThickness + RailMetrics.dividerPadding * 2)
+            + RailMetrics.footGap
+            + RailMetrics.itemSpacing * CGFloat(tools + 4 - 1)            // gaps between all children
+            + RailMetrics.bottomPadding
+        XCTAssertEqual(RailMetrics.intrinsicHeight(toolCount: tools), expected)
+    }
+
+    /// Width is a deliberate content judgement, not derived — so it just has
+    /// to stay sane. This catches an accidental zero or a wild value.
+    func testMinimumWidthStaysReasonable() {
+        XCTAssertEqual(WindowMetrics.minimumSize.width, WindowMetrics.minimumWidth)
+        XCTAssertGreaterThanOrEqual(WindowMetrics.minimumWidth, 900)
+        XCTAssertLessThanOrEqual(WindowMetrics.minimumWidth, 1400,
+                                 "a minimum this large stops fitting on small laptops")
+    }
+
+    /// The minimum must fit on the smallest display Burrow supports. A
+    /// 13-inch MacBook Air is 1440×900 in points, and macOS reserves the menu
+    /// bar, so anything approaching 900 tall is unusable there.
+    func testMinimumSizeFitsASmallLaptopDisplay() {
+        XCTAssertLessThanOrEqual(WindowMetrics.minimumSize.width, 1440)
+        XCTAssertLessThanOrEqual(WindowMetrics.minimumSize.height, 820,
+                                 "must leave room for the menu bar on a 900pt-tall display")
+    }
+}


### PR DESCRIPTION
The sidebar was being clipped on small displays — Settings fell off the bottom.

**Cause.** The minimum window size was a hand-picked `940x640` duplicated in `RootView` and `AppDelegate`, while the rail's height grows with `Tool.navOrder`. Tools were added over several releases and the rail outgrew it. SwiftUI clips silently, so nothing failed.

**Arithmetic.** The rail needs 673pt for ten tools (20 top padding + 12x44 buttons + 5 divider + 8 foot gap + 13x8 spacing + 8 bottom), plus RootView's 10+14 padding = **697**. The old minimum was 640 — short by 57, exactly the missing strip.

**Fix.** `RailMetrics` holds the rail's geometry and the layout uses those constants; `WindowMetrics` derives the minimum height from them. Adding a tool now moves the minimum automatically. Width stays a deliberate constant — that's a content judgement about the widest panes (Analyze's treemap, process tables), not something to derive.

`WindowMetricsTests` pins the relationship rather than the number: the minimum must fit the rail, one more tool must cost exactly one button plus one gap, and the result must still fit a 1440x900 laptop with room for the menu bar.

Verified by hand at the new minimum on a local build — the full rail including Settings is visible.

857 tests, 0 failures.