### PR TITLE
feat(macos): offer the privileged helper from an ambient banner

### DIFF
--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -541,6 +541,9 @@
 /* Access banner */
 "Full Disk Access is off" = "完全磁盘访问权限已关闭";
 "Without it, Burrow can't reach most system caches." = "没有它，Burrow 无法触达大多数系统缓存。";
+"Use Touch ID for admin operations" = "用触控 ID 完成管理员操作";
+"Install the signed helper and scan, clean, and optimize authenticate with a fingerprint instead of a password." = "安装已签名的辅助工具后，扫描、清理与优化将用指纹验证，而不必输入密码。";
+"Set up" = "去设置";
 "Dismiss" = "关闭";
 
 /* Clean — result hero & run */

--- a/macos/Resources/zh-Hant.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hant.lproj/Localizable.strings
@@ -526,6 +526,9 @@
 /* Access banner */
 "Full Disk Access is off" = "完整磁碟取用權限已關閉";
 "Without it, Burrow can't reach most system caches." = "沒有它，Burrow 無法觸及大多數系統快取。";
+"Use Touch ID for admin operations" = "用觸控 ID 完成管理員操作";
+"Install the signed helper and scan, clean, and optimize authenticate with a fingerprint instead of a password." = "安裝已簽署的輔助工具後，掃描、清理與最佳化將以指紋驗證，不必輸入密碼。";
+"Set up" = "去設定";
 "Dismiss" = "關閉";
 
 /* Clean — result hero & run */

--- a/macos/Sources/Components/AccessBanner.swift
+++ b/macos/Sources/Components/AccessBanner.swift
@@ -2,36 +2,41 @@
 //  AccessBanner.swift
 //  Burrow / Components
 //
-//  The ambient "Full Disk Access is off" state, demoted from blocking
-//  gate cards to one bottom-anchored banner over the whole window. It
-//  informs — the page behind stays fully usable. RootView mounts it
-//  once and re-probes access whenever the app activates, so granting
-//  FDA in System Settings dismisses it without a click.
+//  The ambient "something about privileges isn't set up" state, demoted
+//  from blocking gate cards to one bottom-anchored banner over the whole
+//  window. It informs — the page behind stays fully usable. RootView owns
+//  the copy and mounts at most one at a time (Full Disk Access first, then
+//  the privileged helper), re-probing on every app activation so granting
+//  the thing in System Settings dismisses the banner without a click.
 //
 
 import SwiftUI
 
 struct AccessBanner: View {
-    var onOpenSettings: () -> Void = { Privacy.openFullDiskAccessSettings() }
+    var glyph: String = "lock.shield"
+    var title: String
+    var detail: String
+    var actionTitle: String = NSLocalizedString("Open Settings", comment: "")
+    var onAction: () -> Void = { Privacy.openFullDiskAccessSettings() }
     var onDismiss: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: "lock.shield")
+            Image(systemName: glyph)
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Brand.amber)
                 .frame(width: 32, height: 32)
                 .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(Brand.amber.opacity(0.14)))
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
-                Text("Full Disk Access is off")
+                Text(title)
                     .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.textPrimary)
-                Text("Without it, Burrow can't reach most system caches.")
+                Text(detail)
                     .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
             }
             Spacer(minLength: 14)
-            Button(action: onOpenSettings) {
-                Text("Open Settings")
+            Button(action: onAction) {
+                Text(actionTitle)
                     .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.textPrimary)
                     .padding(.horizontal, 12).padding(.vertical, 6)
                     .background(Capsule().fill(Color.white.opacity(0.10)))
@@ -57,6 +62,6 @@ struct AccessBanner: View {
         .overlay(RoundedRectangle(cornerRadius: 14, style: .continuous).strokeBorder(Brand.amber.opacity(0.25), lineWidth: 1))
         .shadow(color: .black.opacity(0.35), radius: 18, y: 6)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(NSLocalizedString("Full Disk Access is off", comment: ""))
+        .accessibilityLabel(title)
     }
 }

