### PR TITLE
fix(net): ask for Location before the nearby Wi-Fi scan

### DIFF
--- a/macos/Resources/Info.plist
+++ b/macos/Resources/Info.plist
@@ -32,6 +32,10 @@
 	<string>Burrow scans your Downloads for leftover installer files (.dmg, .pkg).</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>MIT License. © 2026 Henry Zhang.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Burrow needs Location access to read nearby Wi-Fi network names and channels. macOS ties Wi-Fi details to Location Services; Burrow never records or shares your location.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Burrow needs Location access to read nearby Wi-Fi network names and channels. macOS ties Wi-Fi details to Location Services; Burrow never records or shares your location.</string>
 	<key>NSRemovableVolumesUsageDescription</key>
 	<string>Burrow analyzes external drives when you point it at them.</string>
 	<key>PHPostHogApiKey</key>

--- a/macos/Sources/ConnectivityView.swift
+++ b/macos/Sources/ConnectivityView.swift
@@ -32,6 +32,9 @@ struct ConnectivityView: View {
     @State private var nearby: [NearbyNetworks.Net] = []
     @State private var scanning = false
     @State private var scanned = false
+    /// The last scan was refused Location access (#416) — the card explains
+    /// and links to the pane, instead of claiming "no networks".
+    @State private var scanDenied = false
     /// On-demand throughput + latency test (PRD §β). User-initiated — it
     /// transfers data to/from Cloudflare's public speed endpoint.
     @State private var speed: SpeedTest.Result?
@@ -197,8 +200,19 @@ struct ConnectivityView: View {
                                 .foregroundStyle(Brand.textSecondary).frame(width: 64, alignment: .trailing)
                         }
                     }
