### PR TITLE
feat(macos): add privacy-safe cached PostHog feature flags

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -190,6 +190,16 @@ This is the part people rightly scrutinize in cleaners. Burrow's model:
   historical event at a time with bounded backoff, discards permanent HTTP
   rejections, and runs only while telemetry is enabled; an opted-out launch
   does not read it or contact PostHog.
+- **Feature flags are allowlisted, cached, and UI-only.** The only remote
+  flags Burrow ever evaluates are fixed, typed keys in
+  [`macos/Sources/RemoteFeatureFlags.swift`](macos/Sources/RemoteFeatureFlags.swift),
+  restricted to harmless UI/rollout choices — never cleaning/deletion,
+  permissions, security, signing, Sparkle, launch recovery, or telemetry
+  consent. Accepted values are cached locally (bounded size and age) and every
+  missing/stale/malformed value falls back to a conservative baked-in default;
+  evaluation never blocks on the network, and an opted-out launch reads no flag
+  cache and contacts PostHog for none. See
+  **[TELEMETRY.md](TELEMETRY.md)**.
 - **Local launch recovery journal.** Burrow atomically stores a coarse launch
   phase plus app/OS versions under Application Support so it can avoid a
   status-item path that failed on the same macOS build. This local safety file

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -121,11 +121,12 @@ Sparkle verification, launch recovery, or telemetry consent.
   read the cache or contact PostHog.
 - **Fetched on the background queue.** Flags are fetched from PostHog's
   `POST {host}/decide/?v=3` on the private background telemetry queue — never on
