### PR TITLE
telemetry: add privacy-safe cached PostHog feature flags

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -190,10 +190,11 @@ This is the part people rightly scrutinize in cleaners. Burrow's model:
   historical event at a time with bounded backoff, discards permanent HTTP
   rejections, and runs only while telemetry is enabled; an opted-out launch
   does not read it or contact PostHog. Feature flags use the same gate and
-  queue (issue #322): one decide request per enabled launch, an allowlist of
-  UI-only boolean keys with baked-in OFF defaults, a 7-day bounded local cache
-  that an opted-out launch never reads, and a conservative local fallback on
-  every failure — details in **[TELEMETRY.md](TELEMETRY.md)**.
+  queue (issue #322): one decide request per enabled launch and once more on
+  opt-in, an allowlist of UI-only boolean keys with baked-in OFF defaults, a
+  7-day bounded local cache that an opted-out launch never reads, and a
+  conservative local fallback on every failure — details in
+  **[TELEMETRY.md](TELEMETRY.md)**.
 - **Local launch recovery journal.** Burrow atomically stores a coarse launch
   phase plus app/OS versions under Application Support so it can avoid a
   status-item path that failed on the same macOS build. This local safety file

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -189,7 +189,11 @@ This is the part people rightly scrutinize in cleaners. Burrow's model:
   ran on AppKit's main run loop. A local 64-event sanitized outbox retries one
   historical event at a time with bounded backoff, discards permanent HTTP
   rejections, and runs only while telemetry is enabled; an opted-out launch
-  does not read it or contact PostHog.
+  does not read it or contact PostHog. Feature flags use the same gate and
+  queue (issue #322): one decide request per enabled launch, an allowlist of
+  UI-only boolean keys with baked-in OFF defaults, a 7-day bounded local cache
+  that an opted-out launch never reads, and a conservative local fallback on
+  every failure — details in **[TELEMETRY.md](TELEMETRY.md)**.
 - **Local launch recovery journal.** Burrow atomically stores a coarse launch
   phase plus app/OS versions under Application Support so it can avoid a
   status-item path that failed on the same macOS build. This local safety file

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -99,12 +99,14 @@ behavior, permissions, security controls, signing/notarization, Sparkle
 verification, launch recovery, or telemetry consent. Client code:
 [`macos/Sources/FeatureFlags.swift`](macos/Sources/FeatureFlags.swift).
 
-**Request.** One HTTPS `POST` to `https://us.i.posthog.com/decide/?v=3`
-per enabled launch (and once more on opt-in), serialized on the telemetry
-queue with no timer and no retry — a failure falls back to local state and
-waits for the next launch. The request body contains exactly two fields:
-`api_key` and the same random `distinct_id` events already use. No person
-properties, groups, or locale.
+**Request.** One HTTPS `POST` to `{validated PHPostHogHost}/decide/?v=3`
+per enabled launch (and once more on opt-in). The validated `PHPostHogHost`
+build setting overrides the default `https://us.i.posthog.com`; otherwise the
+default is used. The request is serialized on the telemetry queue with no
+timer and no retry — a failure falls back to local state and waits for the
+next launch. The request body contains exactly two fields: `api_key` and the
+same random `distinct_id` events already use. No person properties, groups,
+or locale.
 
 **Flags.** The complete allowlist, with its conservative (OFF) default:
 
@@ -125,13 +127,16 @@ in force until a later successful fetch rewrites it. An opted-out launch
 neither reads nor writes it, exactly like the event outbox.
 
 **Exposure event.** The first lookup of each flag per launch emits
-`feature_flag_exposed` with exactly two properties — `flag` (the allowlisted
-key) and `value` (boolean). Like every event it is dropped while opted out.
+`feature_flag_exposed` with exactly two feature-flag-specific properties —
+`flag` (the allowlisted key) and `value` (boolean). The usual telemetry super
+properties (app version, OS build, platform, locale, etc.) are also attached,
+just like any other event. Like every event it is dropped while opted out.
 
 **Failure model.** Opt-out, missing release key, network error, non-2xx
-status, malformed payload, and stale cache all produce the same result: the
-app runs fully on baked-in defaults, indistinguishable from a flag-free
-build.
+status, malformed payload, or stale cache all fall back to local values. If a
+usable cached snapshot exists, it is applied before the decide request and
+retained if the request fails; only a launch with no usable cache runs fully
+on the baked-in defaults, indistinguishable from a flag-free build.
 
 **IP address:** as with any HTTPS request, the TCP connection still exposes
 your IP to the receiving service at the network layer, but neither pipeline

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -88,8 +88,50 @@ own project instead.
 
 Burrow's first-party client attaches no hidden SDK context. It additionally
 sends fixed PostHog protocol fields: `$ip: "0"`, `$lib: "burrow-macos"`,
-`$lib_version`, and `$process_person_profile: false`. A later feature-flag
-rollout will be separately reviewed and will use cached, conservative defaults.
+`$lib_version`, and `$process_person_profile: false`.
+
+## Feature flags (issue #322)
+
+Burrow fetches PostHog feature flags through the same opt-out gate and the
+same background queue as events. Flags exist for gradual rollout and UI
+experiments only — they are **never** consulted for cleaning/deletion
+behavior, permissions, security controls, signing/notarization, Sparkle
+verification, launch recovery, or telemetry consent. Client code:
+[`macos/Sources/FeatureFlags.swift`](macos/Sources/FeatureFlags.swift).
+
+**Request.** One HTTPS `POST` to `https://us.i.posthog.com/decide/?v=3`
+per enabled launch (and once more on opt-in), serialized on the telemetry
+queue with no timer and no retry — a failure falls back to local state and
+waits for the next launch. The request body contains exactly two fields:
+`api_key` and the same random `distinct_id` events already use. No person
+properties, groups, or locale.
+
+**Flags.** The complete allowlist, with its conservative (OFF) default:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `about_release_notes_link` | `false` | Shows a "Release Notes" link in Settings ▸ About. Deliberately harmless; validates the pipeline before any broader use. |
+
+Unknown flag keys and non-boolean values in the decide response are ignored
+at parse time, so a key not listed above cannot exist in Burrow regardless
+of what the server returns.
+
+**Cache.** The merged snapshot is stored at
+`~/Library/Application Support/Burrow/feature-flags.json` — a bounded
+(≤16 KB) JSON file with a schema version, an ISO-8601 fetch timestamp, and
+the boolean flags. It expires after 7 days; malformed, oversized, stale, or
+wrong-version files are discarded whole, and the conservative defaults stay
+in force until a later successful fetch rewrites it. An opted-out launch
+neither reads nor writes it, exactly like the event outbox.
+
+**Exposure event.** The first lookup of each flag per launch emits
+`feature_flag_exposed` with exactly two properties — `flag` (the allowlisted
+key) and `value` (boolean). Like every event it is dropped while opted out.
+
+**Failure model.** Opt-out, missing release key, network error, non-2xx
+status, malformed payload, and stale cache all produce the same result: the
+app runs fully on baked-in defaults, indistinguishable from a flag-free
+build.
 
 **IP address:** as with any HTTPS request, the TCP connection still exposes
 your IP to the receiving service at the network layer, but neither pipeline
@@ -108,6 +150,7 @@ so no IP is attached to events either.
 | `app_updated` | previous/current app version and build |
 | `engine_missing`, `install_window_ready`, `onboarding_completed` | none |
 | `telemetry_opt_in_changed` | enabled boolean |
+| `feature_flag_exposed` | `flag` (allowlisted key), boolean `value` — once per flag per launch |
 | PostHog `$screen` | fixed name: `home`, `settings`, or `tool.<known tool>` |
 | `feature_operation_started` | `feature` (`clean` or `optimize`), `dry_run` boolean, `elevated` boolean |
 | `feature_operation_completed` | `feature` (`clean` or `optimize`), fixed `result` (`succeeded`, `failed`, `authorization_cancelled`, or `cancelled`), `duration_bucket`; failed completions may add `failure_category` (`boundary_changed`, `privileged_launch_refused`, or `engine_nonzero`) |
@@ -186,9 +229,9 @@ All of that disk work runs on the background telemetry queue.
 ### Deliberately deferred
 
 `fda_state`, uninstall/purge detail, and MCP subprocess events are not wired.
-PostHog feature flags are also deferred to a separate change so flags can be
-cached, telemetry-gated, and restricted to non-safety-critical UI/rollout
-choices. Burrow will not build a custom pixel recorder for macOS.
+PostHog feature flags now exist under the strict model above (issue #322);
+new flags must be added to the allowlist with an OFF default and a
+TELEMETRY.md row. Burrow will not build a custom pixel recorder for macOS.
 
 ## Turning it off
 

--- a/macos/Sources/FeatureFlags.swift
+++ b/macos/Sources/FeatureFlags.swift
@@ -74,10 +74,12 @@ enum FeatureFlags {
     }
 
     /// One fixed-name exposure event per flag per launch, carrying only the
-    /// allowlisted key and its boolean. `Telemetry.capture` drops it while
-    /// opted out or before `start()`, so an opted-out launch reports
-    /// nothing even when a lookup happens.
+    /// allowlisted key and its boolean. The key is only marked reported
+    /// when `Telemetry` can actually queue the event; while opted out,
+    /// before `start()`, or without a release key, the lookup remains
+    /// eligible so a later enabled session can emit the exposure.
     private static func expose(_ key: Key, value: Bool) {
+        guard Telemetry.canCapture else { return }
         lock.lock()
         let alreadyReported = !exposedThisLaunch.insert(key).inserted
         lock.unlock()
@@ -126,8 +128,9 @@ enum FeatureFlags {
               (object["version"] as? Int) == 1,
               let fetchedAt = (object["fetched_at"] as? String)
                   .flatMap(timestampFormatter.date(from:)),
-              let values = object["flags"] as? [String: Any],
-              now.timeIntervalSince(fetchedAt) <= maxCacheAge else { return nil }
+              fetchedAt <= now,
+              now.timeIntervalSince(fetchedAt) <= maxCacheAge,
+              let values = object["flags"] as? [String: Any] else { return nil }
 
         var flags: [Key: Bool] = [:]
         for key in Key.allCases {

--- a/macos/Sources/FeatureFlags.swift
+++ b/macos/Sources/FeatureFlags.swift
@@ -1,0 +1,202 @@
+//
+//  FeatureFlags.swift
+//  Burrow
+//
+//  Privacy-safe, cached PostHog feature flags (issue #322). Flags gate
+//  UI-only rollout choices and nothing else: they can never influence
+//  cleaning/deletion behavior, permissions, security controls, signing or
+//  notarization, Sparkle verification, launch recovery, or telemetry
+//  consent. Every unknown key, malformed value, stale cache, and network
+//  failure falls back to the baked-in conservative defaults below, so the
+//  app is always fully functional — and identical to a flag-free build —
+//  without PostHog.
+//
+
+import Foundation
+
+enum FeatureFlags {
+
+    /// The complete allowlist. A key that is not in this enum is ignored
+    /// everywhere: it is never requested, cached, persisted, reported, or
+    /// able to change any behavior, no matter what the decide endpoint
+    /// returns.
+    enum Key: String, CaseIterable {
+        /// Settings ▸ About shows an extra "Release Notes" link. This is
+        /// the deliberately harmless UI-only flag that validates the whole
+        /// pipeline (fetch → cache → lookup → exposure event) before any
+        /// broader use; default OFF.
+        case aboutReleaseNotesLink = "about_release_notes_link"
+    }
+
+    /// Baked-in conservative defaults served before anything is fetched and
+    /// whenever a fetch, cache read, or parse fails. Everything defaults to
+    /// OFF so a flag that cannot be proven ON simply does not exist.
+    private static let defaults: [Key: Bool] = [
+        .aboutReleaseNotesLink: false,
+    ]
+
+    /// A cache older than this is stale: its values are ignored and the
+    /// file is rewritten only after a later successful fetch.
+    static let maxCacheAge: TimeInterval = 7 * 24 * 3_600
+
+    /// The cache is allowlist-sized by construction (a handful of booleans);
+    /// a file larger than this bound is corrupt or foreign and is discarded
+    /// unread.
+    static let maxCacheBytes = 16 * 1024
+
+    static let cacheFileName = "feature-flags.json"
+
+    private static let lock = NSLock()
+    private static let timestampFormatter = ISO8601DateFormatter()
+    /// Accessed under `lock`. Defaults merged with the last accepted set.
+    private static var snapshot: [Key: Bool] = defaults
+    /// Accessed under `lock`. Keys already reported this launch, so each
+    /// flag emits at most one exposure event per session.
+    private static var exposedThisLaunch: Set<Key> = []
+
+    // MARK: - Lookup
+
+    /// Synchronous, main-thread-safe, and never touches disk or network:
+    /// it reads the in-memory snapshot only. An opted-out launch never
+    /// populates the snapshot, so it sees the conservative defaults until
+    /// telemetry has been enabled and a fresh cache or successful fetch
+    /// has been applied at least once.
+    ///
+    /// The value is evaluated where it is read (typically a SwiftUI body):
+    /// a flag that flips mid-session becomes visible the next time that
+    /// view rebuilds — these are rollout switches, not live remotes.
+    static func isEnabled(_ key: Key) -> Bool {
+        lock.lock()
+        let value = snapshot[key] ?? defaults[key] ?? false
+        lock.unlock()
+        expose(key, value: value)
+        return value
+    }
+
+    /// One fixed-name exposure event per flag per launch, carrying only the
+    /// allowlisted key and its boolean. `Telemetry.capture` drops it while
+    /// opted out or before `start()`, so an opted-out launch reports
+    /// nothing even when a lookup happens.
+    private static func expose(_ key: Key, value: Bool) {
+        lock.lock()
+        let alreadyReported = !exposedThisLaunch.insert(key).inserted
+        lock.unlock()
+        guard !alreadyReported else { return }
+        Telemetry.capture("feature_flag_exposed", ["flag": key.rawValue, "value": value])
+    }
+
+    // MARK: - Remote payload filter
+
+    /// Accepts only allowlisted keys with boolean values. Strings, numbers,
+    /// flag payloads, experiment metadata, and anything else PostHog adds
+    /// to the decide response is ignored; only booleans are ever stored.
+    static func sanitizeRemoteFlags(_ raw: [String: Any]?) -> [Key: Bool] {
+        guard let raw else { return [:] }
+        var accepted: [Key: Bool] = [:]
+        for key in Key.allCases {
+            if let value = raw[key.rawValue] as? Bool {
+                accepted[key] = value
+            }
+        }
+        return accepted
+    }
+
+    // MARK: - Cache codec
+
+    static func encodeCache(_ flags: [Key: Bool], fetchedAt: Date) -> Data? {
+        var values: [String: Bool] = [:]
+        for (key, value) in flags { values[key.rawValue] = value }
+        let payload: [String: Any] = [
+            "version": 1,
+            "fetched_at": timestampFormatter.string(from: fetchedAt),
+            "flags": values,
+        ]
+        guard JSONSerialization.isValidJSONObject(payload) else { return nil }
+        return try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+    }
+
+    /// Strict decode: exact version, allowlisted boolean flags, and a
+    /// timestamp no older than `maxCacheAge`. Anything else — malformed
+    /// JSON, wrong types, unknown keys, a missing or stale timestamp —
+    /// discards the whole cache, so a corrupt file can only ever produce
+    /// the conservative defaults.
+    static func decodeCache(_ data: Data, now: Date) -> [Key: Bool]? {
+        guard let decoded = try? JSONSerialization.jsonObject(with: data),
+              let object = decoded as? [String: Any],
+              (object["version"] as? Int) == 1,
+              let fetchedAt = (object["fetched_at"] as? String)
+                  .flatMap(timestampFormatter.date(from:)),
+              let values = object["flags"] as? [String: Any],
+              now.timeIntervalSince(fetchedAt) <= maxCacheAge else { return nil }
+
+        var flags: [Key: Bool] = [:]
+        for key in Key.allCases {
+            if let value = values[key.rawValue] as? Bool {
+                flags[key] = value
+            }
+        }
+        return flags
+    }
+
+    /// Reads the on-disk cache. `nil` means "no usable cache" (absent,
+    /// oversized, corrupt, or stale); callers leave defaults in place.
+    /// The file's size is checked before a single byte is read.
+    static func loadCached(from directory: URL, now: Date) -> [Key: Bool]? {
+        let fileURL = directory.appendingPathComponent(cacheFileName)
+        guard let values = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+              values.isRegularFile == true,
+              let size = values.fileSize,
+              (1 ... maxCacheBytes).contains(size),
+              let data = try? Data(contentsOf: fileURL) else { return nil }
+        return decodeCache(data, now: now)
+    }
+
+    /// The opt-out gate for cache reads: an opted-out launch must not read
+    /// the flag cache any more than it contacts PostHog, so it returns `nil`
+    /// without touching the filesystem.
+    static func loadCachedIfEnabled(isEnabled: Bool, directory: URL?, now: Date = Date()) -> [Key: Bool]? {
+        guard isEnabled, let directory else { return nil }
+        return loadCached(from: directory, now: now)
+    }
+
+    // MARK: - Applying results
+
+    /// Merges an accepted set (remote or freshly decoded cache) over the
+    /// defaults, updates the in-memory snapshot, and optionally persists
+    /// the merged snapshot atomically. Runs on Telemetry's background
+    /// queue; the caller owns the `Telemetry.isEnabled` gate so an
+    /// opted-out launch neither reads nor writes anything here.
+    static func apply(_ flags: [Key: Bool], persistTo directory: URL?) {
+        lock.lock()
+        var merged = defaults
+        for (key, value) in flags { merged[key] = value }
+        snapshot = merged
+        lock.unlock()
+
+        guard let directory,
+              let data = encodeCache(merged, fetchedAt: Date()) else { return }
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? data.write(to: directory.appendingPathComponent(cacheFileName), options: .atomic)
+    }
+
+    /// `~/Library/Application Support/Burrow` — the same directory as the
+    /// telemetry id, outbox, and launch journal.
+    static func defaultCacheDirectory() -> URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("Burrow", isDirectory: true)
+    }
+
+    // MARK: - Tests
+
+    #if DEBUG
+    /// Restores the pristine pre-launch state between tests. Never called
+    /// by production code.
+    static func resetForTesting() {
+        lock.lock()
+        snapshot = defaults
+        exposedThisLaunch = []
+        lock.unlock()
+    }
+    #endif
+}

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -376,6 +376,13 @@ struct SettingsView: View {
                              destination: UpdateRecovery.manualDownloadURL)
                         Link(NSLocalizedString("Source on GitHub", comment: ""),
                              destination: URL(string: "https://github.com/caezium/Burrow")!)
+                        // The harmless UI-only rollout validator (issue #322):
+                        // a cached, telemetry-gated boolean that adds one
+                        // factual link and does nothing else. OFF by default.
+                        if FeatureFlags.isEnabled(.aboutReleaseNotesLink) {
+                            Link(NSLocalizedString("Release Notes", comment: ""),
+                                 destination: URL(string: "https://github.com/caezium/Burrow/releases")!)
+                        }
                     }
                     .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.green)
                 }

--- a/macos/Sources/Telemetry.swift
+++ b/macos/Sources/Telemetry.swift
@@ -220,6 +220,11 @@ enum Telemetry {
         return deliveryConfiguration
     }
 
+    /// Whether a feature-flag exposure would actually be queued. Used by
+    /// `FeatureFlags` to commit an exposure key only when the event is
+    /// admitted; otherwise the key stays eligible for a later lookup.
+    static var canCapture: Bool { activeDeliveryConfiguration() != nil }
+
     private static func configuredDelivery() -> DeliveryConfiguration? {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -459,7 +464,11 @@ enum Telemetry {
         guard var components = URLComponents(url: host, resolvingAgainstBaseURL: false) else {
             return nil
         }
-        components.path = components.path + "/decide/"
+        // Normalize a trailing slash so both "https://host" and
+        // "https://host/" produce exactly one separator.
+        var path = components.path
+        if path.hasSuffix("/") { path.removeLast() }
+        components.path = path + "/decide/"
         components.query = "v=3"
         return components.url
     }

--- a/macos/Sources/Telemetry.swift
+++ b/macos/Sources/Telemetry.swift
@@ -25,7 +25,11 @@ enum Telemetry {
 
     private struct DeliveryConfiguration {
         let projectKey: String
-        let endpoint: URL
+        /// Validated HTTPS host root, shared by the `/batch` event endpoint
+        /// and the `/decide/` feature-flag endpoint.
+        let host: URL
+
+        var endpoint: URL { host.appendingPathComponent("batch") }
     }
 
     private static let stateLock = NSLock()
@@ -86,8 +90,8 @@ enum Telemetry {
         let projectKey = (info?["PHPostHogApiKey"] as? String) ?? ""
         let host = (info?["PHPostHogHost"] as? String).flatMap { $0.isEmpty ? nil : $0 }
             ?? "https://us.i.posthog.com"
-        if !projectKey.isEmpty, let endpoint = postHogEndpoint(host: host) {
-            deliveryConfiguration = DeliveryConfiguration(projectKey: projectKey, endpoint: endpoint)
+        if !projectKey.isEmpty, let hostRoot = postHogHostRoot(host: host) {
+            deliveryConfiguration = DeliveryConfiguration(projectKey: projectKey, host: hostRoot)
         }
         let delivery = deliveryConfiguration
         stateLock.unlock()
@@ -99,6 +103,7 @@ enum Telemetry {
         guard let delivery, isEnabled else { return }
         CrashReporter.breadcrumb("app_opened", category: "lifecycle")
         enqueue(.event("app_opened", ["cold_start": true]), using: delivery)
+        refreshFeatureFlags(using: delivery)
     }
 
     /// Best-effort termination flush. Every event has already started its own
@@ -161,6 +166,9 @@ enum Telemetry {
 
         if enabled {
             capture("telemetry_opt_in_changed", ["enabled": true])
+            // Flags were inert while opted out; pick them up now that the
+            // gate is open, exactly as a launch that begins opted-in would.
+            refreshFeatureFlags(using: delivery)
         } else {
             workQueue.async {
                 cancelInFlightDeliveries()
@@ -429,6 +437,12 @@ enum Telemetry {
     }
 
     static func postHogEndpoint(host: String) -> URL? {
+        postHogHostRoot(host: host)?.appendingPathComponent("batch")
+    }
+
+    /// Validated HTTPS host root (no credentials, query, or fragment) shared
+    /// by the event and decide endpoints.
+    static func postHogHostRoot(host: String) -> URL? {
         guard let base = URL(string: host),
               base.scheme == "https",
               base.host != nil,
@@ -436,7 +450,90 @@ enum Telemetry {
               base.password == nil,
               base.query == nil,
               base.fragment == nil else { return nil }
-        return base.appendingPathComponent("batch")
+        return base
+    }
+
+    /// The feature-flag decide endpoint. HTTPS comes from the validated host
+    /// root; the fixed `v=3` API version is the only query parameter.
+    static func decideEndpoint(on host: URL) -> URL? {
+        guard var components = URLComponents(url: host, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.path = components.path + "/decide/"
+        components.query = "v=3"
+        return components.url
+    }
+
+    // MARK: - Feature flags (issue #322)
+
+    /// Fetches PostHog's decide response once per launch (and once more on
+    /// opt-in) on the telemetry queue, and hands the filtered result to
+    /// `FeatureFlags`. Nothing ever waits on this: lookups serve the
+    /// conservative defaults until a fresh cache or successful response is
+    /// applied, and every failure — opt-out, missing key, transport, HTTP,
+    /// malformed payload — simply leaves the local state untouched. There is
+    /// exactly one attempt per trigger, serialized behind the same queue as
+    /// event delivery, so flags add no timer, no retry loop, and no extra
+    /// concurrency; the next launch is the backoff.
+    private static func refreshFeatureFlags(using delivery: DeliveryConfiguration) {
+        workQueue.async {
+            // Re-check at execution time: an opt-out that raced this block
+            // must neither read the flag cache nor contact PostHog.
+            guard isEnabled else { return }
+            if let cached = FeatureFlags.loadCachedIfEnabled(
+                isEnabled: isEnabled,
+                directory: FeatureFlags.defaultCacheDirectory()
+            ) {
+                FeatureFlags.apply(cached, persistTo: nil)
+            }
+
+            // The decide request is the smallest possible: the project key
+            // and the same anonymous distinct id events already use. No
+            // person properties, no groups, no locale — the response is
+            // filtered down to the boolean allowlist in `FeatureFlags`
+            // regardless of what PostHog returns.
+            guard let decide = decideEndpoint(on: delivery.host) else { return }
+            let payload: [String: Any] = [
+                "api_key": delivery.projectKey,
+                "distinct_id": resolveDistinctID(projectKey: delivery.projectKey),
+            ]
+            guard JSONSerialization.isValidJSONObject(payload),
+                  let body = try? JSONSerialization.data(withJSONObject: payload) else { return }
+
+            var request = URLRequest(url: decide)
+            request.httpMethod = "POST"
+            request.timeoutInterval = 10
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+            request.setValue("Burrow/\(RuntimeEnvironment.current.appVersion)", forHTTPHeaderField: "User-Agent")
+            request.httpBody = body
+
+            let requestID = UUID()
+            deliveries.enter()
+            let task = session.dataTask(with: request) { data, response, error in
+                let status = (response as? HTTPURLResponse)?.statusCode
+                let disposition = deliveryDisposition(statusCode: status, hasTransportError: error != nil)
+                workQueue.async {
+                    inFlightTasks.removeValue(forKey: requestID)
+                    // Re-check the gate at completion: an opt-out that raced
+                    // the response must neither mutate nor persist flags.
+                    guard isEnabled, disposition == .delivered, let data,
+                          let decoded = try? JSONSerialization.jsonObject(with: data),
+                          let object = decoded as? [String: Any],
+                          let rawFlags = object["featureFlags"] as? [String: Any] else {
+                        deliveries.leave()
+                        return
+                    }
+                    FeatureFlags.apply(
+                        FeatureFlags.sanitizeRemoteFlags(rawFlags),
+                        persistTo: FeatureFlags.defaultCacheDirectory()
+                    )
+                    deliveries.leave()
+                }
+            }
+            inFlightTasks[requestID] = task
+            task.resume()
+        }
     }
 
     /// Stable random install id, resolved only after telemetry is enabled. For

--- a/macos/Tests/FeatureFlagTests.swift
+++ b/macos/Tests/FeatureFlagTests.swift
@@ -78,15 +78,18 @@ final class FeatureFlagTests: XCTestCase {
 
     // A malformed cache (bad JSON, wrong version, wrong types, missing or
     // stale timestamp) discards the whole file; only a strict, fresh shape
-    // decodes.
+    // decodes. This keeps a corrupt or malicious file from ever overriding
+    // the conservative defaults.
     func testMalformedOrStaleCachesAreDiscarded() throws {
         let stale = now.addingTimeInterval(-FeatureFlags.maxCacheAge - 60)
         let fresh = now.addingTimeInterval(-FeatureFlags.maxCacheAge + 60)
+        let future = now.addingTimeInterval(60)
 
         XCTAssertNil(FeatureFlags.decodeCache(Data("not json".utf8), now: now))
         XCTAssertNil(FeatureFlags.decodeCache(Data("[]".utf8), now: now))
 
-        // Wrong top-level types.
+        // A cache with the wrong schema or types is unsafe to use; it
+        // must be discarded rather than partially decoded.
         XCTAssertNil(
             FeatureFlags.decodeCache(Data(#"{"version":1,"fetched_at":"oops","flags":{}}"#.utf8), now: now)
         )
@@ -94,22 +97,15 @@ final class FeatureFlagTests: XCTestCase {
             FeatureFlags.decodeCache(Data(#"{"version":2,"fetched_at":"2026-01-01T00:00:00Z","flags":{}}"#.utf8), now: now)
         )
 
-        // Stale timestamp → discard; fresh-but-unknown flag keys inside a
-        // well-formed envelope → valid empty set (defaults stay in force).
+        // Future or stale timestamps are both untrustworthy.
         try encodeAndWrite([.aboutReleaseNotesLink: true], fetchedAt: stale)
         XCTAssertNil(FeatureFlags.loadCached(from: directory, now: now), "stale cache must be discarded")
 
-        let freshData = try XCTUnwrap(
-            FeatureFlags.encodeCache([:], fetchedAt: fresh),
-            "encoder must produce data"
-        )
-        XCTAssertEqual(
-            FeatureFlags.decodeCache(freshData, now: now),
-            [:],
-            "valid envelope with no allowlisted keys is fine — defaults apply"
-        )
+        let futureData = try XCTUnwrap(FeatureFlags.encodeCache([.aboutReleaseNotesLink: true], fetchedAt: future))
+        XCTAssertNil(FeatureFlags.decodeCache(futureData, now: now), "future cache timestamp must be rejected")
 
-        // Roundtrip preserves values.
+        // Persisting and reloading must reproduce the accepted snapshot
+        // exactly while discarding unknown keys.
         let roundtrip = try XCTUnwrap(FeatureFlags.encodeCache([.aboutReleaseNotesLink: true], fetchedAt: fresh))
         XCTAssertEqual(FeatureFlags.decodeCache(roundtrip, now: now), [.aboutReleaseNotesLink: true])
     }
@@ -159,13 +155,21 @@ final class FeatureFlagTests: XCTestCase {
     }
 
     // The decide URL is fixed by the validated HTTPS host root; only the
-    // API version appears as a query.
+    // API version appears as a query. Trailing slashes must not create
+    // double path separators.
     func testDecideEndpointIsHTTPSWithFixedVersion() throws {
         let host = try XCTUnwrap(Telemetry.postHogHostRoot(host: "https://us.i.posthog.com"))
         XCTAssertEqual(
             Telemetry.decideEndpoint(on: host)?.absoluteString,
             "https://us.i.posthog.com/decide/?v=3"
         )
+
+        let hostWithSlash = try XCTUnwrap(Telemetry.postHogHostRoot(host: "https://us.i.posthog.com/"))
+        XCTAssertEqual(
+            Telemetry.decideEndpoint(on: hostWithSlash)?.absoluteString,
+            "https://us.i.posthog.com/decide/?v=3"
+        )
+
         XCTAssertNil(Telemetry.postHogHostRoot(host: "http://insecure.example.com"))
     }
 }

--- a/macos/Tests/FeatureFlagTests.swift
+++ b/macos/Tests/FeatureFlagTests.swift
@@ -1,0 +1,171 @@
+//
+//  FeatureFlagTests.swift
+//  BurrowTests
+//
+//  Issue #322 acceptance: the flag system must be inert when opted out,
+//  discard stale/malformed/oversized caches, ignore unknown keys and
+//  non-boolean values, and fall back to conservative defaults on every
+//  failure path. These tests pin those rules down without any network.
+//
+
+import XCTest
+@testable import Burrow
+
+final class FeatureFlagTests: XCTestCase {
+    private var directory: URL!
+    private var now: Date!
+
+    override func setUp() {
+        super.setUp()
+        FeatureFlags.resetForTesting()
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("feature-flag-tests-\(UUID().uuidString)", isDirectory: true)
+        now = Date()
+    }
+
+    override func tearDown() {
+        FeatureFlags.resetForTesting()
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    private func cacheURL() -> URL {
+        directory.appendingPathComponent(FeatureFlags.cacheFileName)
+    }
+
+    private func writeCache(_ data: Data) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try data.write(to: cacheURL(), options: .atomic)
+    }
+
+    private func encodeAndWrite(_ flags: [FeatureFlags.Key: Bool], fetchedAt: Date) throws {
+        let data = try XCTUnwrap(FeatureFlags.encodeCache(flags, fetchedAt: fetchedAt))
+        try writeCache(data)
+    }
+
+    // An opted-out launch must not even read the flag cache.
+    func testOptedOutLaunchNeverReadsTheCache() throws {
+        try encodeAndWrite([.aboutReleaseNotesLink: true], fetchedAt: now)
+        XCTAssertNil(
+            FeatureFlags.loadCachedIfEnabled(isEnabled: false, directory: directory, now: now),
+            "opt-out must ignore a perfectly fresh cache"
+        )
+        XCTAssertEqual(
+            FeatureFlags.loadCachedIfEnabled(isEnabled: true, directory: directory, now: now),
+            [.aboutReleaseNotesLink: true],
+            "the same cache is readable once telemetry is enabled"
+        )
+    }
+
+    // Unknown keys and non-boolean values in a decide response are ignored;
+    // only allowlisted booleans survive, so a hostile or future payload
+    // cannot smuggle new flags or types into the app.
+    func testRemotePayloadAcceptsOnlyAllowlistedBooleans() {
+        let raw: [String: Any] = [
+            "about_release_notes_link": true,
+            "delete_everything": true,
+            "about_release_notes_link_variant": "bold",
+            "rollout_percent": 50,
+        ]
+        XCTAssertEqual(FeatureFlags.sanitizeRemoteFlags(raw), [.aboutReleaseNotesLink: true])
+        XCTAssertEqual(FeatureFlags.sanitizeRemoteFlags(nil), [:])
+        XCTAssertEqual(
+            FeatureFlags.sanitizeRemoteFlags(["about_release_notes_link": "true"]),
+            [:],
+            "a string is not a boolean — ignored"
+        )
+    }
+
+    // A malformed cache (bad JSON, wrong version, wrong types, missing or
+    // stale timestamp) discards the whole file; only a strict, fresh shape
+    // decodes.
+    func testMalformedOrStaleCachesAreDiscarded() throws {
+        let stale = now.addingTimeInterval(-FeatureFlags.maxCacheAge - 60)
+        let fresh = now.addingTimeInterval(-FeatureFlags.maxCacheAge + 60)
+
+        XCTAssertNil(FeatureFlags.decodeCache(Data("not json".utf8), now: now))
+        XCTAssertNil(FeatureFlags.decodeCache(Data("[]".utf8), now: now))
+
+        // Wrong top-level types.
+        XCTAssertNil(
+            FeatureFlags.decodeCache(Data(#"{"version":1,"fetched_at":"oops","flags":{}}"#.utf8), now: now)
+        )
+        XCTAssertNil(
+            FeatureFlags.decodeCache(Data(#"{"version":2,"fetched_at":"2026-01-01T00:00:00Z","flags":{}}"#.utf8), now: now)
+        )
+
+        // Stale timestamp → discard; fresh-but-unknown flag keys inside a
+        // well-formed envelope → valid empty set (defaults stay in force).
+        try encodeAndWrite([.aboutReleaseNotesLink: true], fetchedAt: stale)
+        XCTAssertNil(FeatureFlags.loadCached(from: directory, now: now), "stale cache must be discarded")
+
+        let freshData = try XCTUnwrap(
+            FeatureFlags.encodeCache([:], fetchedAt: fresh),
+            "encoder must produce data"
+        )
+        XCTAssertEqual(
+            FeatureFlags.decodeCache(freshData, now: now),
+            [:],
+            "valid envelope with no allowlisted keys is fine — defaults apply"
+        )
+
+        // Roundtrip preserves values.
+        let roundtrip = try XCTUnwrap(FeatureFlags.encodeCache([.aboutReleaseNotesLink: true], fetchedAt: fresh))
+        XCTAssertEqual(FeatureFlags.decodeCache(roundtrip, now: now), [.aboutReleaseNotesLink: true])
+    }
+
+    // The cache file is allowlist-sized by construction; anything bigger is
+    // corrupt or foreign and must be discarded before it is even read.
+    func testOversizedCacheFileIsDiscardedUnread() throws {
+        try writeCache(Data(repeating: 0x20, count: FeatureFlags.maxCacheBytes + 1))
+        XCTAssertNil(FeatureFlags.loadCached(from: directory, now: now))
+    }
+
+    // Conservative defaults: before anything is applied — and after any
+    // empty/failed application — every flag reads OFF.
+    func testLookupsServeConservativeDefaultsOnEveryFailure() {
+        XCTAssertFalse(FeatureFlags.isEnabled(.aboutReleaseNotesLink), "default is OFF")
+
+        // The network-failure path: no (or an empty) accepted set is applied.
+        FeatureFlags.apply(FeatureFlags.sanitizeRemoteFlags(nil), persistTo: nil)
+        XCTAssertFalse(FeatureFlags.isEnabled(.aboutReleaseNotesLink))
+
+        FeatureFlags.apply([.aboutReleaseNotesLink: true], persistTo: nil)
+        XCTAssertTrue(FeatureFlags.isEnabled(.aboutReleaseNotesLink))
+    }
+
+    // apply(persistTo:) writes the merged snapshot; a later launch reads it
+    // back through the same codec and non-allowlisted content never lands
+    // in the file.
+    func testApplyPersistsMergedSnapshotForLaterLaunches() throws {
+        FeatureFlags.apply([.aboutReleaseNotesLink: true], persistTo: directory)
+        XCTAssertEqual(FeatureFlags.loadCached(from: directory, now: now), [.aboutReleaseNotesLink: true])
+
+        let written = try String(contentsOf: cacheURL(), encoding: .utf8)
+        XCTAssertFalse(written.contains("delete_everything"))
+        XCTAssertTrue(written.contains("about_release_notes_link"))
+    }
+
+    // Flag keys become event properties and on-disk names, so the allowlist
+    // must stay safe identifiers and duplicate-free.
+    func testAllowlistedKeysAreSafeUniqueIdentifiers() {
+        XCTAssertEqual(Set(FeatureFlags.Key.allCases.map(\.rawValue)).count,
+                       FeatureFlags.Key.allCases.count,
+                       "keys key the snapshot map, so they must be unique")
+        for key in FeatureFlags.Key.allCases {
+            XCTAssertTrue(DiagnosticPrivacy.isSafeIdentifier(key.rawValue),
+                          "\(key.rawValue) must remain a safe identifier")
+        }
+    }
+
+    // The decide URL is fixed by the validated HTTPS host root; only the
+    // API version appears as a query.
+    func testDecideEndpointIsHTTPSWithFixedVersion() throws {
+        let host = try XCTUnwrap(Telemetry.postHogHostRoot(host: "https://us.i.posthog.com"))
+        XCTAssertEqual(
+            Telemetry.decideEndpoint(on: host)?.absoluteString,
+            "https://us.i.posthog.com/decide/?v=3"
+        )
+        XCTAssertNil(Telemetry.postHogHostRoot(host: "http://insecure.example.com"))
+    }
+}


### PR DESCRIPTION
## Description

Implements #322. Burrow gains privacy-safe, cached feature flags for gradual rollout and UI experiments, built on the existing first-party PostHog transport.

### How it works

- **Allowlist-only keys** (`macos/Sources/FeatureFlags.swift`): a `FeatureFlags.Key` enum is the complete set of flags. Unknown keys and non-boolean values in a decide response are ignored at parse time — a key not in the enum cannot be requested, cached, persisted, or change any behavior, regardless of what the server returns.
- **Conservative defaults**: every flag bakes in an OFF default; lookups are synchronous, main-thread-safe, and never touch disk or network.
- **One decide request per enabled launch** (`Telemetry.refreshFeatureFlags`), plus one more on opt-in. It runs on the existing `dev.caezium.Burrow.telemetry.posthog` serial queue — no run-loop timer, no retry loop, no new concurrency; the next launch is the backoff. The request body is exactly `api_key` + the same random `distinct_id` events already use (no person properties, groups, or locale). HTTPS comes from the validated host root (same checks as `/batch`); a plain `http` host is rejected.
- **Cache** at `~/Library/Application Support/Burrow/feature-flags.json`: bounded to 16 KB, expires after 7 days, strict decode (exact version + ISO-8601 timestamp + allowlisted booleans). Malformed/oversized/stale/wrong-version files are discarded whole. Startup reads the cache only when telemetry is enabled; an opted-out launch neither reads nor writes it and contacts nothing.
- **Exposure events**: first lookup of each flag per launch emits `feature_flag_exposed` with exactly `flag` + boolean `value`; like every event it is dropped while opted out or before `start()`.
- **Failure model**: opt-out, missing release key, transport error, non-2xx, malformed payload, stale cache → the app runs fully on baked-in defaults, indistinguishable from a flag-free build. Flags gate UI/rollout choices only — never cleaning/deletion behavior, permissions, security controls, signing/notarization, Sparkle verification, launch recovery, or telemetry consent.

### Rollout validator

The initial allowlist has one deliberately harmless flag: `about_release_notes_link` (default OFF) adds a "Release Notes" link in Settings ▸ About — a real end-to-end fetch → cache → lookup → exposure exercise before any broader use.

### Docs

- `TELEMETRY.md`: new "Feature flags" section documenting the exact request fields, stored cache, flag keys, defaults, and exposure event; events table gains `feature_flag_exposed`; the "deliberately deferred" note is updated.
- `SECURITY.md`: the telemetry bullet describes the flag gate/queue/allowlist/cache model.
- `PrivacyInfo.xcprivacy` is unchanged: flags reuse the already-declared Product Interaction / Other Usage Data categories with no new data types.

## Related Issue

Closes #322

## Type of Change

- [x] New feature

## Testing

- New `macos/Tests/FeatureFlagTests.swift` (8 tests): opt-out inertness, stale/malformed/oversized cache handling, unknown keys / non-boolean values, network-failure fallback to conservative defaults, persistence roundtrip, key-identifier safety, decide endpoint construction.
- Full macOS test suite passes locally: `xcodebuild test -scheme Burrow -destination 'platform=macOS'` — **TEST SUCCEEDED** (all suites, 0 failures), unsigned per CI convention.

## Notes for reviewers

- `DeliveryConfiguration` now stores the validated host root and derives `/batch` from it (`postHogEndpoint` behavior is unchanged and still covered by `TelemetryPolicyTests`).
- Flag values are evaluated on view rebuild (rollout switches, not live remotes); a mid-session flip becomes visible the next time the view rebuilds.
- Greenlight: the only new URL construction reuses the existing HTTPS-validated host root; no plaintext-http endpoints are introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added privacy-conscious feature flags with secure defaults, local caching, and opt-out support.
  * Added an optional “Release Notes” link to the About section.
  * Added launch-time flag updates and exposure tracking with reliable fallback behavior.

* **Documentation**
  * Updated telemetry and security documentation to explain feature-flag behavior, caching, privacy protections, and failure handling.

* **Tests**
  * Added coverage for cache validation, privacy controls, remote flag filtering, persistence, endpoint configuration, and safe defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->