### PR TITLE
test(macos): stop conductor tests depending on what the build staged

### DIFF
--- a/macos/Sources/BurrowConductor.swift
+++ b/macos/Sources/BurrowConductor.swift
@@ -20,10 +20,21 @@ enum BurrowConductor {
 
     // MARK: - Resolution
 
+    /// Where the bundled sidecars are looked up. Production reads the app bundle; tests point it
+    /// at a directory they control.
+    ///
+    /// This is a seam rather than a direct `Bundle.main` read because the "no conductor bundled"
+    /// behaviour has to be *chosen* by a test, not inherited from whatever the build happened to
+    /// stage. Resources/burrow only exists when the vendor/burrow-cli submodule is checked out —
+    /// which a developer must do for the Network, Orphans and Photos panes to work at all — so
+    /// tests that simply assumed it was absent went red on a correctly-configured checkout while
+    /// passing on CI, where actions/checkout fetches no submodules.
+    static var resourceDirectory: () -> URL? = { Bundle.main.resourceURL }
+
     /// The bundled conductor binary, or nil if this build didn't ship one — callers then fall
     /// back to the direct engine (MoEngine).
     static func executableURL() -> URL? {
-        guard let res = Bundle.main.resourceURL else { return nil }
+        guard let res = resourceDirectory() else { return nil }
         let burrow = res.appendingPathComponent("burrow")
         return FileManager.default.isExecutableFile(atPath: burrow.path) ? burrow : nil
     }
@@ -31,7 +42,7 @@ enum BurrowConductor {
     /// The bundled engine directory the conductor should target (Resources/engine, from
     /// bundle-engine.sh), or nil if the engine isn't bundled either.
     static func engineDir() -> URL? {
-        guard let res = Bundle.main.resourceURL else { return nil }
+        guard let res = resourceDirectory() else { return nil }
         let dir = res.appendingPathComponent("engine")
         var isDir: ObjCBool = false
         let exists = FileManager.default.fileExists(atPath: dir.path, isDirectory: &isDir)
@@ -43,7 +54,7 @@ enum BurrowConductor {
     /// back to a `$BURROW_FCLONES`/PATH fclones, and if none exists the Duplicates pane shows
     /// "fclones not found".
     static func fclonesURL() -> URL? {
-        guard let res = Bundle.main.resourceURL else { return nil }
+        guard let res = resourceDirectory() else { return nil }
         let fclones = res.appendingPathComponent("fclones")
         return FileManager.default.isExecutableFile(atPath: fclones.path) ? fclones : nil
     }

--- a/macos/Tests/BurrowEnvelopeTests.swift
+++ b/macos/Tests/BurrowEnvelopeTests.swift
@@ -155,30 +155,49 @@ final class BurrowEnvelopeTests: XCTestCase {
     /// at its last guard — so the assertion held for a reason unrelated to the switch, and would
     /// have kept holding had the default flipped either way.
     func testStreamOverride_withBundledConductor_routesThroughItByDefault() {
-        UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor")
-        ConductorBundleFixture.withConductor(present: true) {
-            let override = BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false)
-            XCTAssertEqual(override?.arguments, ["clean", "--apply", "--stream"])
-            XCTAssertEqual(URL(fileURLWithPath: override?.executable ?? "").lastPathComponent, "burrow")
+        withStreamSwitch(nil) {
+            ConductorBundleFixture.withConductor(present: true) {
+                let override = BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false)
+                XCTAssertEqual(override?.arguments, ["clean", "--apply", "--stream"])
+                XCTAssertEqual(URL(fileURLWithPath: override?.executable ?? "").lastPathComponent, "burrow")
+            }
         }
     }
 
     /// The documented kill-switch has to actually kill it.
     func testStreamOverride_killSwitchKeepsDirectEngineEvenWithConductorBundled() {
-        UserDefaults.standard.set(false, forKey: "BurrowStreamViaConductor")
-        defer { UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor") }
-        ConductorBundleFixture.withConductor(present: true) {
-            XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false))
+        withStreamSwitch(false) {
+            ConductorBundleFixture.withConductor(present: true) {
+                XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false))
+            }
         }
     }
 
     func testStreamOverride_elevatedAlwaysDirect() {
-        UserDefaults.standard.set(true, forKey: "BurrowStreamViaConductor")
-        defer { UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor") }
         // Elevated runs (osascript, fresh env) stay on mo even with the switch on — and this is
         // only meaningful on a build that HAS a conductor to be tempted by.
-        ConductorBundleFixture.withConductor(present: true) {
-            XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: true))
+        withStreamSwitch(true) {
+            ConductorBundleFixture.withConductor(present: true) {
+                XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: true))
+            }
         }
+    }
+
+    /// Put the switch in a chosen state and put it back exactly as it was.
+    ///
+    /// These tests run against `UserDefaults.standard` for the real app domain,
+    /// so removing the key outright would erase a kill-switch the developer had
+    /// genuinely set — restoring the prior value, absent or not, keeps the suite
+    /// from editing anyone's configuration.
+    private func withStreamSwitch(_ value: Bool?, _ body: () -> Void) {
+        let key = "BurrowStreamViaConductor"
+        let saved = UserDefaults.standard.object(forKey: key)
+        defer {
+            if let saved { UserDefaults.standard.set(saved, forKey: key) }
+            else { UserDefaults.standard.removeObject(forKey: key) }
+        }
+        if let value { UserDefaults.standard.set(value, forKey: key) }
+        else { UserDefaults.standard.removeObject(forKey: key) }
+        body()
     }
 }

