### PR TITLE
fix(macos): notify when the scan finishes, and make "Stop after current" respond

### DIFF
--- a/macos/Sources/CleanView.swift
+++ b/macos/Sources/CleanView.swift
@@ -435,7 +435,24 @@ struct CleanView: View {
                           let bytes = lines.reduce(Int64(0)) { $0 + CleanList.streamedItemBytes($1) }
                           return (groups, summary, bytes)
                       },
-                      hudLine: { TaskReportText.line($0) })
+                      hudLine: { TaskReportText.line($0) },
+                      // The scan is the step people walk away from — it can run
+                      // for minutes on a full disk and, unlike the clean, it ends
+                      // by just sitting there with a number. Same opt-in the real
+                      // run uses, so it respects the Settings toggle and stays
+                      // silent for anyone who turned it off.
+                      notifyOnEnd: true,
+                      // Without this the notification body is whatever the last
+                      // streamed HUD line happened to be — which for a task
+                      // report is usually the "=====" separator, so the notice
+                      // arrived as a row of equals signs. Say what was found.
+                      finalDetail: { report in
+                          let items = report.groups.reduce(0) { $0 + $1.items.count }
+                          return items == 0
+                              ? NSLocalizedString("Nothing to clean.", comment: "")
+                              : String(format: NSLocalizedString("%@ found across %d items.", comment: ""),
+                                       Fmt.bytes(report.liveBytes), items)
+                      })
     }
 
     private func startDry() {

--- a/macos/Sources/UpdatesView.swift
+++ b/macos/Sources/UpdatesView.swift
@@ -158,9 +158,12 @@ struct UpdatesView: View {
                         model.updateAllCompleted,
                         model.updateAllTotal
                     ))
-                PillButton(title: "Stop after current", filled: false) {
+                PillButton(title: model.cancelUpdateAllAfterCurrent
+                            ? "Stopping after current…" : "Stop after current",
+                           filled: false) {
                     model.cancelUpdateAll()
                 }
+                .disabled(model.cancelUpdateAllAfterCurrent)
             } else if model.checked, model.availableItems.count + model.brewItems.count > 1 {
                 PillButton(title: "Update All", filled: false) {
                     model.updateAll()
@@ -448,7 +451,10 @@ final class UpdatesModel: ObservableObject {
     private var appTasks: [String: TrackedAppTask] = [:]
     private var appTaskGeneration: UInt64 = 0
     private var updateAllTask: Task<Void, Never>?
-    private var cancelUpdateAllAfterCurrent = false
+    /// Published, and not private, because the header button reads it: the
+    /// stop only takes effect after the in-flight item, so without a visible
+    /// state change the click looked ignored for however long that took.
+    @Published private(set) var cancelUpdateAllAfterCurrent = false
 
     init(
         detectSource: ((InstalledApp) -> UpdateSources.Source?)? = nil,

--- a/macos/Tests/UpdateWorkflowTests.swift
+++ b/macos/Tests/UpdateWorkflowTests.swift
@@ -117,15 +117,21 @@ final class UpdateWorkflowTests: XCTestCase {
         // These used to assert the name did not contain the literal source text
         // "UUID().uuidString", which no filesystem path could ever contain — so
         // they passed no matter what create() produced. Assert the real mkdtemp
-        // shape instead: the fixed prefix, and six substituted template
-        // characters with no X left unreplaced.
+        // shape instead: the fixed prefix and six substituted characters.
         for url in [first, second] {
             let name = url.lastPathComponent
             XCTAssertTrue(name.hasPrefix("BurrowUpdate."),
                           "unexpected staging name: \(name)")
             let suffix = name.dropFirst("BurrowUpdate.".count)
             XCTAssertEqual(suffix.count, 6, "mkdtemp substitutes exactly the six Xs: \(name)")
-            XCTAssertFalse(suffix.contains("X"), "an unsubstituted template leaked: \(name)")
+            // NOT "contains no X": mkdtemp draws the replacement characters from
+            // an alphanumeric set that includes 'X', so a legitimate name like
+            // BurrowUpdate.YmzfxX failed that check roughly one run in eight.
+            // The real failure being guarded against is the template surviving
+            // whole, so test for that and for the charset.
+            XCTAssertNotEqual(suffix, "XXXXXX", "the template was never substituted: \(name)")
+            XCTAssertTrue(suffix.allSatisfy { $0.isLetter || $0.isNumber },
+                          "mkdtemp suffix must be alphanumeric: \(name)")
         }
         var firstStat = stat()
         var secondStat = stat()


### PR DESCRIPTION
Two bugs found hand-testing the release candidate.

## "Stop after current" looked broken

`cancelUpdateAll()` set `cancelUpdateAllAfterCurrent`, which was `private` and not `@Published` — so SwiftUI could not observe it and the header button never changed. The stop *was* queued correctly, but nothing on screen said so, and since it only takes effect after the in-flight item finishes, the click looked ignored for however long that took.

Now published, the label switches to "Stopping after current…", and the button disables so it can't be pressed twice.

## The scan finished silently, then notified with `======`

The scan is the step people walk away from — minutes on a full disk, ending by just sitting there with a number — but it never opted into a completion notice. The real clean already did, via `notifyOnEnd`, so the scan now uses the same flag and inherits the Settings toggle: silent for anyone who turned notifications off.

That alone produced a notification whose body was a row of equals signs. The body falls back to the last streamed HUD line, and for a task report that's the `=====` separator:

> **Scanning caches — done**
> `==============================`

So the scan supplies its own `finalDetail` — "12.4 GB found across 37 items." or "Nothing to clean."

## Verification

1053 tests, 0 failures. Both paths exercised by hand on a Developer ID-signed local build with the engine bundled.

## Not a bug, for the record

Two other things turned up while testing and were both artifacts of the local build, not defects:

- **Repeated password prompts.** TCC has the shipped `dev.caezium.Burrow` at `2` (allowed) but a DerivedData build at `0` (denied), so the scan's `.fullDiskAccess(adminBypass: true)` gate fires on every elevated step.
- **App scan returning no sizes.** A local Debug build bundles no engine and silently falls back to Homebrew's `mo` 1.46.0 — upstream GPL Mole, not the 1.42.0 fork we ship. Copying the real engine into the bundle restored it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dry-run cleaning now displays progress updates and a completion notification with results, including total bytes and item counts—or confirmation when nothing needs cleaning.

- **Bug Fixes**
  - The update-all stop action now clearly indicates when cancellation is pending.
  - The stop button is disabled after cancellation is requested to prevent duplicate actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->