### PR TITLE
Add failure telemetry and manual update recovery

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -109,7 +109,8 @@ so no IP is attached to events either.
 | `engine_missing`, `install_window_ready`, `onboarding_completed` | none |
 | `telemetry_opt_in_changed` | enabled boolean |
 | PostHog `$screen` | fixed name: `home`, `settings`, or `tool.<known tool>` |
-| `feature_operation_started`, `feature_operation_completed` | `clean`/`optimize`, dry-run/elevated booleans, fixed result, bucketed duration; failed completions add fixed `boundary_changed`, `privileged_launch_refused`, or `engine_nonzero` category |
+| `feature_operation_started` | `feature` (`clean` or `optimize`), `dry_run` boolean, `elevated` boolean |
+| `feature_operation_completed` | `feature` (`clean` or `optimize`), fixed `result` (`succeeded`, `failed`, `authorization_cancelled`, or `cancelled`), `duration_bucket`; failed completions may add `failure_category` (`boundary_changed`, `privileged_launch_refused`, or `engine_nonzero`) |
 | `previous_launch_incomplete` | previous phase, app version/build, OS build, bucketed elapsed time |
 | `compatibility_fallback_activated`, `compatibility_fallback_reaffirmed` | fixed reason, OS build, menu-bar mode |
 | `status_item_creation_scheduled`, `status_item_stability_started`, `status_item_stabilized` | fixed `launch` or `settings` source |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -109,7 +109,7 @@ so no IP is attached to events either.
 | `engine_missing`, `install_window_ready`, `onboarding_completed` | none |
 | `telemetry_opt_in_changed` | enabled boolean |
 | PostHog `$screen` | fixed name: `home`, `settings`, or `tool.<known tool>` |
-| `feature_operation_started`, `feature_operation_completed` | `clean`/`optimize`, dry-run/elevated booleans, fixed result, bucketed duration |
+| `feature_operation_started`, `feature_operation_completed` | `clean`/`optimize`, dry-run/elevated booleans, fixed result, bucketed duration; failed completions add fixed `boundary_changed`, `privileged_launch_refused`, or `engine_nonzero` category |
 | `previous_launch_incomplete` | previous phase, app version/build, OS build, bucketed elapsed time |
 | `compatibility_fallback_activated`, `compatibility_fallback_reaffirmed` | fixed reason, OS build, menu-bar mode |
 | `status_item_creation_scheduled`, `status_item_stability_started`, `status_item_stabilized` | fixed `launch` or `settings` source |

--- a/docs/install.html
+++ b/docs/install.html
@@ -84,6 +84,10 @@
   .pick > .lede { font-size:12.5px; color:var(--ink-3); margin:0 0 22px; text-align:center; }
   .dlcount { margin-top:34px; text-align:center; font-size:12.5px; color:var(--ink-3); }
   .dlcount b { font-weight:600; color:var(--ink-2); font-variant-numeric:tabular-nums; }
+  .recovery { max-width:48rem; margin:24px auto 0; padding:14px 16px; text-align:left;
+    font-size:13px; line-height:1.6; color:var(--ink-2); background:var(--surface);
+    border:1px solid var(--hair-2); border-radius:16px; }
+  .recovery strong { color:var(--ink); font-weight:600; }
   .rel { margin-top:9px; text-align:center; font-size:12.5px; line-height:1.6; color:var(--ink-3); }
   .rel a { color:var(--accent); text-decoration:underline; text-underline-offset:2px; }
 </style>
@@ -136,6 +140,7 @@
           </div>
         </div>
       </div>
+      <p class="recovery"><strong>Updating an older copy?</strong> If the in-app update can’t complete, quit Burrow, download the latest macOS ZIP above, and replace Burrow.app in Applications. Your settings and history stay on this Mac.</p>
       <p class="dlcount">Already downloaded by <b>13,091</b> people</p>
       <p class="rel">Latest release v0.14.0, a 22 MB universal build.
         Looking for an older version, the Windows preview notes, or the checksums?

--- a/docs/install.html
+++ b/docs/install.html
@@ -140,7 +140,7 @@
           </div>
         </div>
       </div>
-      <p class="recovery"><strong>Updating an older copy?</strong> If the in-app update can’t complete, quit Burrow, download the latest macOS ZIP above, and replace Burrow.app in Applications. Your settings and history stay on this Mac.</p>
+      <p class="recovery"><strong>Updating an older copy?</strong> If the in-app update can't complete, quit Burrow, download the latest macOS ZIP above, and replace Burrow.app in Applications. Your settings and history stay on this Mac.</p>
       <p class="dlcount">Already downloaded by <b>13,091</b> people</p>
       <p class="rel">Latest release v0.14.0, a 22 MB universal build.
         Looking for an older version, the Windows preview notes, or the checksums?

