### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,11 @@ _Recently shipped: Developer ID signed & Apple-notarized macOS releases, Signed 
 <!-- ROADMAP:END -->
 
 
-<a href="https://www.star-history.com/?repos=caezium%2FBurrow&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#caezium/Burrow&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=caezium/Burrow&type=timeline&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=caezium/Burrow&type=timeline&legend=top-left" />
-   <img height="350" alt="Star History Chart" src="https://api.star-history.com/chart?repos=caezium/Burrow&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=caezium/Burrow&type=timeline&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=caezium/Burrow&type=timeline&legend=top-left" />
+   <img height="350" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=caezium/Burrow&type=timeline&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README is currently broken and no longer displays the repository's history. Update its links so the chart renders correctly again while preserving the existing timeline and legend settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History embed links to use the current hosting domain and SVG assets.
  * Replaced legacy Star History URLs in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->