--- a/macos/Tests/BurrowEnvelopeTests.swift
+++ b/macos/Tests/BurrowEnvelopeTests.swift
@@ -139,15 +139,46 @@ final class BurrowEnvelopeTests: XCTestCase {
                        ["optimize", "--apply", "--stream"])
     }
 
-    func testStreamOverride_offByDefault_keepsDirectEngine() {
-        // The switch is off unless explicitly set → no override, the direct mo path is preserved.
-        XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false))
+    /// No conductor staged → no override, whatever the switch says, because there is nothing to
+    /// route to. This is the fallback every call site depends on.
+    func testStreamOverride_withoutBundledConductor_keepsDirectEngine() {
+        ConductorBundleFixture.withConductor(present: false) {
+            XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false))
+        }
+    }
+
+    /// Streaming is ON by default (`BurrowStreamViaConductor` unset), so a build that bundled the
+    /// conductor routes `clean` through it.
+    ///
+    /// This used to be asserted the other way round, as "off by default keeps the direct engine".
+    /// It only ever passed because the test host bundled no conductor and `streamOverride` bailed
+    /// at its last guard — so the assertion held for a reason unrelated to the switch, and would
+    /// have kept holding had the default flipped either way.
+    func testStreamOverride_withBundledConductor_routesThroughItByDefault() {
+        UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor")
+        ConductorBundleFixture.withConductor(present: true) {
+            let override = BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false)
+            XCTAssertEqual(override?.arguments, ["clean", "--apply", "--stream"])
+            XCTAssertEqual(URL(fileURLWithPath: override?.executable ?? "").lastPathComponent, "burrow")
+        }
+    }
+
+    /// The documented kill-switch has to actually kill it.
+    func testStreamOverride_killSwitchKeepsDirectEngineEvenWithConductorBundled() {
+        UserDefaults.standard.set(false, forKey: "BurrowStreamViaConductor")
+        defer { UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor") }
+        ConductorBundleFixture.withConductor(present: true) {
+            XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: false))
+        }
     }
 
     func testStreamOverride_elevatedAlwaysDirect() {
         UserDefaults.standard.set(true, forKey: "BurrowStreamViaConductor")
         defer { UserDefaults.standard.removeObject(forKey: "BurrowStreamViaConductor") }
-        // Elevated runs (osascript, fresh env) stay on mo even with the switch on.
-        XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: true))
+        // Elevated runs (osascript, fresh env) stay on mo even with the switch on — and this is
+        // only meaningful on a build that HAS a conductor to be tempted by.
+        ConductorBundleFixture.withConductor(present: true) {
+            XCTAssertNil(BurrowConductor.streamOverride(moArgs: ["clean"], elevated: true))
+        }
     }
 }

