### PR TITLE
fix: guard terminationStatus against a never-launched process

### DIFF
--- a/macos/Sources/MoInteractive.swift
+++ b/macos/Sources/MoInteractive.swift
@@ -182,6 +182,14 @@ enum MoTUI {
 final class PTYTask: PTYPort {
     private var proc = Process()   // replaced on each launch (a Process runs once)
     private var master: FileHandle?
+    /// `isRunning` is `false` for BOTH a finished process and a never-launched
+    /// one, so it can't distinguish "already reaped" from "run() threw". Only a
+    /// process that actually launched may report `terminationStatus`; reading it
+    /// from a never-launched child raises `NSInvalidArgumentException` ("task not
+    /// launched"), which Swift cannot catch — Sentry BURROW-A5, issue #374. Track
+    /// the launch state so the EOF branch never asks a never-spawned child for
+    /// its exit code.
+    private var didLaunch = false
 
     var onOutput: ((String) -> Void)?
     var onExit: ((Int32) -> Void)?
@@ -210,6 +218,7 @@ final class PTYTask: PTYPort {
         proc = Process()
         // New child, new exactly-once exit report.
         reportedExit = false
+        didLaunch = false
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
@@ -243,7 +252,10 @@ final class PTYTask: PTYPort {
                 // report the exit ourselves; otherwise the now-unstarved
                 // terminationHandler will.
                 h.readabilityHandler = nil
-                if !self.proc.isRunning {
+                // Only a launched process has a valid exit code. If run() threw
+                // (the child never spawned), didLaunch is false and reading
+                // terminationStatus would raise "task not launched" (#374).
+                if self.didLaunch && !self.proc.isRunning {
                     let code = self.proc.terminationStatus
                     DispatchQueue.main.async { self.reportExitOnce(code) }
                 }
@@ -256,8 +268,18 @@ final class PTYTask: PTYPort {
         // Close the parent's slave fd whether or not the launch succeeds — on a
         // throw the child never starts, so nothing else would ever close it.
         do { try proc.run() }
-        catch { close(aslave); throw error }
+        catch {
+            // The child never started, so it can never report an exit. Drop the
+            // armed read handler and the master fd now — otherwise the EOF branch
+            // would fire later and, seeing a never-launched process, crash on
+            // terminationStatus (Sentry BURROW-A5, #374).
+            close(aslave)
+            m.readabilityHandler = nil
+            master = nil
+            throw error
+        }
         close(aslave)   // parent doesn't use the slave end
+        didLaunch = true
     }
 
     /// PTY writes go through a dedicated serial queue so a blocked `write()`

--- a/macos/Sources/MoInteractive.swift
+++ b/macos/Sources/MoInteractive.swift
@@ -249,12 +249,11 @@ final class PTYTask: PTYPort {
         let proc = Process()
         launchCount &+= 1
         let gen = Generation(id: launchCount, child: proc)
-        // Don't depend on the caller having terminated first. A relaunch over a
-        // live `master` would otherwise leave its read handler armed, and the
-        // dispatch source holding that handler keeps the FileHandle alive — so
-        // its fd would never close. Generation tagging already makes a late
-        // delivery harmless; this is about the descriptor, not correctness.
-        master?.readabilityHandler = nil
+        // Everything below builds the replacement WITHOUT touching the pty that's
+        // already installed. A relaunch that fails partway must leave the running
+        // child exactly as it found it — still readable, its master fd still open
+        // (closing it would raise SIGHUP on a child that's very much alive).
+        let previousMaster = master
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
@@ -306,17 +305,17 @@ final class PTYTask: PTYPort {
             guard let s = String(data: d, encoding: .utf8) else { return }
             DispatchQueue.main.async { self.deliverOutput(s, from: gen.id) }
         }
-        master = m
         // Close the parent's slave fd whether or not the launch succeeds — on a
         // throw the child never starts, so nothing else would ever close it.
         do { try proc.run() }
         catch {
             // The child never started, so it can never report an exit. Disarm the
-            // read handler and drop the master fd BEFORE closing the slave: that
-            // close is what makes the master see EOF, and a handler firing then
-            // would ask a never-launched child for terminationStatus (#374).
+            // read handler BEFORE closing the slave: that close is what makes this
+            // master see EOF, and a handler firing then would ask a never-launched
+            // child for terminationStatus (#374). `m` was never installed as
+            // `master`, so the previous child keeps its own pty untouched; letting
+            // `m` go out of scope closes this abandoned master fd.
             m.readabilityHandler = nil
-            master = nil
             close(aslave)
             throw error
         }
@@ -332,6 +331,13 @@ final class PTYTask: PTYPort {
         current = gen
         // New child, new exactly-once exit report.
         reportedExit = false
+        // Only now hand the task over to the new pty. Disarming the old handler
+        // releases the dispatch source that was keeping that FileHandle alive, so
+        // its fd finally closes — a relaunch over a live master used to strand it
+        // open. Callers terminate first in practice; this just stops the fd's fate
+        // depending on their remembering to.
+        previousMaster?.readabilityHandler = nil
+        master = m
         close(aslave)   // parent doesn't use the slave end
     }
 

--- a/macos/Sources/MoInteractive.swift
+++ b/macos/Sources/MoInteractive.swift
@@ -249,9 +249,6 @@ final class PTYTask: PTYPort {
         let proc = Process()
         launchCount &+= 1
         let gen = Generation(id: launchCount, child: proc)
-        current = gen
-        // New child, new exactly-once exit report.
-        reportedExit = false
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
@@ -321,6 +318,14 @@ final class PTYTask: PTYPort {
         // child that exits instantly would otherwise reach the EOF branch while
         // this launch still looked unlaunched, and its exit would go unreported.
         gen.didLaunch = true
+        // Retire the previous generation only once this one is actually running:
+        // a launch that threw must leave the old child still able to report its
+        // exit, rather than installing a never-started generation that silently
+        // outranks it. Safe to defer — launch() runs on main and every callback
+        // compares ids on main, so this assignment always lands first.
+        current = gen
+        // New child, new exactly-once exit report.
+        reportedExit = false
         close(aslave)   // parent doesn't use the slave end
     }
 

--- a/macos/Sources/MoInteractive.swift
+++ b/macos/Sources/MoInteractive.swift
@@ -180,16 +180,37 @@ enum MoTUI {
 /// owns its read loop and delivers output/exit on the main thread so the host
 /// reducer stays single-threaded. The only impure seam — kept tiny.
 final class PTYTask: PTYPort {
-    private var proc = Process()   // replaced on each launch (a Process runs once)
+    /// One launch's private state. Both callbacks close over their own instance,
+    /// so a handler still armed from an earlier child can never read the CURRENT
+    /// child's process, launch flag, or exit code.
+    ///
+    /// A rescan makes that concrete: it's only reachable from the chooser, where
+    /// the old `mo` is still sitting at the selection screen, so `terminate()`
+    /// SIGTERMs a live child and its terminationHandler fires on a background
+    /// thread *after* `launch()` has already reset the exactly-once flag for the
+    /// new one. Reported untagged, that stale exit lands on the fresh scan, and
+    /// `SelectionSession.exited` turns an exit-before-any-list into `.done` — so
+    /// the rescan finished instantly with the previous child's SIGTERM status.
+    private final class Generation {
+        let id: UInt64
+        let child: Process
+        /// `isRunning` is `false` for BOTH a finished process and a never-launched
+        /// one, so it can't distinguish "already reaped" from "run() threw". Only a
+        /// process that actually launched may report `terminationStatus`; reading it
+        /// from a never-launched child raises `NSInvalidArgumentException` ("task not
+        /// launched"), which Swift cannot catch — Sentry BURROW-A5, issue #374. Track
+        /// the launch state so the EOF branch never asks a never-spawned child for
+        /// its exit code.
+        var didLaunch = false
+        init(id: UInt64, child: Process) { self.id = id; self.child = child }
+    }
+
+    /// The launch entitled to speak for this task. Main-confined: `launch()`
+    /// replaces it, and every callback's captured id is compared against it on
+    /// main, so the check never races the swap.
+    private var current: Generation?
+    private var launchCount: UInt64 = 0
     private var master: FileHandle?
-    /// `isRunning` is `false` for BOTH a finished process and a never-launched
-    /// one, so it can't distinguish "already reaped" from "run() threw". Only a
-    /// process that actually launched may report `terminationStatus`; reading it
-    /// from a never-launched child raises `NSInvalidArgumentException` ("task not
-    /// launched"), which Swift cannot catch — Sentry BURROW-A5, issue #374. Track
-    /// the launch state so the EOF branch never asks a never-spawned child for
-    /// its exit code.
-    private var didLaunch = false
 
     var onOutput: ((String) -> Void)?
     var onExit: ((Int32) -> Void)?
@@ -198,10 +219,20 @@ final class PTYTask: PTYPort {
     /// exit; the session must hear about it exactly once. Main-confined —
     /// both reporters dispatch here.
     private var reportedExit = false
-    private func reportExitOnce(_ code: Int32) {
-        guard !reportedExit else { return }
+
+    /// Report only for the live launch. A callback carrying a retired id belongs
+    /// to a child the host has already torn down and moved past.
+    private func reportExitOnce(_ code: Int32, from id: UInt64) {
+        guard id == current?.id, !reportedExit else { return }
         reportedExit = true
         onExit?(code)
+    }
+
+    /// Same gate for output: bytes a dead child wrote must never be parsed as
+    /// the new scan's screen.
+    private func deliverOutput(_ text: String, from id: UInt64) {
+        guard id == current?.id else { return }
+        onOutput?(text)
     }
 
     private let cols: UInt16
@@ -215,10 +246,12 @@ final class PTYTask: PTYPort {
         // A Process can only be run ONCE; a rescan calls launch again, so start
         // from a fresh instance each time. (Reusing the old one left the second
         // scan with a dead, never-spawning child — the UI hung on "Scanning…".)
-        proc = Process()
+        let proc = Process()
+        launchCount &+= 1
+        let gen = Generation(id: launchCount, child: proc)
+        current = gen
         // New child, new exactly-once exit report.
         reportedExit = false
-        didLaunch = false
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
@@ -235,9 +268,13 @@ final class PTYTask: PTYPort {
         var env = Foundation.ProcessInfo.processInfo.environment
         env["TERM"] = "xterm-256color"
         proc.environment = env
+        // Capture the id, not `gen` — a Process retains its terminationHandler,
+        // so closing over the Generation (which holds the Process) would be a
+        // retain cycle that outlives the child.
+        let id = gen.id
         proc.terminationHandler = { [weak self] p in
             let code = p.terminationStatus
-            DispatchQueue.main.async { self?.reportExitOnce(code) }
+            DispatchQueue.main.async { self?.reportExitOnce(code, from: id) }
         }
         let m = FileHandle(fileDescriptor: amaster, closeOnDealloc: true)
         m.readabilityHandler = { [weak self] h in
@@ -252,34 +289,39 @@ final class PTYTask: PTYPort {
                 // report the exit ourselves; otherwise the now-unstarved
                 // terminationHandler will.
                 h.readabilityHandler = nil
-                // Only a launched process has a valid exit code. If run() threw
-                // (the child never spawned), didLaunch is false and reading
-                // terminationStatus would raise "task not launched" (#374).
-                if self.didLaunch && !self.proc.isRunning {
-                    let code = self.proc.terminationStatus
-                    DispatchQueue.main.async { self.reportExitOnce(code) }
+                // This launch's own child and flag — never `current`'s, which
+                // after a rescan is a different process whose status says nothing
+                // about this EOF. Only a launched process has a valid exit code:
+                // if run() threw, didLaunch is false and reading terminationStatus
+                // would raise "task not launched" (#374).
+                if gen.didLaunch && !gen.child.isRunning {
+                    let code = gen.child.terminationStatus
+                    DispatchQueue.main.async { self.reportExitOnce(code, from: gen.id) }
                 }
                 return
             }
             guard let s = String(data: d, encoding: .utf8) else { return }
-            DispatchQueue.main.async { self.onOutput?(s) }
+            DispatchQueue.main.async { self.deliverOutput(s, from: gen.id) }
         }
         master = m
         // Close the parent's slave fd whether or not the launch succeeds — on a
         // throw the child never starts, so nothing else would ever close it.
         do { try proc.run() }
         catch {
-            // The child never started, so it can never report an exit. Drop the
-            // armed read handler and the master fd now — otherwise the EOF branch
-            // would fire later and, seeing a never-launched process, crash on
-            // terminationStatus (Sentry BURROW-A5, #374).
-            close(aslave)
+            // The child never started, so it can never report an exit. Disarm the
+            // read handler and drop the master fd BEFORE closing the slave: that
+            // close is what makes the master see EOF, and a handler firing then
+            // would ask a never-launched child for terminationStatus (#374).
             m.readabilityHandler = nil
             master = nil
+            close(aslave)
             throw error
         }
+        // Also set before the slave closes, for the same reason in reverse: a
+        // child that exits instantly would otherwise reach the EOF branch while
+        // this launch still looked unlaunched, and its exit would go unreported.
+        gen.didLaunch = true
         close(aslave)   // parent doesn't use the slave end
-        didLaunch = true
     }
 
     /// PTY writes go through a dedicated serial queue so a blocked `write()`
@@ -297,8 +339,12 @@ final class PTYTask: PTYPort {
         let data = Data(bytes)
         writeQueue.async { try? master.write(contentsOf: data) }
     }
+    /// Deliberately does NOT retire the current generation: a terminate with no
+    /// relaunch behind it (the reducer's `.terminate` effect, `cancel()`) still
+    /// wants to hear the child's exit. Only `launch()` retires a generation,
+    /// because only a relaunch means the host has moved on to another child.
     func terminate() {
         master?.readabilityHandler = nil
-        if proc.isRunning { proc.terminate() }
+        if let child = current?.child, child.isRunning { child.terminate() }
     }
 }

--- a/macos/Sources/MoInteractive.swift
+++ b/macos/Sources/MoInteractive.swift
@@ -249,6 +249,12 @@ final class PTYTask: PTYPort {
         let proc = Process()
         launchCount &+= 1
         let gen = Generation(id: launchCount, child: proc)
+        // Don't depend on the caller having terminated first. A relaunch over a
+        // live `master` would otherwise leave its read handler armed, and the
+        // dispatch source holding that handler keeps the FileHandle alive — so
+        // its fd would never close. Generation tagging already makes a late
+        // delivery harmless; this is about the descriptor, not correctness.
+        master?.readabilityHandler = nil
         var amaster: Int32 = 0
         var aslave: Int32 = 0
         var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
@@ -334,7 +340,9 @@ final class PTYTask: PTYPort {
     /// caller (issue #73 / Sentry BURROW-D: the 0.06 s selection-replay tick
     /// runs on the main queue). The serial queue preserves keystroke order;
     /// the captured handle keeps the fd alive for an in-flight write even if
-    /// `terminate()` clears `master` underneath it. The master fd is otherwise
+    /// `master` is swapped out underneath it — by a relaunch, or dropped by a
+    /// failed one. (`terminate()` only disarms the read handler; it leaves the
+    /// handle itself in place.) The master fd is otherwise
     /// only touched by the FileHandle read handler, and read/write on a pty are
     /// independent directions, so there's no fd race.
     private let writeQueue = DispatchQueue(label: "dev.caezium.burrow.pty-write")

--- a/macos/Tests/MoInteractiveHostTests.swift
+++ b/macos/Tests/MoInteractiveHostTests.swift
@@ -82,7 +82,7 @@ final class MoInteractiveHostTests: XCTestCase {
     /// list as "nothing to remove", the rescan collapsed straight to `.done`.
     /// `/bin/cat` stands in for `mo` at the selection screen: it holds the pty
     /// open and never exits on its own, so any exit seen here is the old one's.
-    func testPTYTask_relaunchWhileRunning_doesNotReportTheOldChildsExit() {
+    func testPTYTask_relaunchWhileRunning_doesNotReportTheOldChildsExit() throws {
         let pty = PTYTask()
 
         // First child up and running (it echoes, which proves the pty is live).
@@ -91,7 +91,7 @@ final class MoInteractiveHostTests: XCTestCase {
         // back, so "ready" can arrive in one read or two.
         greeted.assertForOverFulfill = false
         pty.onOutput = { if $0.contains("ready") { greeted.fulfill() } }
-        try? pty.launch("/bin/cat", [])
+        try pty.launch("/bin/cat", [])
         pty.send(Array("ready\n".utf8))
         wait(for: [greeted], timeout: 5)
 
@@ -99,10 +99,16 @@ final class MoInteractiveHostTests: XCTestCase {
         // down and relaunch, synchronously, on main.
         let stale = expectation(description: "no exit is reported for the new child")
         stale.isInverted = true
-        pty.onOutput = { _ in }
+        // An absent exit also "passes" when the second child never started, so
+        // prove this one is live before reading anything into that silence.
+        let relaunched = expectation(description: "second child is running")
+        relaunched.assertForOverFulfill = false
+        pty.onOutput = { if $0.contains("again") { relaunched.fulfill() } }
         pty.onExit = { _ in stale.fulfill() }
         pty.terminate()
-        try? pty.launch("/bin/cat", [])
+        try pty.launch("/bin/cat", [])
+        pty.send(Array("again\n".utf8))
+        wait(for: [relaunched], timeout: 5)
 
         // The second `cat` is still alive, so a fired onExit can only be the
         // first child's SIGTERM leaking across the relaunch.

--- a/macos/Tests/MoInteractiveHostTests.swift
+++ b/macos/Tests/MoInteractiveHostTests.swift
@@ -148,6 +148,31 @@ final class MoInteractiveHostTests: XCTestCase {
         wait(for: [exited], timeout: 5)
     }
 
+    /// A relaunch that fails must leave the child that IS running completely
+    /// untouched — still readable, master fd still open. Tearing its pty down on
+    /// the way to a launch that then threw would cost the live child its output
+    /// and hang up its terminal underneath it.
+    func testPTYTask_failedRelaunch_leavesThePreviousChildUsable() throws {
+        let pty = PTYTask()
+        let before = expectation(description: "child echoes before the failed relaunch")
+        before.assertForOverFulfill = false
+        pty.onOutput = { if $0.contains("before") { before.fulfill() } }
+        try pty.launch("/bin/cat", [])
+        pty.send(Array("before\n".utf8))
+        wait(for: [before], timeout: 5)
+
+        // Note there's no terminate() here: the running child is meant to survive.
+        XCTAssertThrowsError(try pty.launch("/nonexistent/mo", []),
+                             "a missing binary must surface as a thrown error")
+
+        let after = expectation(description: "child still echoes afterwards")
+        after.assertForOverFulfill = false
+        pty.onOutput = { if $0.contains("after") { after.fulfill() } }
+        pty.send(Array("after\n".utf8))
+        wait(for: [after], timeout: 5)
+        pty.terminate()
+    }
+
     func testHost_scanSelectConfirm_drivesKeystrokesAndFinishes() {
         let fake = FakePTY()
         // Large tick interval so the real timer never fires; we step manually.

--- a/macos/Tests/MoInteractiveHostTests.swift
+++ b/macos/Tests/MoInteractiveHostTests.swift
@@ -75,6 +75,56 @@ final class MoInteractiveHostTests: XCTestCase {
         wait(for: [second], timeout: 5)
     }
 
+    /// Regression: a rescan from the chooser terminates a child that is still
+    /// ALIVE, and that child's exit is reported asynchronously — after `launch()`
+    /// has already armed a fresh one. Untagged, the dead child's SIGTERM arrived
+    /// as the new scan's exit, and because the reducer reads an exit-before-any-
+    /// list as "nothing to remove", the rescan collapsed straight to `.done`.
+    /// `/bin/cat` stands in for `mo` at the selection screen: it holds the pty
+    /// open and never exits on its own, so any exit seen here is the old one's.
+    func testPTYTask_relaunchWhileRunning_doesNotReportTheOldChildsExit() {
+        let pty = PTYTask()
+
+        // First child up and running (it echoes, which proves the pty is live).
+        let greeted = expectation(description: "first child is running")
+        // The pty's own line discipline echoes the write and `cat` prints it
+        // back, so "ready" can arrive in one read or two.
+        greeted.assertForOverFulfill = false
+        pty.onOutput = { if $0.contains("ready") { greeted.fulfill() } }
+        try? pty.launch("/bin/cat", [])
+        pty.send(Array("ready\n".utf8))
+        wait(for: [greeted], timeout: 5)
+
+        // Exactly what InstallerView.start() does on Rescan: tear the old child
+        // down and relaunch, synchronously, on main.
+        let stale = expectation(description: "no exit is reported for the new child")
+        stale.isInverted = true
+        pty.onOutput = { _ in }
+        pty.onExit = { _ in stale.fulfill() }
+        pty.terminate()
+        try? pty.launch("/bin/cat", [])
+
+        // The second `cat` is still alive, so a fired onExit can only be the
+        // first child's SIGTERM leaking across the relaunch.
+        wait(for: [stale], timeout: 2)
+        pty.onExit = nil        // the teardown SIGTERM must not fulfil a settled expectation
+        pty.terminate()
+    }
+
+    /// The other half of the same guarantee: retiring the old generation must not
+    /// cost the NEW child its own exit report.
+    func testPTYTask_relaunchWhileRunning_stillReportsTheNewChildsExit() {
+        let pty = PTYTask()
+        pty.onOutput = { _ in }
+        try? pty.launch("/bin/cat", [])
+
+        let exited = expectation(description: "the new child's exit is reported")
+        pty.onExit = { _ in exited.fulfill() }
+        pty.terminate()
+        try? pty.launch("/bin/echo", ["done"])   // prints, then exits → pty EOF
+        wait(for: [exited], timeout: 5)
+    }
+
     func testHost_scanSelectConfirm_drivesKeystrokesAndFinishes() {
         let fake = FakePTY()
         // Large tick interval so the real timer never fires; we step manually.

--- a/macos/Tests/MoInteractiveHostTests.swift
+++ b/macos/Tests/MoInteractiveHostTests.swift
@@ -125,6 +125,23 @@ final class MoInteractiveHostTests: XCTestCase {
         wait(for: [exited], timeout: 5)
     }
 
+    /// A launch that throws must not retire the generation before it. The failed
+    /// launch never spawns anything, so if it took over as the live generation it
+    /// would outrank the child that IS still out there and silently swallow its
+    /// exit — the host would then be waiting on a report that can never arrive.
+    func testPTYTask_failedRelaunch_stillReportsTheOldChildsExit() {
+        let pty = PTYTask()
+        pty.onOutput = { _ in }
+        try? pty.launch("/bin/cat", [])
+
+        let exited = expectation(description: "the old child's exit is still reported")
+        pty.onExit = { _ in exited.fulfill() }
+        pty.terminate()
+        XCTAssertThrowsError(try pty.launch("/nonexistent/mo", []),
+                             "a missing binary must surface as a thrown error")
+        wait(for: [exited], timeout: 5)
+    }
+
     func testHost_scanSelectConfirm_drivesKeystrokesAndFinishes() {
         let fake = FakePTY()
         // Large tick interval so the real timer never fires; we step manually.


### PR DESCRIPTION
## Summary

Fixes #374 (Sentry BURROW-A5): a fatal `NSInvalidArgumentException` (`*** -[NSConcreteTask terminationStatus]: task not launched`) in `PTYTask.launch`.

## Root cause

`Process.isRunning` is `false` for **both** a process that has already exited *and* a process whose `run()` never succeeded (e.g. the `mo` binary is missing or the spawn failed). The EOF branch of the master-fd readability handler used `!proc.isRunning` to decide whether to read `terminationStatus` — so when `run()` threw, the still-armed handler would later fire on EOF, see `isRunning == false`, and call `terminationStatus` on a never-launched child. Foundation raises that as an **uncaught ObjC exception** (not a Swift error you can `try`/catch), crashing the app.

## Fix

- Add a `didLaunch` flag that is set only after `proc.run()` succeeds, and require it before reading `terminationStatus` in the EOF branch.
- On a failed launch, disarm the master-fd read handler and drop the master fd so the armed handler can't fire afterward.

No behavioral change on the success path: the EOF branch still reports the exit itself when the child has already been reaped, and otherwise defers to `terminationHandler`.

## Testing

The pure parsing/planning paths remain covered by `MoInteractiveTests` / `SelectionSessionTests`. `PTYTask` is the intentionally impure PTY seam (per the file header), so this change is verified by reasoning plus a standalone repro: `run()` on a missing binary throws `NSCocoaErrorDomain Code=4` with `isRunning == false`, and reading `terminationStatus` from that never-launched task raises the fatal exception. The exception can't be caught in a unit test, so the guard is the fix rather than a recoverable error path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal process relaunch behavior to prevent previous processes from affecting newly launched sessions.
  * Ensured exit notifications are associated with the correct process after a relaunch.
  * Improved handling of terminal process launch failures.
  * Prevented invalid process status checks when a process was not successfully started.
  * Ensured terminal resources and read handlers are properly cleaned up after launch failures.
  * Preserved the active terminal session when a subsequent launch fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->