--- a/macos/Sources/RootView.swift
+++ b/macos/Sources/RootView.swift
@@ -78,8 +78,19 @@ struct RootView: View {
     /// notice — so one historical dismiss suppressed it forever even while FDA
     /// stayed off, which is why upgraders never saw it.)
     @State private var fdaBannerDismissed = false
+    /// Whether the privileged helper is registered. Starts optimistic so the
+    /// banner never flashes before the first probe answers, and is read off
+    /// the main thread — `SMAppService.status` is a synchronous XPC call.
+    @State private var helperInstalled = true
+    /// Persisted, unlike the FDA dismiss: the helper is a convenience (Touch
+    /// ID instead of a password), so once someone says no we stop asking.
+    @State private var helperBannerDismissed = Store.helperNoticeDismissed
     /// Where Esc in the Settings pane returns to.
     @State private var lastNonSettingsPane: Pane = .home
+    /// Set by a banner deep-link so Settings opens on the right tab, scrolled
+    /// to the section that was being offered. Cleared on leaving Settings.
+    @State private var settingsTab: SettingsView.Tab = .general
+    @State private var settingsScrollTarget: String?
     /// Tools that have been opened this session. Panes mount on FIRST visit and stay alive
     /// after (preserving in-flight work) — but never before: a hidden pane still runs full
     /// layout + material backdrops on every display flush, and mounting all ten at launch
@@ -145,11 +156,18 @@ struct RootView: View {
         .onAppear {
             producer.setForeground(Self.isMetricsPane(pane))
             if screenTelemetry.appeared(on: pane) { Telemetry.screen(pane) }
+            refreshHelperStatus()
         }
         .onChange(of: pane) { _, p in
             producer.setForeground(windowVisible && Self.isMetricsPane(p))
             if screenTelemetry.paneChanged(to: p) { Telemetry.screen(p) }
-            if p != .settings { lastNonSettingsPane = p }
+            if p != .settings {
+                lastNonSettingsPane = p
+                // A deep-link is a one-shot: reaching Settings any other way
+                // should land on General, at the top.
+                settingsTab = .general
+                settingsScrollTarget = nil
+            }
             if case .tool(let t) = p { visitedTools.insert(t) }
         }
         .onDisappear { producer.setForeground(false) }
@@ -168,21 +186,59 @@ struct RootView: View {
         // the banner auto-dismisses the moment access is granted.
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             fdaGranted = Privacy.hasFullDiskAccess()
+            // Approving the helper happens in System Settings, in another
+            // process, with nothing notifying us — so re-read on return.
+            refreshHelperStatus()
         }
+        // At most one banner at a time. FDA outranks the helper: without it
+        // scans can't read the caches the helper would elevate over anyway.
         .overlay(alignment: .bottom) {
             if !fdaGranted, !fdaBannerDismissed {
-                AccessBanner(onDismiss: {
-                    // Session-only — don't persist, so a future launch with FDA
-                    // still off shows it again (a gentle once-per-launch nudge).
-                    withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
-                        fdaBannerDismissed = true
-                    }
-                })
+                AccessBanner(
+                    title: NSLocalizedString("Full Disk Access is off", comment: ""),
+                    detail: NSLocalizedString("Without it, Burrow can't reach most system caches.", comment: ""),
+                    onDismiss: {
+                        // Session-only — don't persist, so a future launch with FDA
+                        // still off shows it again (a gentle once-per-launch nudge).
+                        withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
+                            fdaBannerDismissed = true
+                        }
+                    })
+                .padding(.horizontal, 18).padding(.bottom, 14)
+                .transition(reduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity))
+            } else if !helperInstalled, !helperBannerDismissed {
+                AccessBanner(
+                    glyph: "touchid",
+                    title: NSLocalizedString("Use Touch ID for admin operations", comment: ""),
+                    detail: NSLocalizedString("Install the signed helper and scan, clean, and optimize authenticate with a fingerprint instead of a password.", comment: ""),
+                    actionTitle: NSLocalizedString("Set up", comment: ""),
+                    onAction: {
+                        settingsTab = .advanced
+                        settingsScrollTarget = SettingsView.helperAnchor
+                        pane = .settings
+                    },
+                    onDismiss: {
+                        Store.helperNoticeDismissed = true
+                        withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
+                            helperBannerDismissed = true
+                        }
+                    })
                 .padding(.horizontal, 18).padding(.bottom, 14)
                 .transition(reduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity))
             }
         }
         .animation(reduceMotion ? nil : .easeOut(duration: 0.25), value: fdaGranted)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.25), value: helperInstalled)
