### PR TITLE
docs: record the privacy-manifest re-review for feature flags

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -25,6 +25,17 @@ Performance, and Other Diagnostic Data for app functionality. Every category
 is unlinked and non-tracking. The manifest changes no collection behavior; it
 describes the opt-out behavior enforced below.
 
+The manifest was last re-reviewed against the shipping request and event
+fields when feature flags landed (issue #322), and needs no new entry for
+them. The `feature_flag_exposed` event is Product Interaction collected for
+analytics, already declared above; the decide request adds no data type the
+event pipeline was not already sending, since `api_key` is the release
+project key and `distinct_id` is the same random anonymous install id every
+event carries. The local flag cache reads only a file's size and regular-file
+status and takes its age from an ISO-8601 timestamp stored inside the JSON,
+never from file creation or modification dates, so it adds no required-reason
+API category beyond the ones declared above.
+
 Sparkle update checks are operational network traffic. Sparkle requests the
 signed `appcast.xml` asset from GitHub and, after user approval, the signed
 release ZIP; Burrow adds no identifier or device profile to those requests.


### PR DESCRIPTION
Closes the last open acceptance criterion from #322 — "the privacy manifest is re-reviewed against the final request/event fields." The re-review concluded that [`PrivacyInfo.xcprivacy`](macos/Resources/PrivacyInfo.xcprivacy) needs no change, but that conclusion was never recorded, so the next reader cannot distinguish a completed review from a skipped one.

## What changed

Docs only. A paragraph in `TELEMETRY.md`, next to the existing manifest description, stating the result and its reasoning:

- **`feature_flag_exposed`** is Product Interaction collected for analytics — already declared, unlinked and non-tracking.
- **The decide request** adds no data type the event pipeline was not already sending: `api_key` is the release project key, and `distinct_id` is the same random anonymous install id every event already carries.
- **The flag cache** reads only a file's size and regular-file status, and takes its age from an ISO-8601 timestamp stored inside the JSON — never from file creation or modification dates. So it adds no required-reason API category beyond those already declared.

## Verification

Claims were checked against the merged implementation rather than the PR description: `FeatureFlags.loadCached` uses `resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])` and `decodeCache` derives age from the in-JSON `fetched_at`, with no `.creationDateKey` / `.contentModificationDateKey` access anywhere in the file. `greenlight preflight macos` runs in the `compliance` job and covers the other half of that acceptance criterion on every PR.

No code, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that feature-flag analytics and local flag-cache behavior are covered by existing privacy disclosures.
  * Documented the relevant exposure event, decision-request data, anonymous identifiers, and cache metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->