--- a/macos/Tests/ConductorBundleFixture.swift
+++ b/macos/Tests/ConductorBundleFixture.swift
@@ -1,0 +1,55 @@
+//
+//  ConductorBundleFixture.swift
+//  BurrowTests
+//
+//  Lets a test say which build it is exercising — one that bundled the `burrow` conductor, or
+//  one that didn't — instead of inheriting whichever the test host happened to stage.
+//
+//  Resources/burrow is produced by the "Bundle burrow (conductor)" phase, which is gated on a
+//  populated vendor/burrow-cli checkout. CI never fetches submodules, so it always tested the
+//  absent case; a developer who checked the submodule out (required for Network, Orphans and
+//  Photos to do anything) always tested the present case and saw unrelated failures.
+//
+
+import Foundation
+import XCTest
+
+@testable import Burrow
+
+enum ConductorBundleFixture {
+
+    /// Runs `body` with the conductor lookup pointed at a temporary directory, then restores the
+    /// real one. `present: false` leaves the directory empty; `present: true` stages an executable
+    /// stub named `burrow`.
+    ///
+    /// The stub is never spawned by these tests — resolution only checks the executable bit — but
+    /// it is written as a shell script that emits a valid empty envelope so that a future test
+    /// which does run it gets something parseable rather than a crash.
+    static func withConductor<T>(present: Bool,
+                                 file: StaticString = #filePath, line: UInt = #line,
+                                 _ body: () throws -> T) rethrows -> T {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-conductor-fixture-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        if present {
+            let stub = dir.appendingPathComponent("burrow")
+            FileManager.default.createFile(
+                atPath: stub.path,
+                contents: Data("#!/bin/sh\nprintf '{\"ok\":true,\"data\":{}}'\n".utf8),
+                attributes: [.posixPermissions: 0o755])
+        }
+
+        let saved = BurrowConductor.resourceDirectory
+        BurrowConductor.resourceDirectory = { dir }
+        defer {
+            BurrowConductor.resourceDirectory = saved
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        XCTAssertEqual(BurrowConductor.isAvailable, present,
+                       "fixture failed to put the conductor lookup in the requested state",
+                       file: file, line: line)
+        return try body()
+    }
+}

--- a/macos/Tests/MCPConductorToolsTests.swift
+++ b/macos/Tests/MCPConductorToolsTests.swift
@@ -159,33 +159,75 @@ final class MCPConductorToolsTests: XCTestCase {
         }
     }
 
-    // MARK: - Degrade, never throw (no conductor in the test bundle)
+    // MARK: - Degrade, never throw (build that bundled no conductor)
 
