### PR TITLE
fix(ui): light-mode adaptive colors + un-block the Clean confirm pill

### DIFF
--- a/macos/Sources/Brand.swift
+++ b/macos/Sources/Brand.swift
@@ -62,6 +62,12 @@ enum Brand {
     static let cardFillHover = Color.adaptive(0xF2ECE0, 0xFFFFFF, darkA: 0.11, lightA: 0.90)
     static let chipFill      = Color.adaptive(0xF2ECE0, 0x2A2114, darkA: 0.08, lightA: 0.07)
     static let trackFill     = Color.adaptive(0xF2ECE0, 0x2A2114, darkA: 0.10, lightA: 0.10)
+    /// Recessed panel/track — darker than the ground in both modes.
+    static let insetFill     = Color.adaptive(0x000000, 0x2A2114, darkA: 0.22, lightA: 0.07)
+
+    // MARK: Inverse — the high-contrast CTA pill (bright on dark, ink on paper)
+    static let inverse   = Color.adaptive(0xFFFFFF, 0x221B11)
+    static let onInverse = Color.adaptive(0x0F0B05, 0xF4EFE6)
 
     // MARK: Accent — one electric blue for primary emphasis (both modes)
     static let accent   = Color(hex: 0x5B8DEF)

--- a/macos/Sources/CleanReviewView.swift
+++ b/macos/Sources/CleanReviewView.swift
@@ -168,7 +168,7 @@ struct CleanReviewView: View {
         Button(action: action) {
             ZStack {
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(state == .none ? Color.white.opacity(0.07) : accent.opacity(0.9))
+                    .fill(state == .none ? Brand.chipFill : accent.opacity(0.9))
                     .frame(width: 17, height: 17)
                 switch state {
                 case .all:
@@ -194,7 +194,7 @@ struct CleanReviewView: View {
             Button { selection.toggle(item.path) } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .fill(ticked ? accent.opacity(0.9) : Color.white.opacity(0.07))
+                        .fill(ticked ? accent.opacity(0.9) : Brand.chipFill)
                         .frame(width: 15, height: 15)
                     if ticked {
                         Image(systemName: "checkmark").font(.system(size: 8, weight: .bold)).foregroundStyle(.black)
@@ -281,9 +281,9 @@ struct CleanReviewView: View {
             Spacer()
             Button { onConfirm(selection) } label: {
                 Text(pillLabel)
-                    .font(Brand.sans(13, .semibold)).foregroundStyle(.black)
+                    .font(Brand.sans(13, .semibold)).foregroundStyle(Brand.onInverse)
                     .padding(.horizontal, 20).padding(.vertical, 10)
-                    .background(Capsule().fill(Color.white))
+                    .background(Capsule().fill(Brand.inverse))
             }
             .buttonStyle(.plain)
             .disabled(selection.selectedCount == 0)

--- a/macos/Sources/Components/AccessBanner.swift
+++ b/macos/Sources/Components/AccessBanner.swift
@@ -20,6 +20,11 @@ struct AccessBanner: View {
     var onAction: () -> Void = { Privacy.openFullDiskAccessSettings() }
     var onDismiss: () -> Void
 
+    /// The bar keeps its fixed dark ground in both modes, so every foreground
+    /// must be fixed too — the adaptive Brand text colours turn espresso in
+    /// light mode and vanished against this background (#410).
+    private static let onDark = Color(hex: 0xEDE6DA)
+
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: glyph)
@@ -30,23 +35,23 @@ struct AccessBanner: View {
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.textPrimary)
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(Self.onDark)
                 Text(detail)
-                    .font(Brand.sans(11)).foregroundStyle(Brand.textSecondary)
+                    .font(Brand.sans(11)).foregroundStyle(Self.onDark.opacity(0.62))
             }
             Spacer(minLength: 14)
             Button(action: onAction) {
                 Text(actionTitle)
-                    .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.textPrimary)
+                    .font(Brand.sans(11, .semibold)).foregroundStyle(Self.onDark)
                     .padding(.horizontal, 12).padding(.vertical, 6)
                     .background(Capsule().fill(Color.white.opacity(0.10)))
-                    .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
+                    .overlay(Capsule().strokeBorder(Color.white.opacity(0.12), lineWidth: 1))
             }
             .buttonStyle(.plain)
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
                     .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Brand.textTertiary)
+                    .foregroundStyle(Self.onDark.opacity(0.55))
                     .frame(width: 22, height: 22)
                     .contentShape(Rectangle())
             }

--- a/macos/Sources/Components/PermissionRow.swift
+++ b/macos/Sources/Components/PermissionRow.swift
@@ -26,7 +26,7 @@ struct PermissionRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Circle()
-                .fill(granted ? Brand.green : Color.white.opacity(0.22))
+                .fill(granted ? Brand.green : Brand.ink.opacity(0.22))
                 .frame(width: 9, height: 9)
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 3) {
@@ -65,7 +65,7 @@ struct PermissionRow: View {
             Text(label)
                 .font(Brand.sans(11, .semibold)).foregroundStyle(Brand.textPrimary)
                 .padding(.horizontal, 12).padding(.vertical, 6)
-                .background(Capsule().fill(Color.white.opacity(0.08)))
+                .background(Capsule().fill(Brand.chipFill))
                 .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
         }
         .buttonStyle(.plain)

--- a/macos/Sources/Components/ShortcutRecorder.swift
+++ b/macos/Sources/Components/ShortcutRecorder.swift
@@ -32,7 +32,7 @@ struct ShortcutRecorder: View {
                     .foregroundStyle(recording ? Brand.amber : Brand.textPrimary)
                     .padding(.horizontal, 10).padding(.vertical, 5)
                     .frame(minWidth: 86)
-                    .background(RoundedRectangle(cornerRadius: 7).fill(Color.white.opacity(recording ? 0.14 : 0.08)))
+                    .background(RoundedRectangle(cornerRadius: 7).fill(Brand.ink.opacity(recording ? 0.14 : 0.08)))
                     .overlay(RoundedRectangle(cornerRadius: 7)
                         .strokeBorder(recording ? Brand.amber.opacity(0.5) : Brand.hairline, lineWidth: 1))
             }

--- a/macos/Sources/Components/TaskTicker.swift
+++ b/macos/Sources/Components/TaskTicker.swift
@@ -109,7 +109,7 @@ struct TaskTickerView: View {
                 .scrollIndicators(.hidden)
                 .frame(height: CGFloat(Self.visibleRows) * 19 + 20)
                 .frame(maxWidth: 460)
-                .background(RoundedRectangle(cornerRadius: 13, style: .continuous).fill(Color.black.opacity(0.25)))
+                .background(RoundedRectangle(cornerRadius: 13, style: .continuous).fill(Brand.insetFill))
                 .overlay(RoundedRectangle(cornerRadius: 13, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
                 // Deferred past the current update transaction: a synchronous
                 // scrollTo here mutates the scroll responder graph mid-way

--- a/macos/Sources/DupesView.swift
+++ b/macos/Sources/DupesView.swift
@@ -148,9 +148,9 @@ struct DupesView: View {
                 .multilineTextAlignment(.center).frame(maxWidth: 440)
             Button { pickFolder() } label: {
                 Text(NSLocalizedString("Choose a folder…", comment: ""))
-                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.onInverse)
                     .padding(.horizontal, 14).padding(.vertical, 6)
-                    .background(Capsule().fill(.white))
+                    .background(Capsule().fill(Brand.inverse))
             }
             .buttonStyle(.plain)
             .padding(.top, 4)
@@ -286,7 +286,7 @@ struct DupesView: View {
         Button(action: action) {
             ZStack {
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(state == .none ? Color.white.opacity(0.07) : Tool.dupes.accent.opacity(0.9))
+                    .fill(state == .none ? Brand.chipFill : Tool.dupes.accent.opacity(0.9))
                     .frame(width: 17, height: 17)
                 switch state {
                 case .all:
@@ -310,7 +310,7 @@ struct DupesView: View {
             Button { model.toggle(path) } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .fill(ticked ? Tool.dupes.accent.opacity(0.9) : Color.white.opacity(0.07))
+                        .fill(ticked ? Tool.dupes.accent.opacity(0.9) : Brand.chipFill)
                         .frame(width: 15, height: 15)
                     if ticked {
                         Image(systemName: "checkmark").font(.system(size: 8, weight: .bold)).foregroundStyle(.black)
@@ -358,7 +358,7 @@ struct DupesView: View {
                 Text(NSLocalizedString("Reclaim via clones…", comment: ""))
                     .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.textPrimary)
                     .padding(.horizontal, 14).padding(.vertical, 8)
-                    .background(Capsule().fill(Color.white.opacity(0.08)))
+                    .background(Capsule().fill(Brand.chipFill))
                     .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
             }
             .buttonStyle(.plain)
@@ -369,9 +369,9 @@ struct DupesView: View {
                 Text(String(format: NSLocalizedString("Move to Trash · %@", comment: "confirm pill"),
                             Fmt.bytes(model.selection.selectedBytes(in: report))))
                     .font(Brand.sans(12, .semibold))
-                    .foregroundStyle(model.selection.isEmpty ? Brand.textTertiary : .black)
+                    .foregroundStyle(model.selection.isEmpty ? Brand.textTertiary : Brand.onInverse)
                     .padding(.horizontal, 16).padding(.vertical, 8)
-                    .background(Capsule().fill(model.selection.isEmpty ? Color.white.opacity(0.06) : Color.white))
+                    .background(Capsule().fill(model.selection.isEmpty ? Brand.chipFill : Brand.inverse))
             }
             .buttonStyle(.plain)
             .disabled(model.selection.isEmpty || model.deduping || model.scanning)

--- a/macos/Sources/InstallerView.swift
+++ b/macos/Sources/InstallerView.swift
@@ -325,7 +325,7 @@ struct MoInteractiveView: View {
                     Text(selected.isEmpty ? LocalizedStringKey("Remove") : "Remove (\(selected.count))")
                         .font(Brand.sans(12, .semibold)).foregroundStyle(selected.isEmpty ? Brand.textTertiary : .white)
                         .padding(.horizontal, 14).padding(.vertical, 6)
-                        .background(Capsule().fill(selected.isEmpty ? Color.white.opacity(0.06) : cfg.tool.accent))
+                        .background(Capsule().fill(selected.isEmpty ? Brand.chipFill : cfg.tool.accent))
                 }.buttonStyle(.plain).disabled(selected.isEmpty)
             }
             .padding(.horizontal, 18).padding(.vertical, 10)

--- a/macos/Sources/NetView.swift
+++ b/macos/Sources/NetView.swift
@@ -99,9 +99,9 @@ struct NetView: View {
                 .multilineTextAlignment(.center).frame(maxWidth: 440)
             Button { model.scan() } label: {
                 Text(NSLocalizedString("Sample now", comment: ""))
-                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.onInverse)
                     .padding(.horizontal, 14).padding(.vertical, 6)
-                    .background(Capsule().fill(.white))
+                    .background(Capsule().fill(Brand.inverse))
             }
             .buttonStyle(.plain)
             .padding(.top, 4)

--- a/macos/Sources/OnboardingView.swift
+++ b/macos/Sources/OnboardingView.swift
@@ -54,7 +54,7 @@ struct OnboardingView: View {
         HStack(spacing: 7) {
             ForEach(0..<2, id: \.self) { i in
                 Capsule()
-                    .fill(Color.white.opacity(i == page ? 0.95 : 0.30))
+                    .fill(Brand.ink.opacity(i == page ? 0.95 : 0.30))
                     .frame(width: i == page ? 28 : 14, height: 4)
             }
         }
@@ -121,7 +121,7 @@ struct OnboardingView: View {
         HStack(spacing: 12) {
             Circle()
                 .fill((engine?.installed ?? false) ? Brand.green
-                      : (engine == nil ? Color.white.opacity(0.22) : Brand.amber))
+                      : (engine == nil ? Brand.ink.opacity(0.22) : Brand.amber))
                 .frame(width: 9, height: 9)
             VStack(alignment: .leading, spacing: 3) {
                 Text(NSLocalizedString("Cleaning engine", comment: ""))
@@ -235,7 +235,7 @@ struct OnboardingView: View {
     private var heroMark: some View {
         ZStack {
             Circle()
-                .strokeBorder(Color.white.opacity(0.08), lineWidth: 1)
+                .strokeBorder(Brand.hairline, lineWidth: 1)
                 .frame(width: 124, height: 124)
             Circle()
                 .fill(RadialGradient(colors: [Brand.cream.opacity(0.9), Brand.cream.opacity(0.12)],

--- a/macos/Sources/OrphansView.swift
+++ b/macos/Sources/OrphansView.swift
@@ -144,9 +144,9 @@ struct OrphansView: View {
                           path: NSHomeDirectory() + "/Library/Logs")
                 Button { pickFolder() } label: {
                     Text(NSLocalizedString("Choose a folder…", comment: ""))
-                        .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                        .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.onInverse)
                         .padding(.horizontal, 14).padding(.vertical, 6)
-                        .background(Capsule().fill(.white))
+                        .background(Capsule().fill(Brand.inverse))
                 }
                 .buttonStyle(.plain)
             }
@@ -160,7 +160,7 @@ struct OrphansView: View {
             Text(label)
                 .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.textPrimary)
                 .padding(.horizontal, 14).padding(.vertical, 6)
-                .background(Capsule().fill(Color.white.opacity(0.08)))
+                .background(Capsule().fill(Brand.chipFill))
                 .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
         }
         .buttonStyle(.plain)

--- a/macos/Sources/PhotosView.swift
+++ b/macos/Sources/PhotosView.swift
@@ -140,9 +140,9 @@ struct PhotosView: View {
                 .multilineTextAlignment(.center).frame(maxWidth: 440)
             Button { pickFolder() } label: {
                 Text(NSLocalizedString("Choose a folder…", comment: ""))
-                    .font(Brand.sans(12, .semibold)).foregroundStyle(.black)
+                    .font(Brand.sans(12, .semibold)).foregroundStyle(Brand.onInverse)
                     .padding(.horizontal, 14).padding(.vertical, 6)
-                    .background(Capsule().fill(.white))
+                    .background(Capsule().fill(Brand.inverse))
             }
             .buttonStyle(.plain)
             .padding(.top, 4)
@@ -290,7 +290,7 @@ private struct PhotoThumbView: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(Color.white.opacity(0.06))
+                .fill(Brand.chipFill)
             if let image {
                 Image(nsImage: image)
                     .resizable().aspectRatio(contentMode: .fill)

--- a/macos/Sources/PortsView.swift
+++ b/macos/Sources/PortsView.swift
@@ -71,7 +71,7 @@ struct PortsView: View {
                 ForEach(PortInspector.Filter.allCases, id: \.self) { seg($0) }
             }
             .padding(3)
-            .background(Capsule().fill(Color.black.opacity(0.22)))
+            .background(Capsule().fill(Brand.insetFill))
             .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
             if loading { ProgressView().controlSize(.small) }
             Spacer()
@@ -106,9 +106,9 @@ struct PortsView: View {
         }
         return Button { filter = f } label: {
             Text(label).font(Brand.mono(11, on ? .semibold : .regular))
-                .foregroundStyle(on ? .black : Brand.textSecondary)
+                .foregroundStyle(on ? Brand.onInverse : Brand.textSecondary)
                 .padding(.horizontal, 12).padding(.vertical, 5)
-                .background { if on { Capsule().fill(.white) } }
+                .background { if on { Capsule().fill(Brand.inverse) } }
                 .contentShape(Capsule())
         }.buttonStyle(.plain)
     }

--- a/macos/Sources/ProcessInspectorView.swift
+++ b/macos/Sources/ProcessInspectorView.swift
@@ -203,7 +203,7 @@ struct ProcessInspectorView: View {
             VStack(alignment: .leading, spacing: 7) { rows() }
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(RoundedRectangle(cornerRadius: 11, style: .continuous).fill(Color.black.opacity(0.18)))
+                .background(RoundedRectangle(cornerRadius: 11, style: .continuous).fill(Brand.insetFill))
                 .overlay(RoundedRectangle(cornerRadius: 11, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
         }
     }

--- a/macos/Sources/RootView.swift
+++ b/macos/Sources/RootView.swift
@@ -192,7 +192,10 @@ struct RootView: View {
         }
         // At most one banner at a time. FDA outranks the helper: without it
         // scans can't read the caches the helper would elevate over anyway.
-        .overlay(alignment: .bottom) {
+        // A safe-area inset, NOT an overlay: panes anchor their own confirm
+        // footers to the bottom edge, and an overlay drawn over them swallowed
+        // their clicks (#410 — the banner sat exactly on Clean's confirm pill).
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             if !fdaGranted, !fdaBannerDismissed {
                 AccessBanner(
                     title: NSLocalizedString("Full Disk Access is off", comment: ""),

--- a/macos/Sources/SettingsView.swift
+++ b/macos/Sources/SettingsView.swift
@@ -230,9 +230,9 @@ struct SettingsView: View {
                 Button { withAnimation(.easeOut(duration: 0.14)) { tab = t } } label: {
                     Text(t.label)
                         .font(Brand.mono(12, on ? .semibold : .regular))
-                        .foregroundStyle(on ? Color.black : Brand.textSecondary)
+                        .foregroundStyle(on ? Brand.onInverse : Brand.textSecondary)
                         .padding(.horizontal, 12).padding(.vertical, 5)
-                        .background { if on { Capsule().fill(.white) } }
+                        .background { if on { Capsule().fill(Brand.inverse) } }
                         .contentShape(Capsule())
                 }
                 .buttonStyle(.plain)
@@ -240,7 +240,7 @@ struct SettingsView: View {
             }
         }
         .padding(3)
-        .background(Capsule().fill(Color.black.opacity(0.22)))
+        .background(Capsule().fill(Brand.insetFill))
         .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
@@ -1046,7 +1046,7 @@ struct SettingsView: View {
             }
         }
         .padding(11)
-        .background(RoundedRectangle(cornerRadius: 10).fill(Color.black.opacity(0.25)))
+        .background(RoundedRectangle(cornerRadius: 10).fill(Brand.insetFill))
         .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Brand.hairline, lineWidth: 1))
     }
 

--- a/macos/Sources/SoftwareView.swift
+++ b/macos/Sources/SoftwareView.swift
@@ -143,7 +143,7 @@ struct SoftwareView: View {
             if BrewClient.isInstalled { seg("Services", .services) }
         }
         .padding(3)
-        .background(Capsule().fill(Color.black.opacity(0.22)))
+        .background(Capsule().fill(Brand.insetFill))
         .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
@@ -151,9 +151,9 @@ struct SoftwareView: View {
         let on = model.segment == value
         return Button { model.segment = value } label: {
             Text(NSLocalizedString(title, comment: "")).font(Brand.mono(11, on ? .semibold : .regular))
-                .foregroundStyle(on ? .black : Brand.textSecondary)
+                .foregroundStyle(on ? Brand.onInverse : Brand.textSecondary)
                 .padding(.horizontal, 12).padding(.vertical, 5)
-                .background { if on { Capsule().fill(.white) } }
+                .background { if on { Capsule().fill(Brand.inverse) } }
                 .contentShape(Capsule())
         }.buttonStyle(.plain)
     }
@@ -165,7 +165,7 @@ struct SoftwareView: View {
                 .textFieldStyle(.plain).font(Brand.sans(12)).frame(width: 130)
         }
         .padding(.horizontal, 8).padding(.vertical, 5)
-        .background(Capsule().fill(Color.black.opacity(0.22)))
+        .background(Capsule().fill(Brand.insetFill))
         .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
@@ -186,7 +186,7 @@ struct SoftwareView: View {
                 .textFieldStyle(.plain).font(Brand.sans(12)).frame(width: 130)
         }
         .padding(.horizontal, 8).padding(.vertical, 5)
-        .background(Capsule().fill(Color.black.opacity(0.22)))
+        .background(Capsule().fill(Brand.insetFill))
         .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
@@ -291,9 +291,9 @@ struct SoftwareView: View {
             } label: {
                 Text(model.uninstallButtonTitle)
                     .font(Brand.sans(12, .semibold))
-                    .foregroundStyle(model.selected.isEmpty ? Brand.textTertiary : .black)
+                    .foregroundStyle(model.selected.isEmpty ? Brand.textTertiary : Brand.onInverse)
                     .padding(.horizontal, 16).padding(.vertical, 7)
-                    .background(Capsule().fill(model.selected.isEmpty ? Color.white.opacity(0.06) : Color.white))
+                    .background(Capsule().fill(model.selected.isEmpty ? Brand.chipFill : Brand.inverse))
             }
             .buttonStyle(.plain)
             .disabled(model.selected.isEmpty)
@@ -418,7 +418,7 @@ struct AppRow: View {
                 }
             }
             .padding(12)
-            .background(RoundedRectangle(cornerRadius: 11, style: .continuous).fill(Color.black.opacity(0.22)))
+            .background(RoundedRectangle(cornerRadius: 11, style: .continuous).fill(Brand.insetFill))
             .overlay(RoundedRectangle(cornerRadius: 11, style: .continuous).strokeBorder(Brand.hairline, lineWidth: 1))
         } else if preview != nil {
             // Still says nothing about what Remove will then do, for the one reason that survived
@@ -477,7 +477,7 @@ struct AppRow: View {
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 4, style: .continuous)
-                        .fill(ticked ? Tool.apps.accent.opacity(0.9) : Color.white.opacity(0.07))
+                        .fill(ticked ? Tool.apps.accent.opacity(0.9) : Brand.chipFill)
                         .frame(width: 14, height: 14)
                     if refusal != nil {
                         Image(systemName: "lock.fill").font(.system(size: 7, weight: .bold))

--- a/macos/Sources/StatusView.swift
+++ b/macos/Sources/StatusView.swift
@@ -314,7 +314,7 @@ struct HealthRing: View {
     let color: Color
     var body: some View {
         ZStack {
-            Circle().stroke(Color.white.opacity(0.10), lineWidth: 6)
+            Circle().stroke(Brand.trackFill, lineWidth: 6)
             Circle()
                 .trim(from: 0, to: CGFloat(max(0, min(score, 100))) / 100)
                 .stroke(color, style: StrokeStyle(lineWidth: 6, lineCap: .round))
@@ -481,7 +481,7 @@ struct RingGauge: View {
     var body: some View {
         VStack(spacing: 3) {
             ZStack {
-                Circle().stroke(Color.white.opacity(0.10), lineWidth: 4)
+                Circle().stroke(Brand.trackFill, lineWidth: 4)
                 Circle()
                     .trim(from: 0, to: CGFloat(max(0, min(percent, 100))) / 100)
                     .stroke(color, style: StrokeStyle(lineWidth: 4, lineCap: .round))
@@ -551,7 +551,7 @@ struct BluetoothStrip: View {
             }
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
-        .background(Capsule().fill(Color.white.opacity(0.05)))
+        .background(Capsule().fill(Brand.chipFill))
         .overlay(Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
     }
 
@@ -866,7 +866,7 @@ struct AppIconView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
         } else {
             RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .fill(Color.white.opacity(0.08))
+                .fill(Brand.chipFill)
                 .overlay(Image(systemName: "terminal").font(.system(size: 9)).foregroundStyle(Brand.textTertiary))
         }
     }

--- a/macos/Sources/TaskReport.swift
+++ b/macos/Sources/TaskReport.swift
@@ -315,9 +315,9 @@ struct PillButton: View {
         Button(action: action) {
             Text(NSLocalizedString(title, comment: ""))
                 .font(Brand.sans(13, .semibold))
-                .foregroundStyle(filled ? Color.black : Brand.textPrimary)
+                .foregroundStyle(filled ? Brand.onInverse : Brand.textPrimary)
                 .padding(.horizontal, 22).padding(.vertical, 10)
-                .background(Capsule().fill(filled ? Color.white : Color.white.opacity(0.08)))
+                .background(Capsule().fill(filled ? Brand.inverse : Brand.chipFill))
                 .overlay(filled ? nil : Capsule().strokeBorder(Brand.hairline, lineWidth: 1))
         }
         .buttonStyle(.plain)

--- a/macos/Sources/Tool.swift
+++ b/macos/Sources/Tool.swift
@@ -85,33 +85,6 @@ enum Tool: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Dark, desaturated top colour for the window scrim — the wallpaper
-    /// bleeds through the translucency, this just tints it.
-    private var tintTop: Color {
-        switch self {
-        case .clean:     return Color(hex: 0x0E2A27)
-        case .purge:     return Color(hex: 0x12241A)
-        case .installer: return Color(hex: 0x2A1F12)
-        case .apps:      return Color(hex: 0x2B1611)
-        case .optimize:  return Color(hex: 0x1A1730)
-        case .analyze:   return Color(hex: 0x0E1F2E)
-        case .dupes:     return Color(hex: 0x2A141C)
-        case .orphans:   return Color(hex: 0x232612)
-        case .photos:    return Color(hex: 0x281425)
-        case .status:    return Color(hex: 0x241D11)
-        case .ports:     return Color(hex: 0x1B1426)
-        case .net:       return Color(hex: 0x131A2C)
-        case .connectivity: return Color(hex: 0x0E2630)
-        case .tuneup:    return Color(hex: 0x12231D)
-        }
-    }
-
-    /// Window background scrim laid over the behind-window vibrancy.
-    var scrim: LinearGradient {
-        LinearGradient(colors: [tintTop.opacity(0.88), Brand.nearBlack.opacity(0.96)],
-                       startPoint: .top, endPoint: .bottom)
-    }
-
     /// Our own one-liner per tool — earthy, in keeping with the name.
     var tagline: String {
         switch self {
@@ -140,18 +113,4 @@ enum Pane: Equatable, Hashable {
     case home          // the live dashboard: Overview · History · Activity
     case tool(Tool)
     case settings
-
-    /// Window tint scrim. Home wears the dashboard's gold; tools carry their
-    /// own colour; Settings uses a neutral dark so it reads as "chrome".
-    var scrim: LinearGradient {
-        switch self {
-        case .home:
-            return Tool.status.scrim
-        case .tool(let t):
-            return t.scrim
-        case .settings:
-            return LinearGradient(colors: [Color(hex: 0x16150F).opacity(0.90), Brand.nearBlack.opacity(0.97)],
-                                  startPoint: .top, endPoint: .bottom)
-        }
-    }
 }


### PR DESCRIPTION
Fixes #410, fixes #411.

Two distinct bugs from #410, plus the app-wide sweep from #411's audit. The underlying rule this PR enforces: **a fixed color may only sit on other fixed colors, and an adaptive color only on adaptives.** Everything below was a violation of that rule — the dark-mode design rendered verbatim in light mode (or, in AccessBanner's case, light-mode text rendered onto a fixed dark bar).

## #410 — banner blocks the Clean button, dismiss X invisible

- **Layout**: the access banner was a window-level `.overlay(alignment: .bottom)` drawn on top of pane-owned bottom footers — it sat exactly on Clean's "Permanently clean · …" pill and swallowed its clicks. It is now a `.safeAreaInset(edge: .bottom)`, so panes' own bottom overlays (Clean review, Dupes footer, done banners) are pushed above the banner instead of being covered by it.
- **Colors**: `AccessBanner` keeps its intentional fixed dark ground in both modes, so all its foregrounds are now fixed too (warm off-white at the same opacities the dark mode always had). Previously the title/detail/X used the adaptive text colors, which turn espresso in light mode — dark-brown text and a 46%-opacity dark-brown X on a near-black bar, i.e. unreadable, with an effectively invisible dismiss button.

## #411 — light-mode sweep

Three new Brand tokens:

- `insetFill` — recessed panel/track (replaces fixed `Color.black.opacity(0.18–0.25)` panels and segmented-control tracks)
- `inverse` / `onInverse` — the high-contrast CTA pill pair: white pill + near-black label in dark mode, espresso pill + cream label in light mode (replaces fixed `Color.white` + `.black`)

Applied across:

- **Gauge ring tracks** (`HealthRing`, `RingGauge`): `white @ 10%` → `Brand.trackFill`; the tracks were invisible in light mode.
- **Onboarding**: progress dashes and the engine "pending" dot were white-on-cream; now `Brand.ink`-based. Hero-mark ring → `Brand.hairline`.
- **Primary CTA pills** (Clean confirm, Dupes, Photos, Orphans, Net, Software uninstall, `PillButton`): `inverse`/`onInverse`.
- **Segmented controls** (Settings tabs, Software segments, Ports filter): `insetFill` track, `inverse` thumb, `onInverse` selected label.
- **Chips/wells** (`white @ 5–8%` lifts): quick-scan chips, battery strip, thumbnail/app-icon placeholders, checkbox wells, shortcut recorder, `PermissionRow` → `Brand.chipFill` / `Brand.ink.opacity(…)`.
- **Dark panels** (Settings MCP config, ProcessInspector, Software preview, TaskTicker): `insetFill`.

Left alone on purpose (fixed-on-fixed, correct in both modes): checkmarks/labels on fixed accent fills, `CleanScreen`'s deliberate black, SpikeView/TuneUpView (locally forced dark), the menu-bar popover (forced `.darkAqua`), Analyze's treemap labels, and AccessBanner's own dark bar.

## Dead code

Removed `Tool.tintTop`, `Tool.scrim`, and `Pane.scrim` — unused since the window moved to `Brand.windowVeil`, and they mixed fixed dark hexes with adaptive `nearBlack` (a dark→cream gradient waiting to happen if revived).

## Verification

- Debug build passes.
- The `BURROW_APPEARANCE=light` / `dark` QA override in `App.swift` exercises both palettes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bottom banners now occupy dedicated safe-area space, preventing them from covering pane controls or blocking clicks.

* **Style**
  * Updated controls, panels, buttons, chips, placeholders, and status indicators to use consistent brand colors.
  * Improved light and dark mode contrast across the app.
  * Refined banner, onboarding, settings, software, and task interfaces with more consistent visual styling.
  * Removed outdated background gradients and scrim effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->