### PR TITLE
ci: close two mention leaks in the upstream watcher's quoting

### DIFF
--- a/.github/scripts/upstream_watch.py
+++ b/.github/scripts/upstream_watch.py
@@ -44,13 +44,22 @@ DRY_RUN = False
 # would linkify in code spans (GitHub does not link or notify inside code), and
 # fold issue/PR/discussion URLs down to a plain `owner/repo#N` ref.
 
-FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
-CODE_SPAN_RE = re.compile(r"(`+[^`]*`+)")
-MENTION_RE = re.compile(r"(?<![\w`/@!-])@([A-Za-z0-9][A-Za-z0-9-]{0,38}(?:/[A-Za-z0-9._-]+)?)")
+# A fenced block runs to a closer of the same character, at least as long -- a
+# ``` line does not close a ~~~ block. An inline span may wrap across a line but
+# not across a blank line, matching how GitHub itself parses one: if we treated a
+# stray backtick pair as code across a paragraph break, a live mention inside it
+# would slip through untouched.
+CODE_SPAN = r"`+(?:[^`\n]|\n(?![ \t]*\n))*`+"
+PROTECTED_RE = re.compile(
+    r"(?ms)^[ \t]*(?P<fence>`{3,}|~{3,})[^\n]*$.*?(?:^[ \t]*(?P=fence)[`~]*[ \t]*$|\Z)"
+    r"|" + CODE_SPAN
+)
+MENTION_RE = re.compile(r"(?<![\w`/@!+.%-])@([A-Za-z0-9][A-Za-z0-9-]{0,38}(?:/[A-Za-z0-9._-]+)?)")
 ISSUE_REF_RE = re.compile(r"(?<![\w`/#&-])((?:[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*)?#\d+)\b")
-ISSUE_URL = r"https?://(?:www\.)?github\.com/([A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*)/(?:issues|pull|discussions)/(\d+)(?:[#?][^\s)\]]*)?"
+ISSUE_URL = (r"https?://(?:www\.)?github\.com/([A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*)"
+             r"/(?:issues|pull|discussions)/(\d+)(?:/[A-Za-z0-9._-]+)*(?:[#?][^\s)\]]*)?")
 ISSUE_URL_RE = re.compile(ISSUE_URL)
-MD_ISSUE_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*" + ISSUE_URL + r"\s*\)")
+MD_ISSUE_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*" + ISSUE_URL + r"""\s*(?:"[^"]*"|'[^']*')?\s*\)""")
 
 
 def _neutralize_span(s):
@@ -61,18 +70,21 @@ def _neutralize_span(s):
 
 
 def neutralize(text):
-    """Quote upstream-authored text so GitHub links nothing and notifies nobody."""
-    out, in_fence = [], False
-    for line in (text or "").splitlines():
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
-        if in_fence or FENCE_RE.match(line):
-            out.append(line)
-            continue
-        # Odd indices are existing code spans -- already inert, leave them be.
-        parts = CODE_SPAN_RE.split(line)
-        out.append("".join(p if i % 2 else _neutralize_span(p) for i, p in enumerate(parts)))
-    return "\n".join(out)
+    """Quote upstream-authored text so GitHub links nothing and notifies nobody.
+
+    Scans the whole text rather than line by line: a fenced block or an inline
+    span can cover several lines, and quoting only part of one would insert a
+    backtick that re-pairs the span and leaves the mention after it live.
+    """
+    text = text or ""
+    out, pos = [], 0
+    for m in PROTECTED_RE.finditer(text):
+        # Already code -- GitHub neither links nor notifies in there.
+        out.append(_neutralize_span(text[pos:m.start()]))
+        out.append(m.group(0))
+        pos = m.end()
+    out.append(_neutralize_span(text[pos:]))
+    return "".join(out)
 
 
 def log(msg):


### PR DESCRIPTION
Follow-up review of #386. The quoting exists so mirroring an upstream release note never notifies an upstream contributor, and the line-by-line scan had two ways to leave a mention live anyway.

**An inline code span may wrap across a line.** Quoting only the part that fell on one line inserted a backtick that re-paired the delimiters, pushing the mention out of the span:

```
Here is `code with @user
more code` end
```

**A ``` line inside a `~~~` block flipped the fence state early**, so everything past the block's real close went unprocessed and stayed linked.

Both come from scanning a line at a time, so `neutralize()` now walks the whole text and lifts out protected regions with one pass. A fence closes only on a run of the same character, at least as long (so ```` also closes a ``` block, per CommonMark). A span may wrap across a line but deliberately not across a blank line — GitHub doesn't parse one across a paragraph break either, and treating a stray backtick pair as code that far would skip a mention that really is live.

Two cosmetic fixes rode along: trailing URL path segments (`/pull/636/files`) and optional Markdown link titles now fold into the ref instead of leaving `/files` or broken link markup behind, and addresses whose local part ends in a non-word character (`ops+@example.com`) are no longer mangled.

Not changed: the issue title still uses the raw tag and release name. GitHub renders titles as plain text with no mention or `#ref` autolinking, so quoting there would only stamp literal backticks into the title for no safety gain.

Verified: the six most recent real Mole release bodies come out byte-identical to what's on main today (the old version also dropped trailing newlines, which the caller strips anyway), zero residual mentions, zero residual PR URLs, and `WATCH_DRY_RUN=1` over both modes runs clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text sanitization for multiline content.
  * Preserved fenced code blocks and inline code spans while removing mentions, issue references, and GitHub links.
  * Added more accurate handling for code fences, including compatible closing delimiters and inline code spanning multiple lines.
  * Improved recognition of issue links with optional titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->