+    }
+
+    /// `SMAppService.status` is a synchronous XPC round-trip — reading it on
+    /// the main thread hung the window in Settings (BURROW app-hang reports),
+    /// so the banner's probe stays off-main too.
+    private func refreshHelperStatus() {
+        DispatchQueue.global(qos: .utility).async {
+            let installed = PrivilegedHelperClient.shared.registrationStatus != .notRegistered
+            DispatchQueue.main.async { helperInstalled = installed }
+        }
     }
 
     /// Panes whose charts want live, high-cadence data. Home's Overview /
@@ -241,7 +297,9 @@ struct RootView: View {
                     // VACUUM can rewrite the whole DB file).
                     let m = delegate?.maintenance
                     DispatchQueue.global(qos: .utility).async { m?.runNow() }
-                }, onClose: { pane = lastNonSettingsPane })
+                }, onClose: { pane = lastNonSettingsPane },
+                   initialTab: settingsTab,
+                   scrollTarget: settingsScrollTarget)
             }
         }
     }

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -33,13 +33,30 @@ struct SettingsView: View {
         }
     }
 
+    /// Anchor for deep-links that want the privileged-helper section on
+    /// screen (RootView's Touch ID banner).
+    static let helperAnchor = "privileged-helper"
+
     /// Wired by AppDelegate; the only consumer is "Run maintenance now".
     var onRunMaintenance: (() -> Void)?
     /// Esc leaves Settings (RootView returns to the previous pane). The
     /// pane has no close chrome of its own — navigation lives in the floating rail.
     var onClose: (() -> Void)?
+    /// A section anchor to scroll to once the pane lays out. Only set when
+    /// something deep-linked here to offer a specific setting.
+    var scrollTarget: String?
 
-    @State private var tab: Tab = .general
+    @State private var tab: Tab
+
+    init(onRunMaintenance: (() -> Void)? = nil,
+         onClose: (() -> Void)? = nil,
+         initialTab: Tab = .general,
+         scrollTarget: String? = nil) {
+        self.onRunMaintenance = onRunMaintenance
+        self.onClose = onClose
+        self.scrollTarget = scrollTarget
+        self._tab = State(initialValue: initialTab)
+    }
 
     // General
     @State private var fdaGranted = Privacy.hasFullDiskAccess()
@@ -134,24 +151,37 @@ struct SettingsView: View {
             header
                 .padding(.horizontal, 18).padding(.top, 8).padding(.bottom, 10)
             Rectangle().fill(Brand.hairline).frame(height: 1)
-            ScrollView {
-                VStack(alignment: .leading, spacing: 14) {
-                    switch tab {
-                    case .general:     generalTab
-                    case .maintenance: maintenanceTab
-                    case .menuBar:     menuBarTab
-                    case .advanced:    advancedTab
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        switch tab {
+                        case .general:     generalTab
+                        case .maintenance: maintenanceTab
+                        case .menuBar:     menuBarTab
+                        case .advanced:    advancedTab
+                        }
+                    }
+                    // Full-bleed pane, readable column: the cards cap at a
+                    // comfortable measure and stay centered in wide windows.
+                    .frame(maxWidth: 680)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 14)
+                    .padding(.bottom, 22)
+                    .frame(maxWidth: .infinity)
+                }
+                .scrollIndicators(.hidden)
+                // A deep-linked section is often below the fold; the anchor
+                // only exists once the tab's content has laid out, so this
+                // waits a beat rather than scrolling to nothing.
+                .onAppear {
+                    guard let scrollTarget else { return }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            proxy.scrollTo(scrollTarget, anchor: .center)
+                        }
                     }
                 }
-                // Full-bleed pane, readable column: the cards cap at a
-                // comfortable measure and stay centered in wide windows.
-                .frame(maxWidth: 680)
-                .padding(.horizontal, 20)
-                .padding(.top, 14)
-                .padding(.bottom, 22)
-                .frame(maxWidth: .infinity)
             }
-            .scrollIndicators(.hidden)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onExitCommand { onClose?() }
@@ -672,6 +702,7 @@ struct SettingsView: View {
                 }
                 footnote("Runs Burrow's admin operations — scan, clean, optimize — through a small signed helper instead of a password-only prompt, so macOS can offer Touch ID. Installing it needs your approval once and grants no standing access: you're asked to authenticate for each operation you start. The helper can only perform those three operations — it cannot be asked to run anything else.")
             }