+                } else if scanDenied, !scanning {
+                    HStack(alignment: .top, spacing: 8) {
+                        Text(NSLocalizedString("macOS only shows Wi-Fi network names to apps with Location access. Allow Burrow under System Settings ▸ Privacy & Security ▸ Location Services, then rescan.", comment: ""))
+                            .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer(minLength: 8)
+                        Button { NSWorkspace.shared.open(LocationAccess.settingsURL) } label: {
+                            Text(NSLocalizedString("Open Settings", comment: ""))
+                                .font(Brand.sans(11, .semibold)).foregroundStyle(accent)
+                        }.buttonStyle(.plain)
+                    }
                 } else if scanned, !scanning {
-                    Text(NSLocalizedString("No networks found — scanning needs Location access (System Settings ▸ Privacy & Security ▸ Location).", comment: ""))
+                    Text(NSLocalizedString("No networks found. Check that Wi-Fi is on, then rescan.", comment: ""))
                         .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 } else if !scanned {
@@ -334,19 +348,33 @@ struct ConnectivityView: View {
 
     private func scanNearby() {
         scanning = true
-        Task.detached(priority: .utility) {
-            let nets = ConnectivityView.scanNearbyNetworks()
-            await MainActor.run {
-                nearby = nets
-                scanning = false
-                scanned = true
+        Task {
+            // Ask for Location first (#416): CoreWLAN returns nameless networks
+            // without the grant and never prompts for it on its own. The first
+            // Scan raises the system dialog; later ones return at once.
+            let status = await LocationAuthorizer.shared.requestAuthorization()
+            switch LocationAccess.verdict(for: status) {
+            case .ready:
+                scanDenied = false
+                nearby = await Task.detached(priority: .utility) { ConnectivityView.scanNearbyNetworks() }.value
+                if venue == nil {
+                    // The SSID was hidden behind the same grant — a fresh grant
+                    // can surface the venue card now.
+                    let ssid = await Task.detached(priority: .utility) { ConnectivityView.currentSSID() }.value
+                    venue = ssid.flatMap { VenueMatcher.match(ssid: $0) }
+                }
+            case .ask, .denied:
+                scanDenied = true
+                nearby = []
             }
+            scanning = false
+            scanned = true
         }
     }
 
-    /// Active scan via CoreWLAN. Throws/empty without Location access or off
-    /// Wi-Fi → the card shows the permission hint. A scan briefly disrupts the
-    /// link, so it's only ever user-initiated.
+    /// Active scan via CoreWLAN. Called only once Location access is granted;
+    /// empty when Wi-Fi is off. A scan briefly disrupts the link, so it's only
+    /// ever user-initiated.
     private static func scanNearbyNetworks() -> [NearbyNetworks.Net] {
         guard let iface = CWWiFiClient.shared().interface() else { return [] }
         let nets = (try? iface.scanForNetworks(withSSID: nil)) ?? []

--- a/macos/Sources/LocationAccess.swift
+++ b/macos/Sources/LocationAccess.swift
@@ -1,0 +1,94 @@
+//
+//  LocationAccess.swift
+//  Burrow
+//
+//  Location Services authorization for the Get Online pane (#416).
+//
+//  Since macOS 14, CoreWLAN hides Wi-Fi identity behind Location Services:
+//  `scanForNetworks` returns networks with nil SSIDs and `interface().ssid()`
+//  returns nil unless the app holds a Location grant. macOS only ever prompts
+//  for that grant when the app *asks* through CoreLocation — CoreWLAN alone
+//  never triggers the dialog, and an app that never asks never appears under
+//  Privacy & Security ▸ Location Services, so there is nothing for the user
+//  to switch on. Burrow never asked, which is why the nearby-Wi-Fi card told
+//  people to grant a permission they could not find.
+//
+//  The ask is tied to the Scan button: the prompt appears the first time the
+//  user asks for something that needs it, and never on launch.
+//
+
+import Foundation
+import CoreLocation
+
+enum LocationAccess {
+    /// What the pane should do given the current authorization status. Pure,
+    /// so the mapping is unit-testable without CoreLocation.
+    enum Verdict: Equatable {
+        /// The grant is live — scan.
+        case ready
+        /// Never asked — request, then decide on the answer.
+        case ask
+        /// Refused, or managed away — explain and point at Settings.
+        case denied
+    }
+
+    static func verdict(for status: CLAuthorizationStatus) -> Verdict {
+        switch status {
+        // macOS has no when-in-use tier: a grant is `.authorizedAlways`
+        // (`.authorized` is its deprecated spelling, same value).
+        case .authorizedAlways: return .ready
+        case .notDetermined: return .ask
+        case .denied, .restricted: return .denied
+        default: return .denied
+        }
+    }
+
+    /// Privacy & Security ▸ Location Services, the pane the grant lives in.
+    static let settingsURL = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices")!
+}
+
+/// Owns the one `CLLocationManager` Burrow needs. The manager must be created
+/// on a thread with a run loop and kept alive until the user answers the
+/// prompt, or the dialog never appears — hence a main-actor singleton rather
+/// than a local inside the scan.
+@MainActor
+final class LocationAuthorizer: NSObject, CLLocationManagerDelegate {
+    static let shared = LocationAuthorizer()
+
+    private let manager = CLLocationManager()
+    private var waiting: [CheckedContinuation<CLAuthorizationStatus, Never>] = []
+
+    private override init() {
+        super.init()
+        manager.delegate = self
+    }
+
+    /// The grant as it stands, without prompting.
+    var status: CLAuthorizationStatus { manager.authorizationStatus }
+
+    /// Prompts if the user has never been asked, and resolves with the status
+    /// once they answer. Returns immediately when the answer is already known.
+    func requestAuthorization() async -> CLAuthorizationStatus {
+        let current = manager.authorizationStatus
+        guard current == .notDetermined else { return current }
+        return await withCheckedContinuation { continuation in
+            waiting.append(continuation)
+            manager.requestWhenInUseAuthorization()
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in self.settle(status) }
+    }
+
+    private func settle(_ status: CLAuthorizationStatus) {
+        // CoreLocation also calls the delegate right after it is set, while
+        // the status is still undecided; only an answer settles the waiters.
+        guard status != .notDetermined, !waiting.isEmpty else { return }
+        let continuations = waiting
+        waiting = []
+        continuations.forEach { $0.resume(returning: status) }
+    }
+}

--- a/macos/Tests/LocationAccessTests.swift
+++ b/macos/Tests/LocationAccessTests.swift
@@ -1,0 +1,33 @@
+//
+//  LocationAccessTests.swift
+//  BurrowTests
+//
+//  The pure status → action mapping behind the nearby-Wi-Fi scan (#416). The
+//  prompt itself is a TCC dialog and can't run in CI — hand-test it.
+//
+
+import XCTest
+import CoreLocation
+@testable import Burrow
+
+final class LocationAccessTests: XCTestCase {
+    func testAuthorizedStatusScans() {
+        // macOS grants are always-tier; there is no when-in-use case here.
+        XCTAssertEqual(LocationAccess.verdict(for: .authorizedAlways), .ready)
+    }
+
+    func testUndecidedStatusAsksFirst() {
+        // The whole bug: scanning without asking never produces the prompt.
+        XCTAssertEqual(LocationAccess.verdict(for: .notDetermined), .ask)
+    }
+
+    func testRefusedStatusesExplainInsteadOfScanning() {
+        XCTAssertEqual(LocationAccess.verdict(for: .denied), .denied)
+        XCTAssertEqual(LocationAccess.verdict(for: .restricted), .denied)
+    }
+
+    func testSettingsLinkTargetsLocationServicesPane() {
+        XCTAssertEqual(LocationAccess.settingsURL.scheme, "x-apple.systempreferences")
+        XCTAssertTrue(LocationAccess.settingsURL.absoluteString.hasSuffix("Privacy_LocationServices"))
+    }
+}

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -89,6 +89,13 @@ targets:
         NSDocumentsFolderUsageDescription: "Burrow scans your Documents for reclaimable project artifacts."
         NSDownloadsFolderUsageDescription: "Burrow scans your Downloads for leftover installer files (.dmg, .pkg)."
         NSRemovableVolumesUsageDescription: "Burrow analyzes external drives when you point it at them."
+        # macOS 14+ hides Wi-Fi network names behind Location Services, and only
+        # prompts for it when the app asks via CoreLocation with a usage string
+        # (#416). Both keys: NSLocationUsageDescription is the macOS key and
+        # WhenInUse the one requestWhenInUseAuthorization documents. Asked
+        # only from the Get Online pane's Scan button, never at launch.
+        NSLocationUsageDescription: "Burrow needs Location access to read nearby Wi-Fi network names and channels. macOS ties Wi-Fi details to Location Services; Burrow never records or shares your location."
+        NSLocationWhenInUseUsageDescription: "Burrow needs Location access to read nearby Wi-Fi network names and channels. macOS ties Wi-Fi details to Location Services; Burrow never records or shares your location."
         # Telemetry keys, expanded from build settings at build time. Empty in
         # dev builds (the defaults below) → analytics/crash reporting stay off.
         # A release injects real values via `xcodebuild VAR=...` (see scripts/).


### PR DESCRIPTION
Fixes #416.

## What changed

- **Scan now asks for Location first.** New `LocationAccess.swift` owns one main-actor `CLLocationManager` and exposes an async `requestAuthorization()` that resolves once the user answers the system dialog. `ConnectivityView.scanNearby()` awaits it before touching CoreWLAN. The prompt fires on the first press of Scan in Get Online, never at launch.
- **Info.plist carries the usage strings.** `NSLocationUsageDescription` (the macOS key) and `NSLocationWhenInUseUsageDescription` (the one `requestWhenInUseAuthorization` documents) are added in `project.yml`; the generated `Resources/Info.plist` is regenerated with xcodegen.
- **Honest denied state.** A refused or restricted grant shows an explanation with an **Open Settings** button deep-linking to Privacy & Security ▸ Location Services, instead of the old "No networks found" text that pointed at a permission the user could not find. "No networks found" is now reserved for a granted scan that returned nothing.
- **Venue card benefits too.** A fresh grant re-reads the SSID, which sits behind the same gate, so the venue tips can appear without leaving the pane.
- **Tests.** `LocationAccessTests` pins the status-to-verdict mapping and the settings link.

## Why

Since macOS 14, CoreWLAN hides Wi-Fi network names behind Location Services, and macOS only shows the Location prompt when an app requests it through CoreLocation with a usage string. Burrow called `scanForNetworks` directly and never asked, so the dialog never appeared, Burrow never showed up under Location Services, and the card told people to grant a permission they could not find — exactly what #416 reports (`plutil -p Info.plist | grep -i location` returning nothing).

## Reviewer notes

- macOS has no when-in-use tier: `.authorizedWhenInUse` is unavailable on macOS, so only `.authorizedAlways` counts as granted (`.authorized` is its deprecated alias with the same value). The switch uses a plain `default` for that reason.
- The `CLLocationManager` is a main-actor singleton on purpose: it must be created on a run-loop thread and stay alive until the user answers, or the dialog never appears.
- The two new card strings are untranslated, matching the previous hint on this card, which had no entries in any strings table.
- `RELEASES.md` is untouched because CI expects only versioned sections there. Suggested note for the next release: *Nearby Wi-Fi scan now asks for Location access and explains when it is denied (#416).*

## Verification

- `xcodebuild test` for `LocationAccessTests`, `ConnectivityTests`, `LocalizationTests`: 20 tests, 0 failures. Full build clean.
- **Hand test needed** (the prompt is a TCC dialog and cannot run in CI):
  1. Build with `scripts/build.sh`, open Get Online, press **Scan** → the system Location dialog appears and Burrow is listed under Privacy & Security ▸ Location Services.
  2. Allow → networks with names and channels appear.
  3. Deny, press **Rescan** → the explanation with a working **Open Settings** button appears.
  4. To rerun the first-time prompt: `tccutil reset Location dev.caezium.Burrow`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nearby Wi‑Fi scanning now requests Location access before scanning.
  * Added a dedicated explanation when access is unavailable, with a shortcut to Location Services settings.
  * Scan results and venue information now appear only when Location access is granted.

* **Bug Fixes**
  * Empty scan results are no longer shown when Location access has been denied.
  * Added clear macOS permission messaging explaining why Location access is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->