### PR TITLE
fix(macos): report what the reviewed clean actually removed

### DIFF
--- a/macos/Sources/CleanView.swift
+++ b/macos/Sources/CleanView.swift
@@ -317,10 +317,34 @@ struct CleanView: View {
             return
         }
         screen = .hero
+        // `find -delete` succeeds SILENTLY — it writes nothing at all — so
+        // parsing its output produced an empty report: no items, no bytes, no
+        // done-banner. The reviewed clean deleted exactly what was ticked and
+        // then looked like it had done nothing, which is indistinguishable
+        // from a failure. Build the report from the plan we just authorized;
+        // the run only reaches `.done` when every planned path is gone, which
+        // is precisely what makes this safe to state as fact.
+        let cleaned = selection.list.categories
+            .map { category in
+                (category.name, category.items.filter { paths.contains($0.path) })
+            }
+            .filter { !$0.1.isEmpty }
+        let cleanedBytes = cleaned.flatMap(\.1).reduce(Int64(0)) { $0 + $1.sizeBytes }
+        let cleanedCount = cleaned.reduce(0) { $0 + $1.1.count }
         realFlow.start(ToolOperation(
             label: NSLocalizedString("Cleaning reviewed caches", comment: ""),
             executable: .path("/usr/bin/find"), arguments: [], elevated: true,
-            cleanupPlan: plan, reduce: { parseTaskReport($0) }, notifyOnEnd: true))
+            cleanupPlan: plan,
+            reduce: { _ in
+                (groups: cleaned.map { name, items in
+                    TaskGroup(title: name,
+                              items: items.map { TaskItem(marker: .ok, text: $0.path) })
+                 },
+                 summary: TaskSummary(space: Fmt.bytes(cleanedBytes),
+                                      items: "\(cleanedCount)",
+                                      categories: "\(cleaned.count)"))
+            },
+            notifyOnEnd: true))
     }
 
     // MARK: - Trash mode


### PR DESCRIPTION
Shipped in 0.13.0. The reviewed clean **deleted exactly what was ticked and then looked like it had done nothing** — which is how it was reported.

## Why

The reviewed path doesn't run `mo clean`. It runs the plan's own shell, `find -x "$p" -depth -delete` per reviewed path, and `find -delete` succeeds **silently**:

```
$ find -x "$T/cache" -depth -delete   # 4-entry populated tree
exit=0  stdout+stderr bytes=0  []
after: exists=no
```

That silence was still being fed through `parseTaskReport`, so the run produced an empty report — no items, no freed bytes, no done banner. The lifetime total on that screen reads from `mo`'s history, which this path never writes to, so it was blank too.

The machine's own logs show the split: `mo`'s history had a clean session removing 134 items / 677.9 MB, while the reviewed runs appear nowhere at all.

## The fix

Build the report from the plan that was just authorized — ticked paths grouped by category, reviewed sizes summed — instead of parsing `find`'s silence.

This states fact rather than optimism: `irreversibleCleanupShell()` only exits 0 after checking `[ -e "$p" ] || [ -L "$p" ]` for every planned path, so anything that survived fails the run instead of being counted as removed.

## Scope

Reporting only. No change to what is deleted, to the authorization, or to the boundary checks — nothing was ever deleted that wasn't ticked.

## Verification

1053 tests, 0 failures. Confirmed by hand on a Developer ID-signed build with the engine bundled: scan → review → clean now shows the categories and the freed total.

Not unit-tested: the `reduce` closure is inline in a SwiftUI view with no seam to call it from. The underlying claim — that `find -delete` is silent — is demonstrated above.