--- a/macos/Resources/ru.lproj/Localizable.strings
+++ b/macos/Resources/ru.lproj/Localizable.strings
@@ -414,6 +414,7 @@
 "Sparkle checks Burrow's signed update feed after startup settles and about once a day. It asks before downloading or installing anything." = "Sparkle проверяет подписанный канал обновлений Burrow после стабилизации запуска и примерно раз в день. Перед загрузкой или установкой чего-либо он спрашивает разрешение.";
 "Check for updates automatically" = "Проверять обновления автоматически";
 "Check for Updates" = "Проверить обновления";
+"Download Latest Version" = "Скачать последнюю версию";
 "About Burrow" = "О Burrow";
 "Update didn't complete" = "Обновление не завершено";
 "Update external engine" = "Обновить внешний движок";

--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -414,6 +414,7 @@
 "Sparkle checks Burrow's signed update feed after startup settles and about once a day. It asks before downloading or installing anything." = "Sparkle 会在启动稳定后及大约每天一次检查 Burrow 的签名更新源。下载或安装前都会先询问。";
 "Check for updates automatically" = "自动检查更新";
 "Check for Updates" = "检查更新";
+"Download Latest Version" = "下载最新版本";
 "About Burrow" = "关于 Burrow";
 "Update didn't complete" = "更新未完成";
 "Update external engine" = "更新外部引擎";

--- a/macos/Resources/zh-Hant.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hant.lproj/Localizable.strings
@@ -414,6 +414,7 @@
 "Sparkle checks Burrow's signed update feed after startup settles and about once a day. It asks before downloading or installing anything." = "Sparkle 會在啟動穩定後及大約每天一次檢查 Burrow 的簽名更新來源。下載或安裝前都會先詢問。";
 "Check for updates automatically" = "自動檢查更新";
 "Check for Updates" = "檢查更新";
+"Download Latest Version" = "下載最新版本";
 "About Burrow" = "關於 Burrow";
 "Update didn't complete" = "更新未完成";
 "Update external engine" = "更新外部引擎";

--- a/macos/Sources/OperationFlow.swift
+++ b/macos/Sources/OperationFlow.swift
@@ -49,6 +49,59 @@ protocol ProcessPort: Sendable {
     func events(_ spec: ProcessSpec) -> AsyncStream<ProcessEvent>
 }
 
+enum FeatureOperationFailureCategory: String, Equatable {
+    case boundaryChanged = "boundary_changed"
+    case privilegedLaunchRefused = "privileged_launch_refused"
+    case engineNonzero = "engine_nonzero"
+}
+
+enum FeatureOperationFailurePolicy {
+    static func category(
+        forExitCode exitCode: Int32,
+        elevated: Bool,
+        isCleanup: Bool
+    ) -> FeatureOperationFailureCategory {
+        guard elevated else { return .engineNonzero }
+        switch exitCode {
+        case ElevatedExitCode.boundaryCheckFailed where isCleanup:
+            return .boundaryChanged
+        case ElevatedExitCode.logSinkUnavailable,
+             ElevatedExitCode.executableRefused,
+             ElevatedExitCode.launchFailed:
+            return .privilegedLaunchRefused
+        default:
+            return .engineNonzero
+        }
+    }
+}
+
+enum FeatureOperationTelemetry {
+    static func feature<Report: Sendable>(for operation: ToolOperation<Report>) -> String? {
+        if operation.cleanupPlan != nil { return "clean" }
+        guard case .mo = operation.executable,
+              let command = operation.arguments.first,
+              ["clean", "optimize"].contains(command) else { return nil }
+        return command
+    }
+
+    static func completionProperties(
+        feature: String,
+        result: String,
+        duration: TimeInterval,
+        failureCategory: FeatureOperationFailureCategory?
+    ) -> [String: Any] {
+        var properties: [String: Any] = [
+            "feature": feature,
+            "result": result,
+            "duration_bucket": Telemetry.secondsBucket(duration),
+        ]
+        if let failureCategory {
+            properties["failure_category"] = failureCategory.rawValue
+        }
+        return properties
+    }
+}
+
 // MARK: - Tool descriptor
 
 /// All per-tool variation as data. `reduce` is a pure function from the