-  a main-run-loop timer. The request carries exactly two fields: `token` (the
-  release-injected project key) and `distinct_id` (the random anonymous id
-  described above). Nothing else is sent. Retries are serialized with the same
-  bounded backoff as event delivery and are re-driven by later product events;
-  permanent rejections re-check no sooner than the cache trust window.
+  a main-run-loop timer. The JSON request body contains exactly two fields:
+  `token` (the release-injected project key) and `distinct_id` (the random
+  anonymous id described above). No additional PostHog payload properties are
+  sent. Retries are serialized with the same bounded backoff as event delivery
+  and are re-driven by later product events; permanent rejections re-check no
+  sooner than the cache trust window.
 - **Exposure events.** When a flag actually gates behavior, Burrow records one
   PostHog `$feature_flag_called` event per flag per launch with
   `$feature_flag` (the allowlisted key) and `$feature_flag_response` (the typed

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -88,8 +88,9 @@ own project instead.
 
 Burrow's first-party client attaches no hidden SDK context. It additionally
 sends fixed PostHog protocol fields: `$ip: "0"`, `$lib: "burrow-macos"`,
-`$lib_version`, and `$process_person_profile: false`. A later feature-flag
-rollout will be separately reviewed and will use cached, conservative defaults.
+`$lib_version`, and `$process_person_profile: false`. Feature flags are cached,
+telemetry-gated, and restricted to non-safety-critical UI/rollout choices — see
+[Feature flags](#feature-flags).
 
 **IP address:** as with any HTTPS request, the TCP connection still exposes
 your IP to the receiving service at the network layer, but neither pipeline
@@ -97,6 +98,44 @@ stores it as event data. PostHog events carry `$ip = "0"`, so PostHog records
 no IP and derives no GeoIP; the project additionally has **"Discard client IP
 data"** enabled (defence in depth). Sentry runs with `sendDefaultPii = false`,
 so no IP is attached to events either.
+
+## Feature flags
+
+Burrow evaluates a **fixed allowlist** of PostHog feature flags for gradual
+rollout and product/UI experiments. Flags are deliberately restricted to
+harmless, non-safety-critical choices; they are **never** used for
+cleaning/deletion behavior, permissions, security controls, signing/notarization,
+Sparkle verification, launch recovery, or telemetry consent.
+
+- **Allowlisted and typed.** The only keys Burrow accepts are listed in
+  `RemoteFeatureFlags.Key` (client code:
+  [`macos/Sources/RemoteFeatureFlags.swift`](macos/Sources/RemoteFeatureFlags.swift)).
+  Anything PostHog returns that is not in the allowlist — or that decodes to the
+  wrong type — is ignored. Accepted value shapes are `bool`, `string`, and `int`
+  only.
+- **Cached and startup-independent.** The last accepted values are cached at
+  `~/Library/Application Support/Burrow/feature-flags.json` (bounded to 8 KB and
+  a 24-hour trust window). Evaluation reads only that in-memory cache and never
+  blocks on the network; every missing, stale, malformed, or future-dated value
+  falls back to a baked-in conservative default. An opted-out launch does not
+  read the cache or contact PostHog.
+- **Fetched on the background queue.** Flags are fetched from PostHog's
+  `POST {host}/decide/?v=3` on the private background telemetry queue — never on
+  a main-run-loop timer. The request carries exactly two fields: `token` (the
+  release-injected project key) and `distinct_id` (the random anonymous id
+  described above). Nothing else is sent. Retries are serialized with the same
+  bounded backoff as event delivery and are re-driven by later product events;
+  permanent rejections re-check no sooner than the cache trust window.
+- **Exposure events.** When a flag actually gates behavior, Burrow records one
+  PostHog `$feature_flag_called` event per flag per launch with
+  `$feature_flag` (the allowlisted key) and `$feature_flag_response` (the typed
+  value). No user content or arbitrary properties are attached.
+
+### Flag keys
+
+| Key | Type | Conservative default | Purpose |
+|---|---|---|---|
+| `tune_up_badge` | `bool` | `false` | A cosmetic badge on the Tune-Up section (UI-only; the rollout validation target) |
 
 ## Events
 
@@ -109,6 +148,7 @@ so no IP is attached to events either.
 | `engine_missing`, `install_window_ready`, `onboarding_completed` | none |
 | `telemetry_opt_in_changed` | enabled boolean |
 | PostHog `$screen` | fixed name: `home`, `settings`, or `tool.<known tool>` |
+| PostHog `$feature_flag_called` | `$feature_flag` (allowlisted key) and `$feature_flag_response` (typed value); once per flag per launch |
 | `feature_operation_started`, `feature_operation_completed` | `clean`/`optimize`, dry-run/elevated booleans, fixed result, bucketed duration |
 | `previous_launch_incomplete` | previous phase, app version/build, OS build, bucketed elapsed time |
 | `compatibility_fallback_activated`, `compatibility_fallback_reaffirmed` | fixed reason, OS build, menu-bar mode |
@@ -185,9 +225,7 @@ All of that disk work runs on the background telemetry queue.
 ### Deliberately deferred
 
 `fda_state`, uninstall/purge detail, and MCP subprocess events are not wired.
-PostHog feature flags are also deferred to a separate change so flags can be
-cached, telemetry-gated, and restricted to non-safety-critical UI/rollout
-choices. Burrow will not build a custom pixel recorder for macOS.
+Burrow will not build a custom pixel recorder for macOS.
 
 ## Turning it off
 

--- a/macos/Sources/HomeView.swift
+++ b/macos/Sources/HomeView.swift
@@ -32,6 +32,7 @@ struct HomeView: View {
 
     @State private var section: Section = .overview
     @State private var showExplain = false
+    @ObservedObject private var featureFlags = FeatureFlags.shared
 
     var body: some View {
         VStack(spacing: 0) {
@@ -63,7 +64,7 @@ struct HomeView: View {
                 Button { withAnimation(.easeOut(duration: 0.14)) { section = s } } label: {
                     HStack(spacing: 5) {
                         Text(NSLocalizedString(s.rawValue, comment: ""))
-                        if s == .tuneup, Telemetry.featureFlagBool(.tuneUpBadge) {
+                        if s == .tuneup, featureFlags.boolValue(.tuneUpBadge) {
                             Circle()
                                 .fill(Tool.tuneup.accent)
                                 .frame(width: 6, height: 6)

--- a/macos/Sources/HomeView.swift
+++ b/macos/Sources/HomeView.swift
@@ -61,12 +61,19 @@ struct HomeView: View {
             ForEach(Section.allCases) { s in
                 let on = s == section
                 Button { withAnimation(.easeOut(duration: 0.14)) { section = s } } label: {
-                    Text(NSLocalizedString(s.rawValue, comment: ""))
-                        .font(Brand.mono(12, on ? .semibold : .regular))
-                        .foregroundStyle(on ? Brand.base : Brand.textSecondary)
-                        .padding(.horizontal, 12).padding(.vertical, 5)
-                        .background { if on { Capsule().fill(Brand.textPrimary) } }
-                        .contentShape(Capsule())
+                    HStack(spacing: 5) {
+                        Text(NSLocalizedString(s.rawValue, comment: ""))
+                        if s == .tuneup, Telemetry.featureFlagBool(.tuneUpBadge) {
+                            Circle()
+                                .fill(Tool.tuneup.accent)
+                                .frame(width: 6, height: 6)
+                        }
+                    }
+                    .font(Brand.mono(12, on ? .semibold : .regular))
+                    .foregroundStyle(on ? Brand.base : Brand.textSecondary)
+                    .padding(.horizontal, 12).padding(.vertical, 5)
+                    .background { if on { Capsule().fill(Brand.textPrimary) } }
+                    .contentShape(Capsule())
                 }
                 .buttonStyle(.plain)
             }

--- a/macos/Sources/RemoteFeatureFlags.swift
+++ b/macos/Sources/RemoteFeatureFlags.swift
@@ -225,15 +225,14 @@ enum RemoteFeatureFlags {
     }
 
     /// Accept only an integral JSON number — never a Boolean (`true`/`false`
-    /// box as `NSNumber`) or a fractional double.
-    private static func integerValue(_ object: Any) -> Int? {
+    /// box as `NSNumber`) or a fractional/out-of-range double. `Int(exactly:)`
+    /// returns `nil` for fractional and out-of-range values, so `2^63`
+    /// (`Double(Int.max)` rounds up to it) cannot trap.
+    static func integerValue(_ object: Any) -> Int? {
         if object is Bool { return nil }
         if let value = object as? Int { return value }
         if let value = object as? Int64 { return Int(exactly: value) }
-        if let value = object as? Double, value.isFinite, value == value.rounded() {
-            guard value >= Double(Int.min), value <= Double(Int.max) else { return nil }
-            return Int(value)
-        }
+        if let value = object as? Double { return Int(exactly: value) }
         return nil
     }
 }

--- a/macos/Sources/RemoteFeatureFlags.swift
+++ b/macos/Sources/RemoteFeatureFlags.swift
@@ -1,0 +1,239 @@
+//
+//  RemoteFeatureFlags.swift
+//  Burrow
+//
+//  Privacy-safe, cached PostHog feature flags for gradual rollout and
+//  product/UI experiments. Only an explicit allowlist of fixed, non-safety-
+//  critical keys is ever accepted; every value is typed, locally cached, and
+//  backed by a conservative baked-in default so startup and evaluation never
+//  depend on PostHog availability.
+//
+//  This file is pure policy: parsing, typing, allowlisting, cache encode/decode,
+//  and evaluation. `Telemetry.swift` owns the queue, network request, storage,
+//  opt-out gating, and exposure events, and only ever hands this type decoded,
+//  bounded JSON.
+//
+
+import Foundation
+
+enum RemoteFeatureFlags {
+
+    // MARK: - Allowlist
+
+    /// The only remote flag keys Burrow will ever accept. Keys are fixed,
+    /// documented in TELEMETRY.md, and restricted to harmless UI/rollout
+    /// choices. PostHog may return anything; anything not listed here is
+    /// ignored.
+    enum Key: String, CaseIterable, Codable {
+        /// A cosmetic badge on the Tune-Up section. Harmless, UI-only, off by
+        /// default — the first rollout validation target.
+        case tuneUpBadge = "tune_up_badge"
+
+        /// The remote value shape this key accepts. A value that decodes to a
+        /// different shape is treated as malformed and dropped.
+        var expectedType: ValueType {
+            switch self {
+            case .tuneUpBadge: return .bool
+            }
+        }
+
+        /// Conservative baked-in default, returned whenever the remote value is
+        /// absent, stale, malformed, or the network is unreachable.
+        var defaultValue: Value {
+            switch self {
+            case .tuneUpBadge: return .bool(false)
+            }
+        }
+    }
+
+    enum ValueType: String, Codable, Equatable {
+        case bool
+        case string
+        case int
+    }
+
+    /// A decoded, typed flag value. Only these three shapes are accepted.
+    enum Value: Equatable {
+        case bool(Bool)
+        case string(String)
+        case int(Int)
+    }
+
+    // MARK: - Cache format
+
+    /// The on-disk cache. Bounded in size and age; only values that passed the
+    /// allowlist and type checks are ever written, so `evaluate` looks up only
+    /// allowlisted keys regardless of what a hand-edited file contains.
+    struct Snapshot: Codable, Equatable {
+        static let empty = Snapshot(fetchedAt: .distantPast, bools: [:], strings: [:], ints: [:])
+
+        var fetchedAt: Date
+        var bools: [String: Bool]
+        var strings: [String: String]
+        var ints: [String: Int]
+
+        var isEmpty: Bool { bools.isEmpty && strings.isEmpty && ints.isEmpty }
+    }
+
+    /// A cached snapshot stays trusted this long. Older snapshots fall back to
+    /// defaults until a fresh fetch succeeds.
+    static let maxCacheAge: TimeInterval = 24 * 60 * 60
+
+    /// Hard ceiling on the encoded cache size. The allowlist is tiny and values
+    /// are primitive, so a well-formed cache never approaches this; the bound
+    /// stops a corrupted file from growing unbounded.
+    static let maxCacheBytes = 8 * 1_024
+
+    // MARK: - Decide-response parsing
+
+    /// Extract the allowlisted, typed values from a PostHog `/decide/` response
+    /// body (already decoded to JSON). Unknown keys, wrong-typed values, and
+    /// malformed payloads are ignored; the returned snapshot contains only
+    /// values that passed every check.
+    ///
+    /// PostHog returns `featureFlags` as an array of enabled keys (legacy) or
+    /// as an object mapping key → `Bool`/variant `String`, plus an optional
+    /// `featureFlagPayloads` object mapping key → JSON-encoded payload string.
+    static func snapshot(from decideObject: [String: Any], now: Date) -> Snapshot {
+        var bools: [String: Bool] = [:]
+        var strings: [String: String] = [:]
+        var ints: [String: Int] = [:]
+
+        let flagField = decideObject["featureFlags"]
+        let payloads = decideObject["featureFlagPayloads"] as? [String: String] ?? [:]
+
+        for key in Key.allCases {
+            // 1. A payload, when present, is the source of truth for the value.
+            if let rawPayload = payloads[key.rawValue],
+               let value = decodedValue(fromPayload: rawPayload, expected: key.expectedType) {
+                store(value, for: key, bools: &bools, strings: &strings, ints: &ints)
+                continue
+            }
+            // 2. Otherwise fall back to the flag's enable/variant state.
+            guard let remote = flagValue(named: key.rawValue, in: flagField) else { continue }
+            if let value = typedValue(fromFlagValue: remote, expected: key.expectedType) {
+                store(value, for: key, bools: &bools, strings: &strings, ints: &ints)
+            }
+        }
+
+        return Snapshot(fetchedAt: now, bools: bools, strings: strings, ints: ints)
+    }
+
+    // MARK: - Cache encode/decode
+
+    /// Encode a snapshot for the on-disk cache, or `nil` if it would exceed the
+    /// size bound (callers then simply keep the previous cache).
+    static func encodedSnapshot(_ snapshot: Snapshot) -> Data? {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return nil }
+        guard data.count <= maxCacheBytes else { return nil }
+        return data
+    }
+
+    /// Decode a cache file, or `nil` if it is oversized, unreadable, or empty.
+    static func decodeSnapshot(_ data: Data) -> Snapshot? {
+        guard data.count <= maxCacheBytes,
+              let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data),
+              !snapshot.isEmpty else { return nil }
+        return snapshot
+    }
+
+    /// Whether a snapshot is still within its trust window. Future-dated or
+    /// empty snapshots are stale so a clock-skewed file falls back to defaults.
+    static func isFresh(_ snapshot: Snapshot, now: Date, maxAge: TimeInterval = maxCacheAge) -> Bool {
+        guard !snapshot.isEmpty else { return false }
+        let age = now.timeIntervalSince(snapshot.fetchedAt)
+        return age >= 0 && age <= maxAge
+    }
+
+    // MARK: - Evaluation
+
+    /// The effective value for a key: the fresh cached value when one exists,
+    /// otherwise the baked-in conservative default. Synchronous and pure — never
+    /// touches the network. An opted-out process passes no snapshot (or an
+    /// empty one) and therefore always receives the default.
+    static func evaluate(_ key: Key, snapshot: Snapshot?, now: Date = Date()) -> Value {
+        guard let snapshot, isFresh(snapshot, now: now) else { return key.defaultValue }
+        switch key.expectedType {
+        case .bool:
+            if let value = snapshot.bools[key.rawValue] { return .bool(value) }
+        case .string:
+            if let value = snapshot.strings[key.rawValue] { return .string(value) }
+        case .int:
+            if let value = snapshot.ints[key.rawValue] { return .int(value) }
+        }
+        return key.defaultValue
+    }
+
+    // MARK: - Private parsing helpers
+
+    private static func store(
+        _ value: Value,
+        for key: Key,
+        bools: inout [String: Bool],
+        strings: inout [String: String],
+        ints: inout [String: Int]
+    ) {
+        switch value {
+        case .bool(let v): bools[key.rawValue] = v
+        case .string(let v): strings[key.rawValue] = v
+        case .int(let v): ints[key.rawValue] = v
+        }
+    }
+
+    private static func flagValue(named key: String, in flagField: Any?) -> Any? {
+        if let array = flagField as? [String] {
+            return array.contains(key) ? true : nil
+        }
+        if let object = flagField as? [String: Any] {
+            return object[key]
+        }
+        return nil
+    }
+
+    private static func decodedValue(fromPayload raw: String, expected: ValueType) -> Value? {
+        guard let data = raw.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(
+                  with: data,
+                  options: [.fragmentsAllowed]
+              ) else { return nil }
+        return typedValue(object, expected: expected)
+    }
+
+    private static func typedValue(fromFlagValue remote: Any, expected: ValueType) -> Value? {
+        switch expected {
+        case .int:
+            // A bare enable/variant state carries no number; ints come only from
+            // JSON payloads.
+            return nil
+        case .bool, .string:
+            return typedValue(remote, expected: expected)
+        }
+    }
+
+    private static func typedValue(_ object: Any, expected: ValueType) -> Value? {
+        switch expected {
+        case .bool:
+            guard let value = object as? Bool else { return nil }
+            return .bool(value)
+        case .string:
+            guard let value = object as? String else { return nil }
+            return .string(value)
+        case .int:
+            guard let value = integerValue(object) else { return nil }
+            return .int(value)
+        }
+    }
+
+    /// Accept only an integral JSON number — never a Boolean (`true`/`false`
+    /// box as `NSNumber`) or a fractional double.
+    private static func integerValue(_ object: Any) -> Int? {
+        if object is Bool { return nil }
+        if let value = object as? Int { return value }
+        if let value = object as? Int64 { return Int(exactly: value) }
+        if let value = object as? Double, value.isFinite, value == value.rounded() {
+            guard value >= Double(Int.min), value <= Double(Int.max) else { return nil }
+            return Int(value)
+        }
+        return nil
+    }
+}

--- a/macos/Sources/Telemetry.swift
+++ b/macos/Sources/Telemetry.swift
@@ -63,6 +63,16 @@ enum Telemetry {
     private static var nextOutboxRetryAt = Date.distantPast
     private static let outboxLimit = 64
 
+    /// In-memory accepted flag values; the source of truth for evaluation.
+    /// Written on `workQueue`, read anywhere under `stateLock`.
+    private static var flagSnapshot = RemoteFeatureFlags.Snapshot.empty
+    /// Accessed only on `workQueue`.
+    private static var flagFetchInFlight = false
+    private static var flagFetchFailures = 0
+    private static var nextFlagFetchAt = Date.distantPast
+    /// Flag keys already exposed this launch. Guarded by `stateLock`.
+    private static var exposedFlagKeys: Set<String> = []
+
     /// The single persisted gate shared with Sentry.
     static var isEnabled: Bool {
         get { Store.telemetryEnabled }
@@ -99,6 +109,8 @@ enum Telemetry {
         guard let delivery, isEnabled else { return }
         CrashReporter.breadcrumb("app_opened", category: "lifecycle")
         enqueue(.event("app_opened", ["cold_start": true]), using: delivery)
+        reloadFeatureFlagCache()
+        refreshFeatureFlags(using: delivery)
     }
 
     /// Best-effort termination flush. Every event has already started its own
@@ -161,12 +173,186 @@ enum Telemetry {
 
         if enabled {
             capture("telemetry_opt_in_changed", ["enabled": true])
+            reloadFeatureFlagCache()
+            refreshFeatureFlags(using: delivery)
         } else {
             workQueue.async {
                 cancelInFlightDeliveries()
+                clearFeatureFlagState()
                 sendNow(.event("telemetry_opt_in_changed", ["enabled": false]), using: delivery)
             }
         }
+    }
+
+    // MARK: - Feature flags (cached, conservative, UI-only)
+
+    /// Current effective value for an allowlisted flag: the fresh cached value
+    /// or the baked-in conservative default. Synchronous and pure — it never
+    /// touches the network or disk. With telemetry off the snapshot is empty,
+    /// so callers always get the default and no exposure is recorded.
+    static func featureFlagValue(for key: RemoteFeatureFlags.Key) -> RemoteFeatureFlags.Value {
+        let snapshot = currentFlagSnapshot()
+        let value = RemoteFeatureFlags.evaluate(key, snapshot: snapshot, now: Date())
+        reportFeatureFlagExposure(key, value: value)
+        return value
+    }
+
+    static func featureFlagBool(_ key: RemoteFeatureFlags.Key) -> Bool {
+        switch featureFlagValue(for: key) {
+        case .bool(let value): return value
+        default: return false
+        }
+    }
+
+    /// Reads the on-disk flag cache into memory once per launch, only while
+    /// telemetry is enabled. An opted-out launch never reaches here.
+    private static func reloadFeatureFlagCache() {
+        workQueue.async {
+            guard isEnabled, currentFlagSnapshot().isEmpty else { return }
+            guard let url = featureFlagCacheURL(),
+                  let data = try? Data(contentsOf: url),
+                  let snapshot = RemoteFeatureFlags.decodeSnapshot(data) else { return }
+            setFlagSnapshot(snapshot)
+        }
+    }
+
+    /// Work-queue entry point: fetch flags once with serialized/backed-off
+    /// retries driven by later product events — never a run-loop timer.
+    private static func refreshFeatureFlags(using delivery: DeliveryConfiguration) {
+        workQueue.async { refreshFeatureFlagsIfDue(using: delivery) }
+    }
+
+    private static func refreshFeatureFlagsIfDue(using delivery: DeliveryConfiguration) {
+        guard isEnabled, !flagFetchInFlight, Date() >= nextFlagFetchAt else { return }
+        guard let request = featureFlagRequest(using: delivery) else { return }
+        flagFetchInFlight = true
+
+        deliveries.enter()
+        let task = session.dataTask(with: request) { data, response, error in
+            let status = (response as? HTTPURLResponse)?.statusCode
+            let disposition = deliveryDisposition(statusCode: status, hasTransportError: error != nil)
+            workQueue.async {
+                flagFetchInFlight = false
+                defer { deliveries.leave() }
+
+                switch disposition {
+                case .delivered:
+                    flagFetchFailures = 0
+                    nextFlagFetchAt = .distantPast
+                    guard let data,
+                          let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                    else { return }
+                    let snapshot = RemoteFeatureFlags.snapshot(from: object, now: Date())
+                    persistFeatureFlagSnapshot(snapshot)
+                    setFlagSnapshot(snapshot)
+                case .retry:
+                    flagFetchFailures += 1
+                    nextFlagFetchAt = Date().addingTimeInterval(
+                        retryDelay(afterFailure: flagFetchFailures)
+                    )
+                case .discard:
+                    // A permanent rejection cannot be usefully retried; re-check
+                    // no sooner than the cache's own trust window.
+                    nextFlagFetchAt = Date().addingTimeInterval(RemoteFeatureFlags.maxCacheAge)
+                }
+            }
+        }
+        task.resume()
+    }
+
+    private static func featureFlagRequest(using delivery: DeliveryConfiguration) -> URLRequest? {
+        guard let endpoint = decideEndpoint(from: delivery.endpoint) else { return nil }
+        // The only fields ever sent: the release-injected project key and the
+        // random anonymous distinct id. No user content, no arbitrary properties.
+        let payload: [String: Any] = [
+            "token": delivery.projectKey,
+            "distinct_id": resolveDistinctID(projectKey: delivery.projectKey),
+        ]
+        guard JSONSerialization.isValidJSONObject(payload),
+              let body = try? JSONSerialization.data(withJSONObject: payload) else { return nil }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 10
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        request.setValue("Burrow/\(RuntimeEnvironment.current.appVersion)", forHTTPHeaderField: "User-Agent")
+        request.httpBody = body
+        return request
+    }
+
+    /// `/decide/` lives beside `/batch/` under the same host root.
+    static func decideEndpoint(from batchEndpoint: URL) -> URL? {
+        let base = batchEndpoint.deletingLastPathComponent()
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
+        let basePath = components.path.hasSuffix("/") ? components.path : components.path + "/"
+        components.path = basePath + "decide"
+        components.queryItems = [URLQueryItem(name: "v", value: "3")]
+        return components.url
+    }
+
+    private static func persistFeatureFlagSnapshot(_ snapshot: RemoteFeatureFlags.Snapshot) {
+        guard let url = featureFlagCacheURL(),
+              let data = RemoteFeatureFlags.encodedSnapshot(snapshot) else { return }
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? data.write(to: url, options: .atomic)
+    }
+
+    private static func featureFlagCacheURL() -> URL? {
+        applicationSupportDirectory()?.appendingPathComponent("feature-flags.json")
+    }
+
+    /// Records a PostHog `$feature_flag_called` exposure once per flag per
+    /// launch, only while telemetry is enabled. The response is the typed,
+    /// allowlisted value — never user content.
+    private static func reportFeatureFlagExposure(
+        _ key: RemoteFeatureFlags.Key,
+        value: RemoteFeatureFlags.Value
+    ) {
+        stateLock.lock()
+        let isNew = !exposedFlagKeys.contains(key.rawValue)
+        if isNew { exposedFlagKeys.insert(key.rawValue) }
+        let delivery = deliveryConfiguration
+        let enabled = started && isEnabled
+        stateLock.unlock()
+
+        guard isNew, enabled, let delivery else { return }
+
+        let response: Any
+        switch value {
+        case .bool(let v): response = v
+        case .int(let v): response = v
+        case .string(let v): response = DiagnosticPrivacy.redact(v)
+        }
+        enqueue(.event("$feature_flag_called", [
+            "$feature_flag": key.rawValue,
+            "$feature_flag_response": response,
+        ]), using: delivery)
+    }
+
+    private static func currentFlagSnapshot() -> RemoteFeatureFlags.Snapshot {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return flagSnapshot
+    }
+
+    private static func setFlagSnapshot(_ snapshot: RemoteFeatureFlags.Snapshot) {
+        stateLock.lock()
+        flagSnapshot = snapshot
+        stateLock.unlock()
+    }
+
+    private static func clearFeatureFlagState() {
+        stateLock.lock()
+        flagSnapshot = .empty
+        exposedFlagKeys.removeAll()
+        stateLock.unlock()
+        flagFetchInFlight = false
+        flagFetchFailures = 0
+        nextFlagFetchAt = .distantPast
     }
 
     // MARK: - Bucketing (never send raw sizes/counts/durations)
@@ -225,6 +411,7 @@ enum Telemetry {
             // the user flips the switch off.
             guard isEnabled else { return }
             drainOutbox(using: delivery)
+            refreshFeatureFlagsIfDue(using: delivery)
             sendNow(signal, using: delivery)
         }
     }

--- a/macos/Sources/Telemetry.swift
+++ b/macos/Sources/Telemetry.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import Combine
 
 enum Telemetry {
 
@@ -227,13 +228,19 @@ enum Telemetry {
         guard let request = featureFlagRequest(using: delivery) else { return }
         flagFetchInFlight = true
 
+        let requestID = UUID()
         deliveries.enter()
         let task = session.dataTask(with: request) { data, response, error in
             let status = (response as? HTTPURLResponse)?.statusCode
             let disposition = deliveryDisposition(statusCode: status, hasTransportError: error != nil)
             workQueue.async {
+                inFlightTasks.removeValue(forKey: requestID)
                 flagFetchInFlight = false
                 defer { deliveries.leave() }
+
+                // A mid-session opt-out must not be overwritten by a request
+                // that was already in flight when the user flipped the switch.
+                guard isEnabled else { return }
 
                 switch disposition {
                 case .delivered:
@@ -253,10 +260,12 @@ enum Telemetry {
                 case .discard:
                     // A permanent rejection cannot be usefully retried; re-check
                     // no sooner than the cache's own trust window.
+                    flagFetchFailures = 0
                     nextFlagFetchAt = Date().addingTimeInterval(RemoteFeatureFlags.maxCacheAge)
                 }
             }
         }
+        inFlightTasks[requestID] = task
         task.resume()
     }
 
@@ -343,6 +352,7 @@ enum Telemetry {
         stateLock.lock()
         flagSnapshot = snapshot
         stateLock.unlock()
+        publishFlagSnapshot(snapshot)
     }
 
     private static func clearFeatureFlagState() {
@@ -353,6 +363,13 @@ enum Telemetry {
         flagFetchInFlight = false
         flagFetchFailures = 0
         nextFlagFetchAt = .distantPast
+        publishFlagSnapshot(.empty)
+    }
+
+    /// Mirrors the evaluation snapshot to the SwiftUI-observable holder on the
+    /// main thread so views re-render when a background refresh lands.
+    private static func publishFlagSnapshot(_ snapshot: RemoteFeatureFlags.Snapshot) {
+        DispatchQueue.main.async { FeatureFlags.shared.update(snapshot) }
     }
 
     // MARK: - Bucketing (never send raw sizes/counts/durations)
@@ -726,5 +743,26 @@ enum Telemetry {
             for: .applicationSupportDirectory,
             in: .userDomainMask
         ).first
+    }
+}
+
+/// SwiftUI-observable holder for the accepted flag snapshot. Telemetry mirrors
+/// every snapshot change here on the main thread (see `publishFlagSnapshot`);
+/// views observe the shared instance so a background refresh re-renders them
+/// instead of leaving a static flag read stale.
+final class FeatureFlags: ObservableObject {
+    static let shared = FeatureFlags()
+
+    @Published private(set) var snapshot: RemoteFeatureFlags.Snapshot = .empty
+
+    func update(_ snapshot: RemoteFeatureFlags.Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    /// Evaluates `key` and records its exposure via `Telemetry`, while reading
+    /// `snapshot` so the calling view also re-renders when the cache refreshes.
+    func boolValue(_ key: RemoteFeatureFlags.Key) -> Bool {
+        _ = snapshot
+        return Telemetry.featureFlagBool(key)
     }
 }

--- a/macos/Tests/RemoteFeatureFlagsTests.swift
+++ b/macos/Tests/RemoteFeatureFlagsTests.swift
@@ -1,0 +1,193 @@
+//
+//  RemoteFeatureFlagsTests.swift
+//  BurrowTests
+//
+//  Policy tests for the privacy-safe, cached PostHog feature flags. The pure
+//  parsing/evaluation logic lives in RemoteFeatureFlags; Telemetry owns the
+//  queue, network, storage, and opt-out gating.
+//
+
+import XCTest
+@testable import Burrow
+
+final class RemoteFeatureFlagsTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Conservative defaults
+
+    func testEveryKeyHasAConservativeDefault() {
+        for key in RemoteFeatureFlags.Key.allCases {
+            // Every allowlisted key must declare a default; evaluate with no
+            // snapshot must return exactly that default.
+            XCTAssertEqual(
+                RemoteFeatureFlags.evaluate(key, snapshot: nil, now: now),
+                key.defaultValue
+            )
+        }
+        XCTAssertEqual(RemoteFeatureFlags.Key.tuneUpBadge.defaultValue, .bool(false))
+    }
+
+    // MARK: - Opt-out / no-snapshot inertness
+
+    func testEvaluationWithoutSnapshotReturnsDefault() {
+        XCTAssertEqual(
+            RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: nil, now: now),
+            .bool(false)
+        )
+        XCTAssertEqual(
+            RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: .empty, now: now),
+            .bool(false)
+        )
+    }
+
+    // MARK: - Stale cache
+
+    func testStaleSnapshotFallsBackToDefault() {
+        let fresh = RemoteFeatureFlags.Snapshot(
+            fetchedAt: now.addingTimeInterval(-60),
+            bools: ["tune_up_badge": true],
+            strings: [:],
+            ints: [:]
+        )
+        XCTAssertEqual(RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: fresh, now: now), .bool(true))
+
+        let stale = RemoteFeatureFlags.Snapshot(
+            fetchedAt: now.addingTimeInterval(-(RemoteFeatureFlags.maxCacheAge + 1)),
+            bools: ["tune_up_badge": true],
+            strings: [:],
+            ints: [:]
+        )
+        XCTAssertEqual(RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: stale, now: now), .bool(false))
+    }
+
+    func testFutureDatedSnapshotIsStale() {
+        let future = RemoteFeatureFlags.Snapshot(
+            fetchedAt: now.addingTimeInterval(60),
+            bools: ["tune_up_badge": true],
+            strings: [:],
+            ints: [:]
+        )
+        XCTAssertFalse(RemoteFeatureFlags.isFresh(future, now: now))
+        XCTAssertEqual(RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: future, now: now), .bool(false))
+    }
+
+    // MARK: - Malformed cache
+
+    func testMalformedCacheIsRejected() {
+        XCTAssertNil(RemoteFeatureFlags.decodeSnapshot(Data("not json".utf8)))
+        XCTAssertNil(RemoteFeatureFlags.decodeSnapshot(Data("{".utf8)))
+
+        // Oversized cache is rejected.
+        let oversized = Data(repeating: 0x61, count: RemoteFeatureFlags.maxCacheBytes + 1)
+        XCTAssertNil(RemoteFeatureFlags.decodeSnapshot(oversized))
+    }
+
+    func testEmptyCacheIsRejected() throws {
+        let empty = RemoteFeatureFlags.Snapshot.empty
+        let data = try XCTUnwrap(RemoteFeatureFlags.encodedSnapshot(empty))
+        XCTAssertNil(RemoteFeatureFlags.decodeSnapshot(data))
+    }
+
+    func testCacheRoundTripPreservesValues() throws {
+        let snapshot = RemoteFeatureFlags.Snapshot(
+            fetchedAt: now,
+            bools: ["tune_up_badge": true],
+            strings: ["some_future_flag": "variant"],
+            ints: ["some_int_flag": 7]
+        )
+        let data = try XCTUnwrap(RemoteFeatureFlags.encodedSnapshot(snapshot))
+        XCTAssertEqual(RemoteFeatureFlags.decodeSnapshot(data), snapshot)
+    }
+
+    // MARK: - Allowlist / unknown keys
+
+    func testUnknownKeysAreIgnored() {
+        let object: [String: Any] = [
+            "featureFlags": [
+                "tune_up_badge": true,
+                "some_unknown_flag": true,
+                "another_flag": "variant",
+            ],
+        ]
+        let snapshot = RemoteFeatureFlags.snapshot(from: object, now: now)
+        XCTAssertEqual(snapshot.bools, ["tune_up_badge": true])
+        XCTAssertTrue(snapshot.strings.isEmpty)
+        XCTAssertTrue(snapshot.ints.isEmpty)
+    }
+
+    func testLegacyArrayFlagFormatIsAccepted() {
+        let object: [String: Any] = [
+            "featureFlags": ["tune_up_badge", "some_unknown_flag"],
+        ]
+        let snapshot = RemoteFeatureFlags.snapshot(from: object, now: now)
+        XCTAssertEqual(snapshot.bools, ["tune_up_badge": true])
+    }
+
+    // MARK: - Typed values
+
+    func testWrongTypedFlagValueIsDropped() {
+        // A variant string is not a valid bool, so it must not be stored.
+        let object: [String: Any] = [
+            "featureFlags": ["tune_up_badge": "control"],
+        ]
+        let snapshot = RemoteFeatureFlags.snapshot(from: object, now: now)
+        XCTAssertTrue(snapshot.bools.isEmpty)
+        XCTAssertEqual(RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: snapshot, now: now), .bool(false))
+    }
+
+    func testMalformedPayloadIsDropped() {
+        let object: [String: Any] = [
+            "featureFlags": ["tune_up_badge": true],
+            "featureFlagPayloads": ["tune_up_badge": "not-json"],
+        ]
+        let snapshot = RemoteFeatureFlags.snapshot(from: object, now: now)
+        // Payload was malformed, so fall back to the enable flag value.
+        XCTAssertEqual(snapshot.bools, ["tune_up_badge": true])
+    }
+
+    func testBoolPayloadIsAcceptedAndOverridesEnableState() {
+        let object: [String: Any] = [
+            "featureFlags": ["tune_up_badge": false],
+            "featureFlagPayloads": ["tune_up_badge": "true"],
+        ]
+        let snapshot = RemoteFeatureFlags.snapshot(from: object, now: now)
+        // Payload is the source of truth over the enable flag value.
+        XCTAssertEqual(snapshot.bools, ["tune_up_badge": true])
+    }
+
+    func testFragmentPayloadsParse() {
+        // Payloads are JSON fragments (bare values), not just objects.
+        let object: [String: Any] = [
+            "featureFlagPayloads": [
+                "tune_up_badge": "false",
+            ],
+        ]
+        let snapshot = RemoteFeatureFlags.snapshot(from: object, now: now)
+        XCTAssertEqual(snapshot.bools, ["tune_up_badge": false])
+    }
+
+    // MARK: - Network-failure behaviour (no snapshot)
+
+    func testNetworkFailureMeansDefaults() {
+        // A failed fetch leaves the snapshot empty; evaluation must not block
+        // and must return the conservative default.
+        XCTAssertEqual(
+            RemoteFeatureFlags.evaluate(.tuneUpBadge, snapshot: .empty, now: now),
+            .bool(false)
+        )
+    }
+
+    // MARK: - Decide endpoint
+
+    func testDecideEndpointMapsBesideBatchEndpoint() {
+        XCTAssertEqual(
+            Telemetry.decideEndpoint(from: URL(string: "https://us.i.posthog.com/batch")!)?.absoluteString,
+            "https://us.i.posthog.com/decide?v=3"
+        )
+        XCTAssertEqual(
+            Telemetry.decideEndpoint(from: URL(string: "https://example.com/path/batch")!)?.absoluteString,
+            "https://example.com/path/decide?v=3"
+        )
+    }
+}


### PR DESCRIPTION
Follow-up to #321, implementing the scope in #322: Burrow's PostHog integration deliberately dropped the SDK's remote-config path, so feature flags come back only now that they have a separately reviewed privacy and failure model.

## What changed

- **`RemoteFeatureFlags.swift` (new, pure policy)** — a fixed allowlist of typed keys (`bool` / `string` / `int`), conservative baked-in defaults, a bounded size/age cache format, and `/decide/` response parsing that ignores unknown keys, wrong types, and malformed payloads.
- **`Telemetry.swift`** — fetches `POST /decide/?v=3` on the existing private background telemetry queue (no main-run-loop timer), sending exactly `token` (release key) + `distinct_id` (random anonymous id). Retries are serialized with the same bounded backoff and re-driven by later product events; a permanent rejection re-checks no sooner than the cache trust window.
- **Opt-out gate** — everything is behind `Store.telemetryEnabled`: an opted-out launch reads no flag cache and contacts PostHog for none; opting out mid-session clears the in-memory snapshot immediately.
- **Exposure events** — one fixed-name `$feature_flag_called` per flag per launch, carrying only the allowlisted key and the typed response (strings redacted).
- **One harmless UI-only flag** — `tune_up_badge` (default `false`) shows a cosmetic dot on the Tune-Up section, as the rollout validation target.
- **Docs** — `TELEMETRY.md` and `SECURITY.md` now document the exact request fields, cache, flag keys, defaults, and exposure events.

## Guardrails honored

Flags are never used for cleaning/deletion, permissions, security controls, signing/notarization, Sparkle verification, launch recovery, or telemetry consent. No session replay, screenshots, autocapture, element trees, logs, or new instrumentation. Only allowlisted keys and typed values are accepted; everything else is dropped. Cache is bounded (8 KB, 24 h), HTTPS-only, and every failure falls back locally to conservative defaults.

## Test plan

- New unit tests cover opt-out inertness, stale/malformed cache, unknown keys, wrong-typed/malformed payloads, network failure, and conservative defaults, plus the decide-endpoint mapping.
- I verified the pure logic with a standalone SwiftPM target (14/14 pass) and type-checked `Telemetry.swift` + `RemoteFeatureFlags.swift` against the app types.
- I did not run the full `xcodebuild test` locally (needs `xcodegen` + the vendored Sentry/Sparkle frameworks + the engine); CI should exercise it.

Closes #322.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remotely managed, allowlisted feature flags with safe defaults, validation, caching, and asynchronous updates.
  * Added a Tune-Up badge in navigation when the feature is enabled.
  * Added telemetry-based flag exposure reporting and automatic refresh handling.
  * Telemetry opt-outs now prevent remote flag access and clear stored flag data.

* **Documentation**
  * Documented remote feature-flag security, privacy, caching, and evaluation behavior.

* **Tests**
  * Added coverage for flag validation, caching, fallback behavior, and network failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->