### PR TITLE
fix(macos): stop one bad exit from disabling the menu bar until macOS updates

### DIFF
--- a/macos/Sources/AppDelegate.swift
+++ b/macos/Sources/AppDelegate.swift
@@ -58,6 +58,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// can say what is actually happening rather than flipping on and quietly
     /// doing nothing (#319).
     var menuBarSuppressedByCompatibilityGuard: Bool { recoveryReason != nil }
+
+    /// Why the menu-bar item is paused, so Settings can say something true.
+    /// The two reasons need different advice: only the macOS-build guard is
+    /// fixed by updating macOS.
+    var menuBarSuppressionReason: LaunchRecoveryReason? { recoveryReason }
     private var recoveryNoticePresented = false
     private var launchCompleted = false
     private var initialStatusItemCreationTask: Task<Void, Never>?

--- a/macos/Sources/LaunchDiagnostics.swift
+++ b/macos/Sources/LaunchDiagnostics.swift
@@ -72,6 +72,18 @@ struct LaunchRecord: Codable, Equatable {
     var statusItemUnsafeOSBuild: String? = nil
     var statusItemAttempted: Bool? = nil
     var statusItemStable: Bool? = nil
+    /// Consecutive launches that ended without the status item proving itself.
+    ///
+    /// The guard used to act on the first one, which made it fire on anything
+    /// that kills the app in its first 30 seconds — a force quit, an unrelated
+    /// crash, a jetsam kill, or Launch at Login followed by a restart. For a
+    /// menu-bar app that means losing the primary surface to an unrelated
+    /// event, and the mark then persisted until the user updated macOS.
+    ///
+    /// A real WindowServer freeze reproduces on every launch (it did, on two
+    /// Macs), so requiring two in a row still catches it on the second run
+    /// while a one-off never pauses anything.
+    var statusItemFailureStreak: Int? = nil
     var automaticUpdaterUnsafeEnvironment: String? = nil
     var automaticUpdaterAttempted: Bool? = nil
     var automaticUpdaterStable: Bool? = nil
@@ -93,6 +105,11 @@ final class LaunchJournal {
     /// Starts a new durable record and returns the prior run only when it did
     /// not reach normal termination. A power loss can create the same signal,
     /// so callers treat it as a coarse diagnostic rather than proof of a crash.
+    /// Consecutive suspicious launches required before the status item is
+    /// paused. Two, because a genuine WindowServer freeze reproduces every
+    /// time while an unrelated kill does not.
+    static let statusItemFailureThreshold = 2
+
     @discardableResult
     func begin(environment: RuntimeEnvironment) -> LaunchRecord? {
         lock.lock()
@@ -100,9 +117,26 @@ final class LaunchJournal {
 
         let previous = readRecord()
         let timestamp = now()
-        let unsafeBuild: String?
+
+        // Count consecutive launches that ended without the item proving
+        // itself, and only treat the build as unsafe once there are two. A
+        // launch that reached stable clears the count outright — that is
+        // positive proof the item works here, and without it the mark was
+        // carried forward forever and only expired on a macOS update.
+        let streak: Int
         if Self.hasUnstableStatusItem(previous) {
+            streak = (previous?.statusItemFailureStreak ?? 0) + 1
+        } else if previous?.statusItemStable == true {
+            streak = 0
+        } else {
+            streak = previous?.statusItemFailureStreak ?? 0
+        }
+
+        let unsafeBuild: String?
+        if streak >= Self.statusItemFailureThreshold {
             unsafeBuild = previous?.environment.osBuild
+        } else if streak == 0 {
+            unsafeBuild = nil
         } else {
             unsafeBuild = previous?.statusItemUnsafeOSBuild
         }
@@ -122,6 +156,8 @@ final class LaunchJournal {
             statusItemUnsafeOSBuild: unsafeBuild == environment.osBuild ? unsafeBuild : nil,
             statusItemAttempted: false,
             statusItemStable: nil,
+            // The streak only means anything on the build that produced it.
+            statusItemFailureStreak: previous?.environment.osBuild == environment.osBuild ? streak : 0,
             automaticUpdaterUnsafeEnvironment: unsafeUpdaterEnvironment == currentUpdaterEnvironment
                 ? unsafeUpdaterEnvironment
                 : nil,
@@ -230,6 +266,15 @@ final class LaunchJournal {
         return support.appendingPathComponent("launch-state.json")
     }
 
+    /// Did the previous launch end without the status item proving itself?
+    ///
+    /// Deliberately broad, and it stays broad: the macOS 27 Beta 4 freeze hung
+    /// WindowServer *after* the item existed, so the next boot saw
+    /// `.statusItemReady` or later rather than `.statusItemCreating`. Narrowing
+    /// this to mid-creation would miss the very bug the guard exists for.
+    ///
+    /// Breadth is fine as a SUSPICION. What was wrong is that one suspicion
+    /// was enough to act on — see `statusItemFailureStreak`.
     fileprivate static func hasUnstableStatusItem(_ record: LaunchRecord?) -> Bool {
         guard let record, record.phase != .terminatedNormally else { return false }
         if let attempted = record.statusItemAttempted {
@@ -284,9 +329,15 @@ enum LaunchRecovery {
         if environment.osMajorVersion == 27, environment.osBuild == "26A5388g" {
             return .macOS27Beta4
         }
-        let unstableOnCurrentOS = LaunchJournal.hasUnstableStatusItem(previous)
+        // One bad launch is not enough. `hasUnstableStatusItem` is broad by
+        // design — it has to be, to catch a freeze that happens after the item
+        // exists — so it needs a second, consecutive occurrence before it
+        // costs the user their menu-bar icon.
+        let streakWithThisLaunch = (previous?.statusItemFailureStreak ?? 0)
+            + (LaunchJournal.hasUnstableStatusItem(previous) ? 1 : 0)
+        let repeatedOnCurrentOS = streakWithThisLaunch >= LaunchJournal.statusItemFailureThreshold
             && previous?.environment.osBuild == environment.osBuild
-        if unstableOnCurrentOS
+        if repeatedOnCurrentOS
             || previous?.statusItemUnsafeOSBuild == environment.osBuild {
             return .previousStatusItemFailure
         }

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -85,6 +85,7 @@ struct SettingsView: View {
     /// The compatibility guard suppresses the menu-bar item on some macOS
     /// builds. Without this the toggle read as on while doing nothing (#319).
     @State private var menuBarSuppressed: Bool = false
+    @State private var menuBarSuppressionReason: LaunchRecoveryReason? = nil
     @State private var menuBarItems: [MenuBarItem] = Store.menuBarItems
     /// Which widget's options panel is expanded in the editor (one at a time).
     @State private var expandedMenuBarItem: UUID?
@@ -166,6 +167,7 @@ struct SettingsView: View {
             loadHelperStatus()
             whitelistPatterns = MoleWhitelist.live.patterns()
             menuBarSuppressed = AppDelegate.shared?.menuBarSuppressedByCompatibilityGuard ?? false
+            menuBarSuppressionReason = AppDelegate.shared?.menuBarSuppressionReason
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             fdaGranted = Privacy.hasFullDiskAccess()
@@ -459,6 +461,28 @@ struct SettingsView: View {
     /// Shown in place of a toggle that cannot act. The recovery alert fires
     /// once per macOS build, so without this the only lasting explanation for
     /// a missing menu-bar icon was a checked switch that did nothing (#319).
+    /// Only the macOS-build guard is about macOS. The other reason is "a
+    /// previous launch of Burrow ended badly while the item was being
+    /// created", and telling that user to update macOS sends them to do
+    /// something that cannot help.
+    private var menuBarNoticeTitle: String {
+        switch menuBarSuppressionReason {
+        case .macOS27Beta4:
+            return NSLocalizedString("Menu bar item paused on this macOS build", comment: "")
+        default:
+            return NSLocalizedString("Menu bar item paused after a failed start", comment: "")
+        }
+    }
+
+    private var menuBarNoticeBody: String {
+        switch menuBarSuppressionReason {
+        case .macOS27Beta4:
+            return NSLocalizedString("Creating it could freeze system input on this build, so Burrow runs from the Dock instead. It returns automatically once you update macOS.", comment: "")
+        default:
+            return NSLocalizedString("Burrow stopped unexpectedly while creating the menu bar item last time, so it started from the Dock instead. It returns on its own the next time Burrow runs normally.", comment: "")
+        }
+    }
+
     private var menuBarCompatibilityNotice: some View {
         HStack(alignment: .top, spacing: 9) {
             Image(systemName: "exclamationmark.triangle.fill")
@@ -466,9 +490,9 @@ struct SettingsView: View {
                 .foregroundStyle(Brand.amber)
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 3) {
-                Text(NSLocalizedString("Menu bar item paused on this macOS build", comment: ""))
+                Text(menuBarNoticeTitle)
                     .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.textPrimary)
-                Text(NSLocalizedString("Creating it could freeze system input on this build, so Burrow runs from the Dock instead. It returns automatically once you update macOS.", comment: ""))
+                Text(menuBarNoticeBody)
                     .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/macos/Tests/LaunchDiagnosticsTests.swift
+++ b/macos/Tests/LaunchDiagnosticsTests.swift
@@ -64,6 +64,9 @@ final class LaunchDiagnosticsTests: XCTestCase {
         )
     }
 
+    /// Safe mode engages on the SECOND consecutive interrupted creation, not
+    /// the first. One interrupted launch is indistinguishable from a force
+    /// quit or a restart during startup; a real freeze reproduces every time.
     func testInterruptedStatusItemCreationUsesSafeModeOnNextLaunch() {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("burrow-launch-\(UUID().uuidString).json")
@@ -73,11 +76,19 @@ final class LaunchDiagnosticsTests: XCTestCase {
         XCTAssertNil(first.begin(environment: environment))
         first.mark(.statusItemCreating)
 
+        // One strike: suspicious, but not yet acted on.
         let second = LaunchJournal(fileURL: fileURL, now: { Date(timeIntervalSince1970: 110) })
-        let previous = second.begin(environment: environment)
-        XCTAssertEqual(previous?.phase, .statusItemCreating)
+        let afterOne = second.begin(environment: environment)
+        XCTAssertEqual(afterOne?.phase, .statusItemCreating)
+        XCTAssertNil(LaunchRecovery.reason(environment: environment, previous: afterOne),
+                     "a single interrupted launch must not cost the user the menu bar")
+        second.mark(.statusItemCreating)
+
+        // Two in a row on the same build: now it engages.
+        let third = LaunchJournal(fileURL: fileURL, now: { Date(timeIntervalSince1970: 120) })
+        let afterTwo = third.begin(environment: environment)
         XCTAssertEqual(
-            LaunchRecovery.reason(environment: environment, previous: previous),
+            LaunchRecovery.reason(environment: environment, previous: afterTwo),
             .previousStatusItemFailure
         )
     }
@@ -101,9 +112,14 @@ final class LaunchDiagnosticsTests: XCTestCase {
             .appendingPathComponent("burrow-launch-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
+        // Two consecutive interrupted launches to reach the threshold.
         let failed = LaunchJournal(fileURL: fileURL)
         failed.begin(environment: environment)
         failed.mark(.statusItemCreating)
+
+        let failedAgain = LaunchJournal(fileURL: fileURL)
+        failedAgain.begin(environment: environment)
+        failedAgain.mark(.statusItemCreating)
 
         let recovery = LaunchJournal(fileURL: fileURL)
         recovery.begin(environment: environment)
@@ -134,13 +150,22 @@ final class LaunchDiagnosticsTests: XCTestCase {
             .appendingPathComponent("burrow-launch-\(UUID().uuidString).json")
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
+        // The freeze this guards against hangs WindowServer AFTER the item
+        // exists, so the phase reads appReady rather than statusItemCreating.
+        // It reproduces every launch, so two runs reach the threshold.
         let launch = LaunchJournal(fileURL: fileURL)
         launch.begin(environment: environment)
         launch.mark(.statusItemCreating)
         launch.mark(.statusItemReady)
         launch.mark(.appReady)
 
-        let previous = launch.snapshot()
+        let again = LaunchJournal(fileURL: fileURL)
+        again.begin(environment: environment)
+        again.mark(.statusItemCreating)
+        again.mark(.statusItemReady)
+        again.mark(.appReady)
+
+        let previous = again.snapshot()
         XCTAssertEqual(
             LaunchRecovery.reason(environment: environment, previous: previous),
             .previousStatusItemFailure
@@ -329,5 +354,119 @@ final class LaunchDiagnosticsTests: XCTestCase {
         XCTAssertTrue(report.contains("26A5388g"))
         XCTAssertFalse(report.contains("alice"))
         XCTAssertFalse(report.contains("private-run-id"))
+    }
+}
+
+// MARK: - Status-item guard false positives
+//
+// Burrow is a menu-bar app, so pausing the status item removes its primary
+// surface. The suspicion rule is deliberately broad — it has to be, because
+// the macOS 27 Beta 4 freeze hung WindowServer AFTER the item existed, so the
+// next boot saw `.statusItemReady`, not `.statusItemCreating`.
+//
+// What was wrong is that ONE suspicion was enough to act on. That fires on a
+// force quit, an unrelated crash, a jetsam kill, or Launch at Login followed
+// by a restart — anything that kills the app inside the 30-second stability
+// window — and the mark then persisted until the user updated macOS.
+//
+// Two consecutive occurrences are now required. A real freeze reproduces
+// every launch, so it is still caught on the second run; a one-off never
+// costs anyone their menu bar.
+
+final class StatusItemGuardFalsePositiveTests: XCTestCase {
+
+    private func environment(build: String = "25F84", major: Int = 26) -> RuntimeEnvironment {
+        RuntimeEnvironment(osVersion: "macOS 26.5.2", osMajorVersion: major, osBuild: build,
+                           architecture: "arm64", appVersion: "0.12.0", appBuild: "24")
+    }
+
+    private func record(phase: LaunchPhase,
+                        build: String = "25F84",
+                        attempted: Bool? = nil,
+                        stable: Bool? = nil,
+                        unsafeBuild: String? = nil,
+                        streak: Int? = nil) -> LaunchRecord {
+        LaunchRecord(runID: UUID().uuidString,
+                     environment: environment(build: build),
+                     phase: phase,
+                     startedAt: Date(timeIntervalSince1970: 100),
+                     updatedAt: Date(timeIntervalSince1970: 120),
+                     statusItemUnsafeOSBuild: unsafeBuild,
+                     statusItemAttempted: attempted,
+                     statusItemStable: stable,
+                     statusItemFailureStreak: streak)
+    }
+
+    /// The reported bug: one abnormal exit with the item up must not pause
+    /// the menu bar. This is the force-quit / restart-after-login case.
+    func testASingleBadExitDoesNotPauseTheMenuBar() {
+        let previous = record(phase: .statusItemReady, attempted: true, stable: false, streak: 0)
+        XCTAssertNil(LaunchRecovery.reason(environment: environment(), previous: previous),
+                     "one unexplained exit is not evidence the status item is dangerous")
+    }
+
+    /// Launch at Login, then the user restarts before the 30-second stability
+    /// timer elapses — shutdown can kill the app before
+    /// applicationWillTerminate finishes. The most likely real-world path.
+    func testRestartShortlyAfterLoginDoesNotPause() {
+        let previous = record(phase: .appReady, attempted: true, stable: false, streak: 0)
+        XCTAssertNil(LaunchRecovery.reason(environment: environment(), previous: previous))
+    }
+
+    /// But a REPEAT does pause — the freeze this guard exists for reproduces
+    /// every launch.
+    func testASecondConsecutiveFailurePauses() {
+        let previous = record(phase: .statusItemReady, attempted: true, stable: false, streak: 1)
+        XCTAssertEqual(LaunchRecovery.reason(environment: environment(), previous: previous),
+                       .previousStatusItemFailure)
+    }
+
+    /// A launch that reached stable is positive proof the item works here, so
+    /// the streak resets. Without this, a mark survived until the user updated
+    /// macOS.
+    func testAStableLaunchClearsTheStreak() {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-launch-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let env = environment()
+        let journal = LaunchJournal(fileURL: fileURL)
+        journal.begin(environment: env)
+        journal.mark(.statusItemCreating)
+        journal.mark(.statusItemReady)
+        journal.markStatusItemStable()
+        journal.mark(.terminatedNormally)
+
+        let previous = journal.snapshot()
+        XCTAssertNil(LaunchRecovery.reason(environment: env, previous: previous))
+    }
+
+    /// The exact-build macOS 27 Beta 4 guard is untouched and still immediate.
+    func testMacOS27Beta4GuardStillAppliesWithNoHistory() {
+        let beta = RuntimeEnvironment(osVersion: "macOS 27.0", osMajorVersion: 27,
+                                      osBuild: "26A5388g", architecture: "arm64",
+                                      appVersion: "0.12.0", appBuild: "24")
+        XCTAssertEqual(LaunchRecovery.reason(environment: beta, previous: nil), .macOS27Beta4)
+    }
+
+    /// A clean exit never pauses anything.
+    func testCleanExitNeverPauses() {
+        let previous = record(phase: .terminatedNormally, attempted: true, stable: true)
+        XCTAssertNil(LaunchRecovery.reason(environment: environment(), previous: previous))
+    }
+
+    /// An already-marked build keeps being refused while the mark stands.
+    func testAnExistingUnsafeMarkIsStillHonoured() {
+        let previous = record(phase: .terminatedNormally, unsafeBuild: "25F84")
+        XCTAssertEqual(LaunchRecovery.reason(environment: environment(), previous: previous),
+                       .previousStatusItemFailure)
+    }
+
+    /// A streak from a different macOS build does not carry over.
+    func testStreakDoesNotCarryAcrossOSBuilds() {
+        let previous = record(phase: .statusItemReady, build: "25F70",
+                              attempted: true, stable: false, streak: 5)
+        XCTAssertNil(LaunchRecovery.reason(environment: environment(build: "25F84"),
+                                           previous: previous))
     }
 }


### PR DESCRIPTION
Found while investigating why macOS 26.5.2 (25F84) showed "Menu bar item paused on this macOS build". It isn't the macOS 27 Beta 4 guard — that's an exact-build check and doesn't match.

**The real trigger.** `hasUnstableStatusItem` treats *the app didn't exit cleanly and the status item wasn't 30 seconds old yet* as a status-item failure, and **one** occurrence marked the OS build unsafe. That's satisfied by anything killing the app in its first 30 seconds:

- **Launch at Login, then a restart** — shutdown can kill the app before `applicationWillTerminate` finishes. The most likely real path, and it hits precisely the users who want a menu-bar icon.
- Force-quitting because the app looked busy during startup scans
- Any crash elsewhere in the app during those 30 seconds
- A jetsam kill under memory pressure

Once marked, `statusItemUnsafeOSBuild` was carried forward on every later launch and only expired when the OS build changed. **One unrelated event removed a menu-bar app's primary surface indefinitely**, and the notice blamed macOS and told the user to update — advice that cannot help.

**What I did not do.** I first narrowed the rule to "died mid-creation", which broke `testStatusItemThatNeverStabilizedRecoversEvenAfterAppReady`. That test is right: the freeze hung WindowServer *after* the item existed, so the next boot reads `appReady`. Narrowing would have missed the bug the guard exists for. Breadth as a *suspicion* is correct; acting on a single one was the error.

**Three changes**

1. Two consecutive suspicious launches on the same build are required. A real freeze reproduces every time, so it's still caught on the second run.
2. A launch that reaches stable clears the streak — positive proof the item works here. Previously a mark could only expire via a macOS update.
3. Settings distinguishes the two reasons, so it stops telling people to update macOS for a problem macOS didn't cause.

The three existing tests that asserted immediate engagement now drive a second launch and keep their original intent, including persistence until the OS build changes. `StatusItemGuardFalsePositiveTests` covers the paths that must *not* pause.

**Worth a second opinion:** the threshold of 2 is a judgement call. It's the smallest value that distinguishes "reproduces" from "happened once", but if you'd rather have 3 for a surface this important, it's a one-line constant.

865 tests, 0 failures. Related: #319.