+            .id(Self.helperAnchor)
 
             section("Mole engine", "shippingbox") {
                 infoRow("Version", moleVersion)

--- a/macos/Sources/Store.swift
+++ b/macos/Sources/Store.swift
@@ -373,6 +373,16 @@ enum Store {
         set { d.set(newValue, forKey: "fda_notice_dismissed") }
     }
 
+    /// Whether the user has dismissed the banner offering the privileged
+    /// helper (Touch ID for admin operations). Unlike the FDA notice — which
+    /// re-asks each launch because without it scans genuinely can't read
+    /// protected caches — the helper is a convenience, so one dismiss is
+    /// final. Installing it hides the banner on its own.
+    static var helperNoticeDismissed: Bool {
+        get { d.object(forKey: "helper_notice_dismissed") as? Bool ?? false }
+        set { write(newValue, "helper_notice_dismissed") }
+    }
+
     /// Whether the popover shows a camera/microphone in-use indicator.
     /// Opt-in (off by default): detection is honest (system "in use" flag,
     /// like Control Center) but lights for Siri/dictation/Continuity too, so

--- a/macos/Tests/StoreTests.swift
+++ b/macos/Tests/StoreTests.swift
@@ -75,6 +75,15 @@ final class StoreTests: XCTestCase {
         XCTAssertTrue(Store.telemetryNoticeAcknowledged)
     }
 
+    // The Touch ID banner offers an optional convenience, so unlike the FDA
+    // notice its dismiss is final: shown on a fresh install, never again once
+    // the user says no.
+    func testHelperNotice_defaultsUndismissedAndPersists() {
+        XCTAssertFalse(Store.helperNoticeDismissed)
+        Store.helperNoticeDismissed = true
+        XCTAssertTrue(Store.helperNoticeDismissed)
+    }
+
     // Issue #4: the menu-bar icon is on by default; the off-switch must
     // persist (it's read once at launch to decide menu-bar vs Dock mode).
     func testShowMenuBarIcon_defaultsTrueAndPersists() {


### PR DESCRIPTION
## Why

The privileged helper — the thing that lets scan/clean/optimize authenticate with Touch ID instead of a password — shipped in 0.13.0 with exactly one surface: a button in **Settings ▸ Advanced ▸ Privileged helper**. Nothing points anyone at it. Onboarding covers Full Disk Access and the engine and never mentions it, no pane links to it, and the password prompt it replaces gives no hint an alternative exists. Upgraders could only learn about it from the release notes; fresh installs, not at all.

## What

Offer it the way Full Disk Access is offered: one bottom-anchored banner over the window, informing rather than blocking.

- `AccessBanner` is now generic over glyph/title/detail/action, so `RootView` mounts either notice with its own copy. Only one shows at a time — FDA outranks the helper, since without it the caches the helper would elevate over are unreadable anyway.
- The dismiss **persists** (`helper_notice_dismissed`), unlike FDA's session-only dismiss. The helper is a convenience, not a functional gate, so once someone says no we stop asking. Installing it hides the banner on its own.
- **Set up** deep-links into Settings ▸ Advanced *scrolled to the section*, instead of dropping the user at the top of a long tab to hunt for it. That's a new `initialTab`/`scrollTarget` init on `SettingsView` plus a `ScrollViewReader`; the deep-link is one-shot and resets when you leave Settings.
- Registration status is probed off the main thread and re-probed on every app activation, so approving the helper in System Settings clears the banner without a click. (`SMAppService.status` is a synchronous XPC call — reading it on the main thread has hung this window before.)
- Both zh catalogs get the three new strings.

## Testing

Debug build is green; added a `Store` round-trip test for the new flag.

Worth checking by hand:
- With the helper not installed, the banner appears at the bottom and **Set up** lands on Advanced with the Privileged helper section on screen.
- Dismiss, relaunch — it stays gone.
- With FDA off, only the FDA banner shows; the helper one takes its place once FDA is granted or dismissed.
- On a local ad-hoc build the banner shows but the install itself fails (helper needs Developer ID), so the install path needs a signed build to verify.