### PR TITLE
telemetry: emit PostHog-native $feature_flag_called for flag exposures

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -27,7 +27,7 @@ describes the opt-out behavior enforced below.
 
 The manifest was last re-reviewed against the shipping request and event
 fields when feature flags landed (issue #322), and needs no new entry for
-them. The `feature_flag_exposed` event is Product Interaction collected for
+them. The `$feature_flag_called` event is Product Interaction collected for
 analytics, already declared above; the decide request adds no data type the
 event pipeline was not already sending, since `api_key` is the release
 project key and `distinct_id` is the same random anonymous install id every
@@ -137,9 +137,11 @@ wrong-version files are discarded whole, and the conservative defaults stay
 in force until a later successful fetch rewrites it. An opted-out launch
 neither reads nor writes it, exactly like the event outbox.
 
-**Exposure event.** The first lookup of each flag per launch emits
-`feature_flag_exposed` with exactly two feature-flag-specific properties —
-`flag` (the allowlisted key) and `value` (boolean). The usual telemetry super
+**Exposure event.** The first lookup of each flag per launch emits PostHog's
+native `$feature_flag_called` with exactly two feature-flag-specific
+properties — `$feature_flag` (the allowlisted key) and
+`$feature_flag_response` (boolean). PostHog's flag usage and rollout views
+only count exposures sent under these names. The usual telemetry super
 properties (app version, OS build, platform, locale, etc.) are also attached,
 just like any other event. Like every event it is dropped while opted out.
 
@@ -166,7 +168,7 @@ so no IP is attached to events either.
 | `app_updated` | previous/current app version and build |
 | `engine_missing`, `install_window_ready`, `onboarding_completed` | none |
 | `telemetry_opt_in_changed` | enabled boolean |
-| `feature_flag_exposed` | `flag` (allowlisted key), boolean `value` — once per flag per launch |
+| PostHog `$feature_flag_called` | `$feature_flag` (allowlisted key), boolean `$feature_flag_response` — once per flag per launch |
 | PostHog `$screen` | fixed name: `home`, `settings`, or `tool.<known tool>` |
 | `feature_operation_started` | `feature` (`clean` or `optimize`), `dry_run` boolean, `elevated` boolean |
 | `feature_operation_completed` | `feature` (`clean` or `optimize`), fixed `result` (`succeeded`, `failed`, `authorization_cancelled`, or `cancelled`), `duration_bucket`; failed completions may add `failure_category` (`boundary_changed`, `privileged_launch_refused`, or `engine_nonzero`) |

--- a/macos/Sources/FeatureFlags.swift
+++ b/macos/Sources/FeatureFlags.swift
@@ -73,8 +73,9 @@ enum FeatureFlags {
         return value
     }
 
-    /// One fixed-name exposure event per flag per launch, carrying only the
-    /// allowlisted key and its boolean. The key is only marked reported
+    /// One PostHog-native `$feature_flag_called` exposure per flag per launch,
+    /// carrying only the allowlisted key and its boolean under the property
+    /// names PostHog's flag usage views read. The key is only marked reported
     /// when `Telemetry` can actually queue the event; while opted out,
     /// before `start()`, or without a release key, the lookup remains
     /// eligible so a later enabled session can emit the exposure.
@@ -84,7 +85,7 @@ enum FeatureFlags {
         let alreadyReported = !exposedThisLaunch.insert(key).inserted
         lock.unlock()
         guard !alreadyReported else { return }
-        Telemetry.capture("feature_flag_exposed", ["flag": key.rawValue, "value": value])
+        Telemetry.capture("$feature_flag_called", ["$feature_flag": key.rawValue, "$feature_flag_response": value])
     }
 
     // MARK: - Remote payload filter


### PR DESCRIPTION
## Description

Renames the feature-flag exposure event from the custom `feature_flag_exposed` to PostHog's native `$feature_flag_called`, with the properties `$feature_flag` (allowlisted key) and `$feature_flag_response` (boolean).

PostHog's flag usage and rollout views only count exposures sent under these names. With the custom event, PostHog treated exposures as ordinary events, so the rollout analytics that motivated #322 showed nothing for `about_release_notes_link`.

Nothing else changes: same two properties, same once-per-flag-per-launch rule, still dropped while opted out or before `start()`. `TELEMETRY.md` is updated in the three places that name the event. `PrivacyInfo.xcprivacy` is unaffected (same Product Interaction category, no new data types).

This is the one piece of #391 (by @buiducnhat) worth carrying over after #398 landed; credit to that PR for the change.

## Related Issue

Follow-up to #322 / #398. Supersedes the remaining scope of #391.

## Type of Change

- [x] Bug fix

## Testing

- `xcodebuild test -only-testing:BurrowTests/FeatureFlagTests -only-testing:BurrowTests/TelemetryPolicyTests`: 15 tests, 0 failures, unsigned per CI convention.
- No test referenced the old event name, so no test changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Feature-flag exposure tracking now uses PostHog’s standard `$feature_flag_called` event.
  - Exposure events now report feature-flag details using `$feature_flag` and `$feature_flag_response`.

- **Documentation**
  - Updated feature-flag exposure documentation to reflect the new event name and properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->