-    /// The test bundle ships no Resources/burrow, so `isAvailable` is false
-    /// and the call must come back as a JSON error object naming the
-    /// conductor — never a throw, never a crash, and no process spawned.
+    /// A build without Resources/burrow must answer with a JSON error object naming the
+    /// conductor — never a throw, never a crash, and no process spawned. The fixture chooses
+    /// that state explicitly; before it, the test merely inherited whatever the build staged.
     func testNet_withoutBundledConductor_returnsJSONErrorMentioningConductor() throws {
-        XCTAssertFalse(BurrowConductor.isAvailable,
-                       "test bundles must not ship a conductor; this test depends on that")
-        let json = try catalog.call(name: "burrow_net", arguments: [:])
-        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
-        let error = try XCTUnwrap(obj["error"] as? String)
-        XCTAssertTrue(error.localizedCaseInsensitiveContains("conductor")
-                        || error.localizedCaseInsensitiveContains("burrow"),
-                      "the error must tell the agent the conductor is missing, got: \(error)")
+        try ConductorBundleFixture.withConductor(present: false) {
+            let json = try catalog.call(name: "burrow_net", arguments: [:])
+            let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+            let error = try XCTUnwrap(obj["error"] as? String)
+            XCTAssertTrue(error.localizedCaseInsensitiveContains("conductor")
+                            || error.localizedCaseInsensitiveContains("burrow"),
+                          "the error must tell the agent the conductor is missing, got: \(error)")
+        }
     }
 
     func testSentinel_withoutBundledConductor_returnsJSONErrorNotThrow() throws {
-        let json = try catalog.call(name: "burrow_sentinel", arguments: [:])
-        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
-        XCTAssertNotNil(obj["error"])
+        try ConductorBundleFixture.withConductor(present: false) {
+            let json = try catalog.call(name: "burrow_sentinel", arguments: [:])
+            let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+            XCTAssertNotNil(obj["error"])
+        }
     }
 
     /// Valid arguments + missing conductor must still degrade (the
     /// argument check passes, then the availability check reports).
     func testSlimCheck_withBinaryButNoConductor_returnsJSONError() throws {
-        let json = try catalog.call(name: "burrow_slim_check", arguments: ["binary": "/usr/bin/true"])
-        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
-        XCTAssertNotNil(obj["error"])
+        try ConductorBundleFixture.withConductor(present: false) {
+            let json = try catalog.call(name: "burrow_slim_check", arguments: ["binary": "/usr/bin/true"])
+            let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+            XCTAssertNotNil(obj["error"])
+        }
+    }
+
+    // MARK: - The other branch: a build that DID bundle one
+
+    /// The complement nothing covered. Argument validation runs BEFORE the availability check, so
+    /// on a build that shipped the conductor a missing argument still surfaces as `badArguments`
+    /// — the caller is told what it got wrong instead of being handed a conductor error, and the
+    /// tool doesn't spawn anything to discover what the schema already knew.
+    func testSlimCheck_withConductorBundled_stillRejectsBadArgumentsWithoutSpawning() throws {
+        try ConductorBundleFixture.withConductor(present: true) {
+            XCTAssertThrowsError(try catalog.call(name: "burrow_slim_check", arguments: [:])) { error in
+                let described = String(describing: error)
+                XCTAssertTrue(described.contains("binary"),
+                              "the caller must be told which argument is missing, got: \(described)")
+                XCTAssertFalse(described.localizedCaseInsensitiveContains("conductor"),
+                               "a missing argument must not be reported as a missing conductor")
+            }
+        }
+    }
+
+    /// Resolution is by executable bit, not by name: a non-executable file called `burrow`
+    /// (a stray artifact, a partially-staged copy) must not read as a usable conductor.
+    func testNonExecutableFileNamedBurrowDoesNotCountAsBundled() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("burrow-nonexec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: dir.appendingPathComponent("burrow").path,
+                                       contents: Data("not a binary".utf8),
+                                       attributes: [.posixPermissions: 0o644])
+        let saved = BurrowConductor.resourceDirectory
+        BurrowConductor.resourceDirectory = { dir }
+        defer {
+            BurrowConductor.resourceDirectory = saved
+            try? FileManager.default.removeItem(at: dir)
+        }
+
+        XCTAssertNil(BurrowConductor.executableURL())
+        XCTAssertFalse(BurrowConductor.isAvailable)
     }
 }