@@ -259,7 +312,7 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         rawLog = ""
         currentElevated = op.elevated
         currentLabel = op.label
-        telemetryFeature = Self.telemetryFeature(for: op)
+        telemetryFeature = FeatureOperationTelemetry.feature(for: op)
         telemetryStartedAt = Date()
         cancelRequested = false
         reactivated = false
@@ -322,7 +375,14 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
                                                           isCleanup: op.cleanupPlan != nil)
                         self.state = .finished(.failed(message))
                         if op.label != nil { self.center.end(id, success: false, detail: message) }
-                        self.captureTelemetryCompletion(result: "failed")
+                        self.captureTelemetryCompletion(
+                            result: "failed",
+                            failureCategory: FeatureOperationFailurePolicy.category(
+                                forExitCode: code,
+                                elevated: op.elevated,
+                                isCleanup: op.cleanupPlan != nil
+                            )
+                        )
                     }
                 case .authCancelled:
                     // Auth-cancel is classified by the runner now (#48 taxonomy),
@@ -355,27 +415,16 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         rawLog = ""
     }
 
-    private static func telemetryFeature(for operation: ToolOperation<Report>) -> String? {
-        guard case .mo = operation.executable,
-              let command = operation.arguments.first,
-              ["clean", "optimize"].contains(command) else { return nil }
-        return command
-    }
-
     /// Turn an exit status into something a person can act on. The wrapper's
     /// own refusals (124–127) all mean NOTHING ran, which is the opposite of a
     /// partial delete, so they must never share wording with a command that
     /// ran and failed partway.
     private static func failureMessage(exitCode: Int32, isCleanup: Bool) -> String {
         switch exitCode {
-        case ElevatedExitCode.boundaryCheckFailed:
-            return isCleanup
-                ? NSLocalizedString(
-                    "Nothing was cleaned: the reviewed items changed before the run started. Rescan before trying again.",
-                    comment: "")
-                : NSLocalizedString(
-                    "Nothing ran: the files Burrow verified changed before the operation started.",
-                    comment: "")
+        case ElevatedExitCode.boundaryCheckFailed where isCleanup:
+            return NSLocalizedString(
+                "Nothing was cleaned: the reviewed items changed before the run started. Rescan before trying again.",
+                comment: "")
         case ElevatedExitCode.logSinkUnavailable,
              ElevatedExitCode.executableRefused,
              ElevatedExitCode.launchFailed:
@@ -392,14 +441,19 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
         }
     }
 
-    private func captureTelemetryCompletion(result: String) {
+    private func captureTelemetryCompletion(
+        result: String,
+        failureCategory: FeatureOperationFailureCategory? = nil
+    ) {
         guard let telemetryFeature else { return }
         let duration = telemetryStartedAt.map { Date().timeIntervalSince($0) } ?? 0
-        Telemetry.capture("feature_operation_completed", [
-            "feature": telemetryFeature,
-            "result": result,
-            "duration_bucket": Telemetry.secondsBucket(duration),
-        ])
+        let properties = FeatureOperationTelemetry.completionProperties(
+            feature: telemetryFeature,
+            result: result,
+            duration: duration,
+            failureCategory: failureCategory
+        )
+        Telemetry.capture("feature_operation_completed", properties)
         self.telemetryFeature = nil
         telemetryStartedAt = nil
     }

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -371,9 +371,13 @@ struct SettingsView: View {
                     PillButton(title: "Check for Updates", filled: false) { UpdateCheck.checkNow() }
                     PillButton(title: "About Burrow", filled: false) { AppDelegate.shared?.showAboutPanel() }
                     Spacer()
-                    Link(NSLocalizedString("Source on GitHub", comment: ""),
-                         destination: URL(string: "https://github.com/caezium/Burrow")!)
-                        .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.green)
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Link(NSLocalizedString("Download Latest Version", comment: ""),
+                             destination: UpdateRecovery.manualDownloadURL)
+                        Link(NSLocalizedString("Source on GitHub", comment: ""),
+                             destination: URL(string: "https://github.com/caezium/Burrow")!)
+                    }
+                    .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.green)
                 }
             }
         }

--- a/macos/Sources/UpdateCheck.swift
+++ b/macos/Sources/UpdateCheck.swift
@@ -17,6 +17,7 @@ enum UpdateStartPolicy {
 }
 
 enum UpdateRecovery {
+    // Keep this stable: it is the canonical recovery endpoint when an in-app update cannot finish.
     static let manualDownloadURL = URL(string: "https://burrow.computer/install")!
 }
 

