### PR TITLE
release(macos): prepare 0.14.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,44 +1,27 @@
-# Burrow 0.13.0
+# Burrow 0.14.0
 
-Headings that rendered as empty boxes now render as text, and Burrow's MCP
-server speaks the 2026-07-28 spec — without dropping any older client.
-
-This release is mostly repair. The visible half fixes three things that were
-easy to hit; the larger half is security and reliability work on the paths that
-delete files and run as root, which you should never notice.
+The Touch ID helper now offers itself, and the reviewed clean says what it
+removed instead of finishing silently.
 
 ## Added
-- **The scan tells you when it's done.** A cache scan can run for minutes and
-  used to end by just sitting there with a number. It now posts a completion
-  notification saying what it found, honouring **Settings ▸ Notify when long
-  operations finish**.
-- **Two more agent tools.** `burrow_anomalies` and `burrow_agent_audit` join the
-  MCP surface.
-
-## Changed
-- **MCP now speaks the 2026-07-28 revision**, including its task and
-  cancellation semantics. Older clients are unaffected: 2025-11-25 through
-  2024-11-05 are still served, and a client that skips `initialize` entirely
-  still works.
+- **Burrow offers the privileged helper.** The helper that lets admin
+  operations authenticate with Touch ID shipped in 0.13.0 behind a single
+  button in **Settings ▸ Advanced**, and nothing pointed anyone at it —
+  upgraders learned about it from the release notes, fresh installs not at all.
+  It is now offered the way Full Disk Access is: one banner over the window,
+  informing rather than blocking. At most one notice shows at a time, and
+  dismissing the helper notice is permanent, because the helper is a
+  convenience rather than something Burrow needs to work.
 
 ## Fixed
-- **Headings rendered as empty boxes.** Geist and Geist Mono shipped as single
-  variable fonts with only Regular registered, so every bold and semibold
-  heading asked macOS to derive a weight at render time — and sometimes it
-  produced no glyphs at all. Burrow now ships real static faces for every weight
-  it uses.
-- **One bad exit no longer disables the menu bar** until macOS updates.
-- **The window can be made smaller again** — its minimum height is derived from
-  the sidebar rather than hardcoded.
-- **"Stop after current" now responds.** The stop was always queued, but nothing
-  on screen said so until the in-flight update finished.
-- **The clean review no longer promises what closing an app can't deliver.** An
-  entry the scan refused was counted in "Close X to clean another N" even though
-  no app was holding it — with no app named at all when it was the only locked
-  entry.
-- **A cancelled app update no longer blocks later update checks** for the rest of
-  the session.
-- **Root operations can't interleave their output.** stdout and stderr shared one
-  line buffer, which could splice half a line from one stream onto the other.
-- **Update archives are size-capped** before they're kept or expanded.
-- **Diagnostics reject more credential shapes** before anything is uploaded.
+- **The reviewed clean reports what it removed.** It deleted exactly what was
+  ticked and then looked like it had done nothing. That path doesn't run the
+  engine's cleaner — it deletes each reviewed path with `find`, which succeeds
+  *silently*, so the result screen had no output to show: no items, no freed
+  total, no done banner. It now reports the paths it was authorized to remove,
+  grouped by category with their sizes summed, which is a statement of fact
+  rather than optimism — the run only succeeds after confirming every planned
+  path is gone.
+
+Nothing changed about what the reviewed clean deletes, or about the checks it
+passes before deleting: this release makes it visible, not different.

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -15,8 +15,8 @@ settings:
     MACOSX_DEPLOYMENT_TARGET: "14.0"
     # The only app/build version declarations. The generated Info.plist keeps
     # these build-setting references, and Xcode expands them in the product.
-    MARKETING_VERSION: "0.13.0"
-    CURRENT_PROJECT_VERSION: "25"
+    MARKETING_VERSION: "0.14.0"
+    CURRENT_PROJECT_VERSION: "26"
     ENABLE_HARDENED_RUNTIME: YES
     # Xcode leaves signing off for reproducible builds. Local scripts apply a
     # coherent ad-hoc signature; the tag workflow applies Developer ID after


### PR DESCRIPTION
Version bump + release notes for **0.14.0**. Tag goes up once this lands.

**Why minor, not patch:** #379 added a surface users see — the privileged helper is now offered from an ambient banner rather than sitting behind a Settings button nothing pointed at. The reviewed-clean reporting fix (#380) would have been a patch on its own.

**What's in it:** the helper discovery banner, and the reviewed clean now reporting what it removed instead of finishing silently — it deleted correctly in 0.13.0 but had no output to show, since it deletes with `find`, which succeeds silently.

1054 tests, 0 failures. Built app reports `CFBundleShortVersionString = 0.14.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismissible, non-blocking banner for accessing the privileged Touch ID helper.
  * Reviewed clean results now show authorized removals, grouped item sizes, and completion only after deletion is verified.
* **Bug Fixes**
  * Improved accuracy of reviewed clean completion and removal reporting.
  * Existing pre-deletion checks and deletion behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->