--- a/macos/Tests/MCPConductorToolsTests.swift
+++ b/macos/Tests/MCPConductorToolsTests.swift
@@ -201,11 +201,13 @@ final class MCPConductorToolsTests: XCTestCase {
     /// tool doesn't spawn anything to discover what the schema already knew.
     func testSlimCheck_withConductorBundled_stillRejectsBadArgumentsWithoutSpawning() throws {
         try ConductorBundleFixture.withConductor(present: true) {
-            XCTAssertThrowsError(try catalog.call(name: "burrow_slim_check", arguments: [:])) { error in
-                let described = String(describing: error)
-                XCTAssertTrue(described.contains("binary"),
-                              "the caller must be told which argument is missing, got: \(described)")
-                XCTAssertFalse(described.localizedCaseInsensitiveContains("conductor"),
+            XCTAssertThrowsError(try catalog.call(name: "burrow_slim_check", arguments: [:])) { err in
+                guard case MCPToolError.badArguments(let message) = err else {
+                    return XCTFail("expected .badArguments, got \(err)")
+                }
+                XCTAssertTrue(message.contains("binary"),
+                              "the caller must be told which argument is missing, got: \(message)")
+                XCTAssertFalse(message.localizedCaseInsensitiveContains("conductor"),
                                "a missing argument must not be reported as a missing conductor")
             }
         }
@@ -217,9 +219,11 @@ final class MCPConductorToolsTests: XCTestCase {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("burrow-nonexec-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        FileManager.default.createFile(atPath: dir.appendingPathComponent("burrow").path,
-                                       contents: Data("not a binary".utf8),
-                                       attributes: [.posixPermissions: 0o644])
+        XCTAssertTrue(
+            FileManager.default.createFile(atPath: dir.appendingPathComponent("burrow").path,
+                                           contents: Data("not a binary".utf8),
+                                           attributes: [.posixPermissions: 0o644]),
+            "the fixture must actually stage the file, or the assertions below prove nothing")
         let saved = BurrowConductor.resourceDirectory
         BurrowConductor.resourceDirectory = { dir }
         defer {

--- a/macos/Tests/OperationFlowTests.swift
+++ b/macos/Tests/OperationFlowTests.swift
@@ -262,13 +262,19 @@ final class OperationFlowTests: XCTestCase {
         XCTAssertFalse(message.contains("Nothing was cleaned"), message)
     }
 
+    /// This is about the DIRECT engine path, so it has to pin the no-conductor world: with a
+    /// conductor staged, `streamOverride` supplies an executable for a non-elevated `clean`
+    /// before `resolveMo` is ever consulted, and the unresolvable-engine branch under test is
+    /// never reached. It previously relied on the test host happening not to bundle one.
     func testMissingExecutableFailsBeforeSpawn() {
-        let port = FakeProcessPort(script: [])
-        let flow = OperationFlow<CleanReport>(process: port, hasFullDiskAccess: { true },
-                                              resolveMo: { _ in nil }, center: OperationCenter())
-        flow.start(Self.cleanOp())
-        guard case .finished(.failed) = flow.state else { return XCTFail("expected failed") }
-        XCTAssertTrue(port.specs.isEmpty)
+        ConductorBundleFixture.withConductor(present: false) {
+            let port = FakeProcessPort(script: [])
+            let flow = OperationFlow<CleanReport>(process: port, hasFullDiskAccess: { true },
+                                                  resolveMo: { _ in nil }, center: OperationCenter())
+            flow.start(Self.cleanOp())
+            guard case .finished(.failed) = flow.state else { return XCTFail("expected failed") }
+            XCTAssertTrue(port.specs.isEmpty)
+        }
     }
 
     func testElevatedRunFailsBeforeSpawnWhenInvokingAccountCannotBeResolved() {


### PR DESCRIPTION
Stacked on #367 — review that first; this branch's diff is only the last commit.

## The problem

Six tests asserted that no `burrow` conductor was bundled, without ever saying so. `Resources/burrow` only appears when the `vendor/burrow-cli` submodule is checked out — which you must do for the Network, Orphans and Photos panes to work at all. So the suite was green on CI, where `actions/checkout` fetches no submodules, and red on a correctly-configured checkout, for reasons unrelated to the code under test.

## The fix

`BurrowConductor` resolves its sidecars through an injectable `resourceDirectory` instead of reading `Bundle.main` directly, and `ConductorBundleFixture` stages a temp directory that is either empty or holds an executable stub. Each test now declares which build it exercises.

Verified green **both ways** — 1013 tests, 0 failures with the conductor bundled, and again with it removed.

## Two tests were not testing what they claimed

`testStreamOverride_offByDefault_keepsDirectEngine` asserted streaming is off by default. It isn't — `streamingEnabled` returns `true` when the switch is unset, as its own doc comment says. The test passed only because `streamOverride` bailed at its last guard, the executable lookup, so it asserted nothing about the switch and would have kept passing had the default flipped either way. It's now three tests: no conductor falls back, a bundled conductor routes through by default, and the documented `defaults write … BurrowStreamViaConductor -bool NO` kill-switch actually kills it.

`testMissingExecutableFailsBeforeSpawn` had the same shape — with a conductor staged, `streamOverride` supplies an executable before `resolveMo` is consulted, so the unresolvable-engine branch it exists to check was unreachable.

## Also adds

The conductor-present coverage that didn't exist: bad arguments still surface as `badArguments` rather than a conductor error, and a non-executable file named `burrow` doesn't count as one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conductor-based streaming is now enabled by default when the bundled conductor is available.
  * Added automatic fallback to the direct execution path when the conductor is missing or unavailable.
  * Added a kill switch to disable conductor-based streaming when needed.
* **Bug Fixes**
  * Improved handling of invalid or non-executable bundled conductor files.
  * Ensured argument validation and clear JSON errors remain available when the conductor cannot be used.
  * Elevated execution continues to use the direct engine path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->