--- a/macos/Sources/UpdateCheck.swift
+++ b/macos/Sources/UpdateCheck.swift
@@ -16,6 +16,10 @@ enum UpdateStartPolicy {
     static func shouldStartForAutomaticChecks(enabled: Bool) -> Bool { enabled }
 }
 
+enum UpdateRecovery {
+    static let manualDownloadURL = URL(string: "https://burrow.computer/install")!
+}
+
 enum UpdateFailureCategory: String, Equatable {
     case appTranslocation = "app_translocation"
     case transientDownload = "transient_download"

--- a/macos/Tests/LocalizationTests.swift
+++ b/macos/Tests/LocalizationTests.swift
@@ -24,6 +24,7 @@ final class LocalizationTests: XCTestCase {
         "Everything's up to date",
         "Update all",
         "Check for Updates",
+        "Download Latest Version",
         "Update external engine",
         "Update Burrow to get the current bundled engine.",
         "Use Settings › Engine › Update external engine, then try again.",

--- a/macos/Tests/LocalizationTests.swift
+++ b/macos/Tests/LocalizationTests.swift
@@ -78,6 +78,21 @@ final class LocalizationTests: XCTestCase {
         try assertCoversCoreInterface(language: "ru")
     }
 
+    func testLocalizedResourcesAreStagedInApplicationBundle() throws {
+        for language in ["zh-Hans", "zh-Hant", "ru"] {
+            let lproj = try XCTUnwrap(
+                Bundle.main.url(forResource: language, withExtension: "lproj"),
+                "\(language).lproj missing from the app bundle"
+            )
+            XCTAssertTrue(
+                FileManager.default.fileExists(
+                    atPath: lproj.appendingPathComponent("Localizable.strings").path
+                ),
+                "\(language) Localizable.strings missing from the app bundle"
+            )
+        }
+    }
+
     /// Both Chinese variants should translate the same set of keys, so a key
     /// added to one file isn't silently missing from the other.
     func testChineseVariantsShareTheSameKeys() throws {
@@ -139,24 +154,24 @@ final class LocalizationTests: XCTestCase {
         }
     }
 
-    // Read the lproj from the BUILT app bundle (the test host), not the
-    // repo checkout: it validates the artifact that actually ships, and
-    // it keeps the suite off TCC-protected user folders — a repo on
-    // ~/Desktop made every Data(contentsOf:) here block on a tccd that
-    // had wedged, hanging the whole suite.
+    // Data-quality assertions read the checked-in tables directly so a stale
+    // staged app resource cannot hide a missing or malformed source entry.
     private func localizedStrings(_ language: String) throws -> [String: String] {
-        let url = try lprojURL(language).appendingPathComponent("Localizable.strings")
+        let url = sourceLprojURL(language).appendingPathComponent("Localizable.strings")
         let data = try Data(contentsOf: url)
         let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
         return try XCTUnwrap(plist as? [String: String])
     }
 
     private func lprojBundle(_ language: String) throws -> Bundle {
-        try XCTUnwrap(Bundle(url: lprojURL(language)))
+        try XCTUnwrap(Bundle(url: sourceLprojURL(language)))
     }
 
-    private func lprojURL(_ language: String) throws -> URL {
-        try XCTUnwrap(Bundle.main.url(forResource: language, withExtension: "lproj"),
-                      "\(language).lproj missing from the app bundle")
+    private func sourceLprojURL(_ language: String, file: StaticString = #filePath) -> URL {
+        URL(fileURLWithPath: "\(file)")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Resources")
+            .appendingPathComponent("\(language).lproj")
     }
 }

--- a/macos/Tests/OperationFlowTests.swift
+++ b/macos/Tests/OperationFlowTests.swift
@@ -84,6 +84,81 @@ final class OperationFlowTests: XCTestCase {
 
     // MARK: Tests
 
+    func testFeatureFailureCategoryUsesBoundedExitTaxonomy() {
+        XCTAssertEqual(
+            FeatureOperationFailurePolicy.category(
+                forExitCode: ElevatedExitCode.boundaryCheckFailed,
+                elevated: true,
+                isCleanup: true
+            ),
+            .boundaryChanged
+        )
+        for code in [
+            ElevatedExitCode.logSinkUnavailable,
+            ElevatedExitCode.executableRefused,
+            ElevatedExitCode.launchFailed,
+        ] {
+            XCTAssertEqual(
+                FeatureOperationFailurePolicy.category(
+                    forExitCode: code,
+                    elevated: true,
+                    isCleanup: false
+                ),
+                .privilegedLaunchRefused
+            )
+        }
+        XCTAssertEqual(
+            FeatureOperationFailurePolicy.category(
+                forExitCode: 1,
+                elevated: true,
+                isCleanup: false
+            ),
+            .engineNonzero
+        )
+        XCTAssertEqual(
+            FeatureOperationFailurePolicy.category(
+                forExitCode: ElevatedExitCode.boundaryCheckFailed,
+                elevated: true,
+                isCleanup: false
+            ),
+            .engineNonzero,
+            "an engine exit must not be mistaken for a changed reviewed-clean boundary"
+        )
+        XCTAssertEqual(
+            FeatureOperationFailurePolicy.category(
+                forExitCode: ElevatedExitCode.executableRefused,
+                elevated: false,
+                isCleanup: false
+            ),
+            .engineNonzero,
+            "unprivileged commands cannot produce privileged-wrapper refusals"
+        )
+        XCTAssertEqual(FeatureOperationFailureCategory.boundaryChanged.rawValue, "boundary_changed")
+        XCTAssertEqual(
+            FeatureOperationFailureCategory.privilegedLaunchRefused.rawValue,
+            "privileged_launch_refused"
+        )
+        XCTAssertEqual(FeatureOperationFailureCategory.engineNonzero.rawValue, "engine_nonzero")
+    }
+
+    func testFeatureCompletionTelemetryIncludesFailureCategoryOnlyForFailures() {
+        let failed = FeatureOperationTelemetry.completionProperties(
+            feature: "clean",
+            result: "failed",
+            duration: 1,
+            failureCategory: .boundaryChanged
+        )
+        XCTAssertEqual(failed["failure_category"] as? String, "boundary_changed")
+
+        let succeeded = FeatureOperationTelemetry.completionProperties(
+            feature: "clean",
+            result: "succeeded",
+            duration: 1,
+            failureCategory: nil
+        )
+        XCTAssertNil(succeeded["failure_category"])
+    }
+
     func testGate_blocksWithoutFDAThenGrantRuns() async throws {
         let port = FakeProcessPort(script: Self.cannedClean)
         var fda = false
@@ -224,7 +299,9 @@ final class OperationFlowTests: XCTestCase {
         let center = OperationCenter()
         let flow = makeFlow(port, center: center)
         var operation = Self.cleanOp(elevated: true)
+        operation.executable = .path("/usr/bin/find")
         operation.cleanupPlan = plan
+        XCTAssertEqual(FeatureOperationTelemetry.feature(for: operation), "clean")
         flow.start(operation)
         await settle(flow)
 

--- a/macos/Tests/UpdateCheckTests.swift
+++ b/macos/Tests/UpdateCheckTests.swift
@@ -31,6 +31,13 @@ final class UpdateCheckTests: XCTestCase {
         XCTAssertTrue(UpdateStartPolicy.shouldStartForAutomaticChecks(enabled: true))
     }
 
+    func testManualUpdateRecoveryUsesCanonicalInstallPage() {
+        XCTAssertEqual(
+            UpdateRecovery.manualDownloadURL.absoluteString,
+            "https://burrow.computer/install"
+        )
+    }
+
     func testTranslocatedSparkleFailureRequiresMovingTheAppWithoutCreatingASentryIssue() {
         let error = NSError(domain: SUSparkleErrorDomain, code: 1005)
 

--- a/scripts/site-release.py
+++ b/scripts/site-release.py
@@ -787,6 +787,10 @@ INSTALL_CSS = """  /* Centered platform picker; the cards themselves come from c
   .pick > .lede { font-size:12.5px; color:var(--ink-3); margin:0 0 22px; text-align:center; }
   .dlcount { margin-top:34px; text-align:center; font-size:12.5px; color:var(--ink-3); }
   .dlcount b { font-weight:600; color:var(--ink-2); font-variant-numeric:tabular-nums; }
+  .recovery { max-width:48rem; margin:24px auto 0; padding:14px 16px; text-align:left;
+    font-size:13px; line-height:1.6; color:var(--ink-2); background:var(--surface);
+    border:1px solid var(--hair-2); border-radius:16px; }
+  .recovery strong { color:var(--ink); font-weight:600; }
   .rel { margin-top:9px; text-align:center; font-size:12.5px; line-height:1.6; color:var(--ink-3); }
   .rel a { color:var(--accent); text-decoration:underline; text-underline-offset:2px; }
 """
@@ -861,6 +865,7 @@ def render_install(version, downloads, stars=None):
     body = f"""    <div class="pick">
       <p class="lede">Pick your platform to download the latest build.</p>
 {render_platforms(version, "install")}
+      <p class="recovery"><strong>Updating an older copy?</strong> If the in-app update can’t complete, quit Burrow, download the latest macOS ZIP above, and replace Burrow.app in Applications. Your settings and history stay on this Mac.</p>
       <p class="dlcount">Already downloaded by <b>{downloads:,}</b> people</p>
       <p class="rel">Latest release v{version}, a {MAC_SIZE} universal build.
         Looking for an older version, the Windows preview notes, or the checksums?

--- a/scripts/site-release.py
+++ b/scripts/site-release.py
@@ -865,7 +865,7 @@ def render_install(version, downloads, stars=None):
     body = f"""    <div class="pick">
       <p class="lede">Pick your platform to download the latest build.</p>
 {render_platforms(version, "install")}
-      <p class="recovery"><strong>Updating an older copy?</strong> If the in-app update can’t complete, quit Burrow, download the latest macOS ZIP above, and replace Burrow.app in Applications. Your settings and history stay on this Mac.</p>
+      <p class="recovery"><strong>Updating an older copy?</strong> If the in-app update can't complete, quit Burrow, download the latest macOS ZIP above, and replace Burrow.app in Applications. Your settings and history stay on this Mac.</p>
       <p class="dlcount">Already downloaded by <b>{downloads:,}</b> people</p>
       <p class="rel">Latest release v{version}, a {MAC_SIZE} universal build.
         Looking for an older version, the Windows preview notes, or the checksums?

--- a/scripts/tests/test_site_analytics.mjs
+++ b/scripts/tests/test_site_analytics.mjs
@@ -190,6 +190,14 @@ test('every public HTML page loads analytics and generated pages remain reproduc
     execFileSync('python3', ['scripts/site-release.py', '--check'], { cwd: root, stdio: 'pipe' })
 })
 
+test('install page explains the manual recovery path for failed in-app updates', () => {
+    const install = fs.readFileSync(path.join(root, 'docs', 'install.html'), 'utf8')
+
+    assert.match(install, /If the in-app update can.t complete, quit Burrow/)
+    assert.match(install, /replace Burrow\.app in Applications/)
+    assert.match(install, /Your settings and history stay on this Mac/)
+})
+
 test('deployment injection validates the key and replaces exactly one placeholder', (t) => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'burrow-site-analytics-'))
     t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))


### PR DESCRIPTION
## Summary

- Add a privacy-safe `failure_category` to failed clean and optimize completion telemetry.
- Add a canonical manual-update recovery link in Settings and clear replacement instructions on the install page.
- Document the bounded telemetry values and localize the new Settings link.
- Keep launch behavior and the work in #390 unchanged.

## Why

Feature failures were aggregated without distinguishing a changed reviewed-clean boundary, a privileged-wrapper refusal, or an engine failure. Older installations can also fail before reaching a healthier updater, so they need a direct path to the latest signed download.

## Changes

- Classify failed feature completions as `boundary_changed`, `privileged_launch_refused`, or `engine_nonzero`, using the operation's elevated and cleanup context to avoid exit-code collisions.
- Attribute production cleanup-plan operations to `clean`, including reviewed-clean commands that execute through `/usr/bin/find`.
- Add “Download Latest Version” to Settings, linking to the canonical install page.
- Add manual replacement guidance to the generated install page without changing local settings or history.
- Update telemetry documentation, localization coverage, unit tests, and generated-site tests.

## Operational follow-up

The PostHog website and release-adoption insights were corrected separately, and rolling alerts now cover launch readiness, feature failure rate, and hard updater failures. Those dashboard changes are operational configuration and are not part of this repository diff.

## Test plan

- [x] macOS test suite: 1,229 tests, 1 expected skip, 0 failures
- [x] Python suite: 91 tests
- [x] Site analytics suite: 8 tests
- [x] Generated site content check
- [x] Read-only scope and standards reviews


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Download Latest Version” link in macOS About settings.
  * Added manual recovery guidance for failed in-app updates while preserving settings and history.
  * Added Russian, Simplified Chinese, and Traditional Chinese translations for the update action.

* **Bug Fixes**
  * Improved feature-operation failure reporting with clearer categories and telemetry details.

* **Documentation**
  * Updated telemetry documentation and installation instructions with recovery information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->