### PR TITLE
Fix authorization, lifecycle and packaging in the iMessage draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
       - name: Install xcodegen
         run: brew install xcodegen
 
+      - name: Prepare and test iMessage sidecar
+        run: |
+          bash scripts/fetch-sidecar-bun.sh "$RUNNER_TEMP/sidecar-bun"
+          echo "BUN_BIN=$RUNNER_TEMP/sidecar-bun/bun" >> "$GITHUB_ENV"
+          cd ../tools/burrow-alerts
+          "$RUNNER_TEMP/sidecar-bun/bun" install --frozen-lockfile --ignore-scripts
+          "$RUNNER_TEMP/sidecar-bun/bun" run typecheck
+          "$RUNNER_TEMP/sidecar-bun/bun" test
+
       # Sentry is a vendored local framework (not SPM — its binary download
       # hangs xcodebuild). Fetch it before generating the project, or xcodegen
       # references a missing framework. (Job working-directory is macos/.)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,15 @@ jobs:
       - name: Install xcodegen
         run: brew install xcodegen
 
+      - name: Prepare and test iMessage sidecar
+        run: |
+          bash macos/scripts/fetch-sidecar-bun.sh "$RUNNER_TEMP/sidecar-bun"
+          echo "BUN_BIN=$RUNNER_TEMP/sidecar-bun/bun" >> "$GITHUB_ENV"
+          cd tools/burrow-alerts
+          "$RUNNER_TEMP/sidecar-bun/bun" install --frozen-lockfile --ignore-scripts
+          "$RUNNER_TEMP/sidecar-bun/bun" run typecheck
+          "$RUNNER_TEMP/sidecar-bun/bun" test
+
       - name: Build (Release)
         id: build
         timeout-minutes: 38
@@ -181,6 +190,7 @@ jobs:
                     if file -b "$f" | grep -q 'Mach-O'; then codesign --force --sign - "$f"; fi
                   done
             fi
+            codesign --force --preserve-metadata=entitlements --sign - "$APP/Contents/Resources/sidecar/bin/bun"
             codesign --force --sign - --entitlements macos/Resources/Burrow.entitlements "$APP"
             codesign --verify --strict --verbose=2 "$APP"
             echo "signed=false" >> "$GITHUB_OUTPUT"
@@ -220,6 +230,9 @@ jobs:
                   fi
                 done
           fi
+          # Bun needs its JIT entitlements as well as the release identity.
+          codesign --force --options runtime --timestamp --preserve-metadata=entitlements \
+            --sign "$SIGN_IDENTITY" "$APP/Contents/Resources/sidecar/bin/bun"
           # Hardened runtime + secure timestamp are required for notarization.
           codesign --force --options runtime --timestamp \
             --entitlements macos/Resources/Burrow.entitlements \

--- a/imessage/BurrowCardsExtension/MessagesViewController.swift
+++ b/imessage/BurrowCardsExtension/MessagesViewController.swift
@@ -79,7 +79,14 @@ final class MessagesViewController: MSMessagesAppViewController {
     }
 
     private func open(_ action: BurrowAction) {
-        guard let url = URL(string: action.deepLinkURL) else { return }
-        extensionContext?.open(url, completionHandler: nil)
+        guard let url = action.burrowURL else { return }
+        extensionContext?.open(url) { [weak self] opened in
+            guard !opened else { return }
+            DispatchQueue.main.async {
+                let alert = UIAlertController(title: "Open Burrow on your Mac", message: "Review your Mac's health and cleanup options in Burrow on that Mac.", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                self?.present(alert, animated: true)
+            }
+        }
     }
 }

--- a/imessage/README.md
+++ b/imessage/README.md
@@ -53,7 +53,7 @@ Point `tools/burrow-alerts` at this extension:
 // config.local.json
 "card": {
   "appName": "Burrow",
-  "extensionBundleId": "dev.caezium.Burrow.imessage",
+  "extensionBundleId": "dev.caezium.Burrow.cards.extension",
   "teamId": "<your Apple Team ID>",
   "url": "https://burrow.henryzh.dev/card"   // base; sidecar appends ?p=<layout>
 }
@@ -67,7 +67,7 @@ The sidecar builds a `BurrowLayout` (`src/burrowlayout.ts`), base64url-encodes i
 
 `vstack` · `hstack` · `section` · `text` · `statusBadge` · `progressBar` · `gauge` · `keyValueRow`
 
-Actions are `{ id, label, systemImage?, deepLinkURL }` — `burrow://action?id=…` buttons that insert a reply into the thread.
+Actions are `{ id, label, systemImage?, deepLinkURL }`. Only the known `burrow://action?id=clean` and `id=inspect` routes are accepted. These open a local Burrow app when available; they cannot launch an app on another device. On an iPhone without a handler, the extension explains that the owner should open Burrow on the Mac.
 
 ## Acknowledgments
 

--- a/imessage/Shared/Sources/BurrowCards/BurrowLayout.swift
+++ b/imessage/Shared/Sources/BurrowCards/BurrowLayout.swift
@@ -27,6 +27,17 @@ public struct BurrowAction: Codable, Equatable {
     public var label: String
     public var systemImage: String?
     public var deepLinkURL: String
+
+    /// Card JSON may select a supported Burrow pane, never an arbitrary app URL.
+    public var burrowURL: URL? {
+        guard let components = URLComponents(string: deepLinkURL),
+              components.scheme == "burrow", components.host == "action",
+              components.queryItems?.count == 1,
+              components.queryItems?.first?.name == "id",
+              components.queryItems?.first?.value == id,
+              ["clean", "inspect"].contains(id) else { return nil }
+        return components.url
+    }
 }
 
 /// The recursive node tree. `type` is the discriminator, matching the TS union.
@@ -124,15 +135,18 @@ extension BurrowNode: Codable {
 // MARK: - Transport (base64url `?p=` payload, matching burrowlayout.ts)
 
 public enum BurrowTransport {
-    public enum Error: Swift.Error { case missingPayload, badBase64, encodeFailed }
+    public enum Error: Swift.Error { case missingPayload, badBase64, encodeFailed, unsupportedPayload }
 
     public static func decode(url: URL) throws -> BurrowLayout {
         guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let p = comps.queryItems?.first(where: { $0.name == "p" })?.value else {
             throw Error.missingPayload
         }
+        guard p.utf8.count <= 90_000 else { throw Error.unsupportedPayload }
         guard let data = Data(base64URLEncoded: p) else { throw Error.badBase64 }
-        return try JSONDecoder().decode(BurrowLayout.self, from: data)
+        let layout = try JSONDecoder().decode(BurrowLayout.self, from: data)
+        guard layout.version == 1 else { throw Error.unsupportedPayload }
+        return layout
     }
 
     /// Encode a layout into `base?p=<base64url>` — the inverse of the sidecar's
@@ -141,6 +155,7 @@ public enum BurrowTransport {
         let data = try JSONEncoder().encode(layout)
         var comps = URLComponents(url: base, resolvingAgainstBaseURL: false)
         var items = comps?.queryItems ?? []
+        items.removeAll { $0.name == "p" }
         items.append(URLQueryItem(name: "p", value: data.base64URLEncodedString()))
         comps?.queryItems = items
         guard let url = comps?.url else { throw Error.encodeFailed }

--- a/imessage/Tests/TransportChecks.swift
+++ b/imessage/Tests/TransportChecks.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+@main
+struct TransportChecks {
+    static func main() throws {
+        var layout = BurrowSamples.disk
+        layout.title = "磁盘 🌕"
+        let base = URL(string: "https://example.com/card?mode=small&p=stale#details")!
+        let encoded = try BurrowTransport.encode(base: base, layout: layout)
+        let components = URLComponents(url: encoded, resolvingAgainstBaseURL: false)!
+        precondition(components.queryItems!.filter { $0.name == "p" }.count == 1)
+        precondition(components.fragment == "details")
+        let decoded = try BurrowTransport.decode(url: encoded)
+        precondition(decoded == layout)
+        precondition(BurrowSamples.disk.actions!.first!.burrowURL != nil)
+        precondition(BurrowAction(id: "clean", label: "Open", deepLinkURL: "https://example.com").burrowURL == nil)
+        precondition(BurrowAction(id: "clean", label: "Open", deepLinkURL: "burrow://action?id=inspect").burrowURL == nil)
+        layout.version = 2
+        do {
+            _ = try BurrowTransport.decode(url: BurrowTransport.encode(base: base, layout: layout))
+            fatalError("unknown schema version was accepted")
+        } catch BurrowTransport.Error.unsupportedPayload {}
+        print("Transport checks passed: Unicode round-trip, payload replacement, version and action boundaries")
+    }
+}

--- a/imessage/scripts/test-transport.sh
+++ b/imessage/scripts/test-transport.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+swiftc "$ROOT/Shared/Sources/BurrowCards/BurrowLayout.swift" \
+  "$ROOT/Shared/Sources/BurrowCards/Samples.swift" "$ROOT/Tests/TransportChecks.swift" \
+  -o "$WORK/transport-checks"
+"$WORK/transport-checks"

--- a/macos/Sources/IMessageSidecar.swift
+++ b/macos/Sources/IMessageSidecar.swift
@@ -16,6 +16,7 @@
 //
 
 import Foundation
+import Darwin
 
 /// A snapshot of the user's iMessage settings, passed to the sidecar as env.
 struct SidecarConfig: Equatable {
@@ -51,10 +52,19 @@ enum SidecarLaunch {
     /// current environment (PATH etc.) in production; empty in tests.
     static func environment(_ c: SidecarConfig, burrowBin: String, base: [String: String] = [:]) -> [String: String] {
         var env = base
+        for key in ["PHOTON_PROJECT_ID", "PHOTON_PROJECT_SECRET", "BURROW_LLM_PROVIDER", "BURROW_LLM_MODEL", "BURROW_LLM_BASEURL", "BURROW_LLM_KEY", "USE_JAN"] {
+            env.removeValue(forKey: key)
+        }
         env["BURROW_ALERT_TO"] = c.ownerPhone
         if !c.projectId.isEmpty { env["PHOTON_PROJECT_ID"] = c.projectId }
         if !c.projectSecret.isEmpty { env["PHOTON_PROJECT_SECRET"] = c.projectSecret }
         env["BURROW_BIN"] = burrowBin
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        env["BURROW_ALERT_STATE_DIR"] = home.appendingPathComponent("Library/Application Support/Burrow/iMessage").path
+        env["BURROW_PARENT_PID"] = String(Foundation.ProcessInfo.processInfo.processIdentifier)
+        // Finder launches don't inherit the user's shell PATH.
+        let knownPaths = ["/usr/bin", "/bin", "/usr/sbin", "/sbin", "/opt/homebrew/bin", "/usr/local/bin", home.appendingPathComponent(".local/bin").path, home.appendingPathComponent(".bun/bin").path]
+        env["PATH"] = (knownPaths + (base["PATH"] ?? "").split(separator: ":").map(String.init)).filter { $0.hasPrefix("/") }.joined(separator: ":")
         // Photon egress is direct; keep any local proxy out of the sidecar.
         env["NO_PROXY"] = "*"; env["no_proxy"] = "*"
         env["LOG_LEVEL"] = "silent"
@@ -69,7 +79,7 @@ enum SidecarLaunch {
 
     static func agentArgs(entry: String) -> [String] { ["run", entry] }
     static func checkArgs(entry: String, digest: Bool = false) -> [String] {
-        digest ? ["run", entry, "--digest"] : ["run", entry]
+        digest ? ["run", entry, "--digest"] : ["run", entry, "--scheduled"]
     }
 }
 
@@ -86,7 +96,10 @@ struct SidecarPaths {
         guard let res = bundle.resourceURL else { return nil }
         let dir = res.appendingPathComponent("sidecar", isDirectory: true)
         let bun = dir.appendingPathComponent("bin/bun")
-        guard FileManager.default.isExecutableFile(atPath: bun.path) else { return nil }
+        guard FileManager.default.isExecutableFile(atPath: bun.path),
+              ["agent.ts", "check.ts", "node_modules/spectrum-ts/package.json"].allSatisfy({
+                  FileManager.default.fileExists(atPath: dir.appendingPathComponent($0).path)
+              }) else { return nil }
         return SidecarPaths(
             dir: dir,
             bun: bun,
@@ -99,33 +112,52 @@ struct SidecarPaths {
 final class IMessageSidecar {
     private let queue = DispatchQueue(label: "dev.caezium.Burrow.imessage")
     private var agent: Process?
+    private var check: Process?
     private var checkTimer: DispatchSourceTimer?
-    private var stopped = false
+    private var stopped = true
+    private var generation = UUID()
 
-    private let checkInterval: TimeInterval = 600      // 10 min
+    private let configuration: () -> SidecarConfig
+    private let pathsProvider: () -> SidecarPaths?
+    private let checkInterval: TimeInterval
+    private let initialDelay: TimeInterval
+    private let checkTimeout: TimeInterval
     private let restartDelay: TimeInterval = 5
+
+    init(configuration: @escaping () -> SidecarConfig = SidecarConfig.fromStore,
+         paths: @escaping () -> SidecarPaths? = { SidecarPaths.bundled() },
+         checkInterval: TimeInterval = 600, initialDelay: TimeInterval = 60,
+         checkTimeout: TimeInterval = 180) {
+        self.configuration = configuration; self.pathsProvider = paths
+        self.checkInterval = checkInterval; self.initialDelay = initialDelay
+        self.checkTimeout = checkTimeout
+    }
 
     func start() {
         queue.async { [weak self] in
-            guard let self else { return }
-            self.stopped = false
-            let cfg = SidecarConfig.fromStore()
-            guard cfg.hasDelivery, let paths = SidecarPaths.bundled() else {
+            guard let self, self.stopped else { return }
+            let cfg = self.configuration()
+            guard cfg.hasDelivery, let paths = self.pathsProvider() else {
                 NSLog("[iMessage] not starting: missing delivery config or bundled sidecar")
                 return
             }
+            self.stopped = false
+            self.generation = UUID()
             self.armCheckTimer(paths: paths, cfg: cfg)
             if cfg.agentEnabled { self.spawnAgent(paths: paths, cfg: cfg) }
         }
     }
 
     func stop() {
-        queue.async { [weak self] in
-            guard let self else { return }
+        // applicationWillTerminate must signal both children before it returns.
+        queue.sync {
             self.stopped = true
+            self.generation = UUID()
             self.checkTimer?.cancel(); self.checkTimer = nil
-            self.agent?.terminationHandler = nil
-            self.agent?.terminate(); self.agent = nil
+            for child in [self.agent, self.check].compactMap({ $0 }) {
+                self.terminate(child)
+            }
+            self.agent = nil; self.check = nil
         }
     }
 
@@ -142,28 +174,64 @@ final class IMessageSidecar {
     }
 
     private func spawnAgent(paths: SidecarPaths, cfg: SidecarConfig) {
+        guard !stopped, agent == nil else { return }
+        let currentGeneration = generation
         let p = makeProcess(paths, cfg, args: SidecarLaunch.agentArgs(entry: paths.agentEntry.path))
-        p.terminationHandler = { [weak self] _ in
+        p.terminationHandler = { [weak self] exited in
             guard let self else { return }
-            self.queue.asyncAfter(deadline: .now() + self.restartDelay) {
-                guard !self.stopped else { return }
-                NSLog("[iMessage] agent exited — restarting")
-                self.spawnAgent(paths: paths, cfg: cfg)   // restart-on-crash
+            self.queue.async {
+                guard self.agent === exited else { return }
+                self.agent = nil
+                self.scheduleRestart(paths: paths, cfg: cfg, generation: currentGeneration)
             }
         }
-        do { try p.run(); agent = p } catch { NSLog("[iMessage] agent failed to launch: \(error)") }
+        do { try p.run(); agent = p } catch {
+            NSLog("[iMessage] agent failed to launch: \(error)")
+            scheduleRestart(paths: paths, cfg: cfg, generation: currentGeneration)
+        }
+    }
+
+    private func scheduleRestart(paths: SidecarPaths, cfg: SidecarConfig, generation: UUID) {
+        queue.asyncAfter(deadline: .now() + restartDelay) { [weak self] in
+            guard let self, !self.stopped, self.generation == generation else { return }
+            self.spawnAgent(paths: paths, cfg: cfg)
+        }
+    }
+
+    private func terminate(_ process: Process) {
+        process.terminationHandler = nil
+        guard process.isRunning else { return }
+        process.terminate()
+        queue.asyncAfter(deadline: .now() + 2) {
+            if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+        }
     }
 
     private func armCheckTimer(paths: SidecarPaths, cfg: SidecarConfig) {
         let t = DispatchSource.makeTimerSource(queue: queue)
-        t.schedule(deadline: .now() + 60, repeating: checkInterval)   // first tick +60s
+        t.schedule(deadline: .now() + initialDelay, repeating: checkInterval)
         t.setEventHandler { [weak self] in self?.runCheckOnce(paths: paths, cfg: cfg) }
         checkTimer = t
         t.resume()
     }
 
     private func runCheckOnce(paths: SidecarPaths, cfg: SidecarConfig) {
+        guard !stopped, check == nil else { return }
         let p = makeProcess(paths, cfg, args: SidecarLaunch.checkArgs(entry: paths.checkEntry.path))
-        do { try p.run() } catch { NSLog("[iMessage] check failed to launch: \(error)") }
+        p.terminationHandler = { [weak self] exited in
+            guard let self else { return }
+            self.queue.async { if self.check === exited { self.check = nil } }
+        }
+        do {
+            try p.run(); check = p
+            queue.asyncAfter(deadline: .now() + checkTimeout) { [weak self] in
+                guard let self, self.check === p, p.isRunning else { return }
+                // Keep the slot occupied until the timed-out process really exits.
+                p.terminate()
+                self.queue.asyncAfter(deadline: .now() + 2) {
+                    if p.isRunning { kill(p.processIdentifier, SIGKILL) }
+                }
+            }
+        } catch { NSLog("[iMessage] check failed to launch: \(error)") }
     }
 }

--- a/macos/Tests/IMessageSidecarLifecycleTests.swift
+++ b/macos/Tests/IMessageSidecarLifecycleTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import Darwin
+@testable import Burrow
+
+final class IMessageSidecarLifecycleTests: XCTestCase {
+    private func waitForStarts(_ count: Int, at log: URL) {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            let text = (try? String(contentsOf: log, encoding: .utf8)) ?? ""
+            if text.split(separator: "\n").filter({ $0.hasPrefix("start") }).count >= count { return }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+    private func withSidecar(agent: Bool, timeout: TimeInterval = 10,
+                             body: (IMessageSidecar, URL) throws -> Void) throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("fake-bun")
+        // A local fixture records lifecycle only. No Bun/Photon/Claude or Burrow MCP runs.
+        try """
+        #!/bin/sh
+        echo "start $$ $2" >> events
+        trap 'echo "stop $$" >> events; exit 0' TERM INT
+        while :; do /bin/sleep 0.03; done
+        """.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        let config = SidecarConfig(ownerPhone: "+15551234567", projectId: "fake", projectSecret: "fake", agentEnabled: agent,
+                                   llmProvider: "claude-cli", llmModel: "", llmBaseURL: "", llmKey: "")
+        let paths = SidecarPaths(dir: dir, bun: executable, agentEntry: URL(fileURLWithPath: "agent.ts"), checkEntry: URL(fileURLWithPath: "check.ts"))
+        let sidecar = IMessageSidecar(configuration: { config }, paths: { paths }, checkInterval: 0.04, initialDelay: 0.02, checkTimeout: timeout)
+        defer { sidecar.stop() }
+        try body(sidecar, dir.appendingPathComponent("events"))
+    }
+
+    func testRepeatedStartDoesNotDuplicateAndStopTerminatesBothChildren() throws {
+        try withSidecar(agent: true) { sidecar, log in
+            sidecar.start(); sidecar.start()
+            waitForStarts(2, at: log)
+            let before = try String(contentsOf: log, encoding: .utf8)
+            XCTAssertEqual(before.split(separator: "\n").filter { $0.hasPrefix("start") }.count, 2)
+            sidecar.stop()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            let after = try String(contentsOf: log, encoding: .utf8)
+            XCTAssertEqual(after.split(separator: "\n").filter { $0.hasPrefix("stop") }.count, 2)
+        }
+    }
+
+    func testTimedOutChecksReleaseTheirSlotWithoutOverlapping() throws {
+        try withSidecar(agent: false, timeout: 0.1) { sidecar, log in
+            sidecar.start()
+            waitForStarts(2, at: log)
+            sidecar.stop()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            let lines = try String(contentsOf: log, encoding: .utf8).split(separator: "\n")
+            XCTAssertGreaterThanOrEqual(lines.filter { $0.hasPrefix("start") }.count, 2)
+            var active = 0
+            for line in lines {
+                active += line.hasPrefix("start") ? 1 : -1
+                XCTAssertTrue((0...1).contains(active), "overlapping check processes: \(lines)")
+            }
+            XCTAssertEqual(active, 0)
+        }
+    }
+}

--- a/macos/Tests/IMessageSidecarTests.swift
+++ b/macos/Tests/IMessageSidecarTests.swift
@@ -49,7 +49,7 @@ final class IMessageSidecarTests: XCTestCase {
 
     func testArgs() {
         XCTAssertEqual(SidecarLaunch.agentArgs(entry: "/s/agent.ts"), ["run", "/s/agent.ts"])
-        XCTAssertEqual(SidecarLaunch.checkArgs(entry: "/s/check.ts"), ["run", "/s/check.ts"])
+        XCTAssertEqual(SidecarLaunch.checkArgs(entry: "/s/check.ts"), ["run", "/s/check.ts", "--scheduled"])
         XCTAssertEqual(SidecarLaunch.checkArgs(entry: "/s/check.ts", digest: true), ["run", "/s/check.ts", "--digest"])
     }
 
@@ -57,5 +57,17 @@ final class IMessageSidecarTests: XCTestCase {
         XCTAssertTrue(cfg().hasDelivery)
         var c = cfg(); c.projectSecret = ""
         XCTAssertFalse(c.hasDelivery)
+    }
+
+    func testEnvironmentClearsStaleCredentialsAndFindsLocalClaude() {
+        let env = SidecarLaunch.environment(cfg(agent: false), burrowBin: "/x", base: [
+            "BURROW_LLM_KEY": "old-key", "BURROW_LLM_PROVIDER": "anthropic", "USE_JAN": "1", "PATH": "/usr/bin:/bin",
+        ])
+        XCTAssertNil(env["BURROW_LLM_KEY"])
+        XCTAssertNil(env["BURROW_LLM_PROVIDER"])
+        XCTAssertNil(env["USE_JAN"])
+        XCTAssertTrue(env["PATH"]!.contains("/.local/bin"))
+        XCTAssertTrue(env["BURROW_ALERT_STATE_DIR"]!.contains("Library/Application Support/Burrow/iMessage"))
+        XCTAssertNotNil(env["BURROW_PARENT_PID"])
     }
 }

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -124,15 +124,16 @@ targets:
         basedOnDependencyAnalysis: false
         script: |
           # Stage the "Burrow over iMessage" sidecar (Bun + spectrum-ts) into
-          # Resources/sidecar so users run it with zero install. Activates when the
-          # sidecar source is present and a `bun` binary can be found (BUN_BIN or
-          # PATH); otherwise the feature stays inert (build still green). Same
+          # Resources/sidecar so users run it with zero install. Requires the
+          # sidecar source and a Bun runtime compatible with every target arch.
+          # BUN_BIN can point at fetch-sidecar-bun.sh's universal runtime. Same
           # post-build re-sign caveat as the engine above.
           SIDECAR_SRC="${BURROW_SIDECAR_SRC:-$SRCROOT/../tools/burrow-alerts}"
           if [ -f "$SIDECAR_SRC/agent.ts" ]; then
             "$SRCROOT/scripts/bundle-sidecar.sh" "$SIDECAR_SRC" "$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH"
           else
-            echo "warning: iMessage sidecar source not present at $SIDECAR_SRC — the iMessage feature will be inert."
+            echo "error: iMessage sidecar source not present at $SIDECAR_SRC" >&2
+            exit 1
           fi
 
   BurrowTests:

--- a/macos/scripts/bundle-sidecar.sh
+++ b/macos/scripts/bundle-sidecar.sh
@@ -9,13 +9,20 @@ set -euo pipefail
 
 SRC="${1:?sidecar source dir}"
 RES="${2:?resources dir}"
+SRC="$(cd "$SRC" && pwd)"
+mkdir -p "$RES"
+RES="$(cd "$RES" && pwd)"
 DEST="$RES/sidecar"
 
 BUN="${BUN_BIN:-$(command -v bun || true)}"
 if [ -z "$BUN" ] || [ ! -x "$BUN" ]; then
-  echo "warning: no bun binary (set BUN_BIN or install bun) — skipping sidecar bundle; feature inert."
-  exit 0
+  echo "error: missing Bun runtime; run macos/scripts/fetch-sidecar-bun.sh and set BUN_BIN to its bun output." >&2
+  exit 1
 fi
+BUN="$(cd "$(dirname "$BUN")" && pwd)/$(basename "$BUN")"
+for ARCH in ${ARCHS:-$(uname -m)}; do
+  lipo "$BUN" -verify_arch "$ARCH" || { echo "error: Bun does not support target $ARCH; use fetch-sidecar-bun.sh" >&2; exit 1; }
+done
 
 rm -rf "$DEST"
 mkdir -p "$DEST/bin"
@@ -25,23 +32,19 @@ mkdir -p "$DEST/bin"
   --exclude '.git' --exclude '.scguard' --exclude 'logs' \
   --exclude '*.test.ts' --exclude 'config.local.json' --exclude '*.state.json' \
   --exclude 'launchd' --exclude 'FRICTION.md' \
-  "$SRC/agent.ts" "$SRC/check.ts" "$SRC/package.json" "$SRC/config.example.json" \
-  "$SRC/src" "$SRC/agent" "$DEST/"
+  "$SRC/agent.ts" "$SRC/check.ts" "$SRC/package.json" "$SRC/bun.lock" "$SRC/config.example.json" \
+  "$SRC/src" "$SRC/agent" "$SRC/assets" "$DEST/"
 
-# node_modules is required at runtime (spectrum-ts). Copy if present, else install.
-if [ -d "$SRC/node_modules" ]; then
-  /usr/bin/rsync -a "$SRC/node_modules" "$DEST/"
-else
-  ( cd "$DEST" && "$BUN" install --production ) || echo "warning: bun install failed; sidecar may not run."
-fi
+# Install the reviewed lockfile, including both supported CPU architectures.
+( cd "$DEST" && "$BUN" install --production --frozen-lockfile --ignore-scripts --os darwin --cpu '*' )
 
 cp "$BUN" "$DEST/bin/bun"
 chmod +x "$DEST/bin/bun"
 
 # Codesign the nested binary (adhoc if no identity, matching engine bundling).
 IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY:--}}"
-codesign --force --timestamp=none --sign "$IDENTITY" "$DEST/bin/bun" 2>/dev/null \
-  || codesign --force --sign - "$DEST/bin/bun" 2>/dev/null \
-  || echo "warning: could not codesign bundled bun."
+codesign --force --timestamp=none --preserve-metadata=entitlements --sign "${IDENTITY:--}" "$DEST/bin/bun"
+codesign --verify --strict "$DEST/bin/bun"
+(cd "$DEST" && "$DEST/bin/bun" -e 'await import("spectrum-ts"); await import("spectrum-ts/providers/imessage");')
 
 echo "bundled iMessage sidecar → $DEST"

--- a/macos/scripts/fetch-sidecar-bun.sh
+++ b/macos/scripts/fetch-sidecar-bun.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Prepare a universal, checksum-pinned Bun runtime without a global install.
+set -euo pipefail
+DEST="${1:?runtime output directory}"
+mkdir -p "$DEST"
+DEST="$(cd "$DEST" && pwd)"
+WORK="$(mktemp -d "$DEST/download.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+VERSION=1.3.14
+for FLAVOR in aarch64 x64-baseline; do
+  case "$FLAVOR" in
+    aarch64) HASH=d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620 ;;
+    x64-baseline) HASH=3e35ad6f53971a9834bf9e6786e2adf72b5f1921cc9a9c5fde073d2972944076 ;;
+  esac
+  ARCHIVE="bun-darwin-$FLAVOR.zip"
+  curl --fail --location --silent --show-error --retry 2 --max-time 120 \
+    "https://github.com/oven-sh/bun/releases/download/bun-v$VERSION/$ARCHIVE" -o "$WORK/$ARCHIVE"
+  (cd "$WORK" && printf '%s  %s\n' "$HASH" "$ARCHIVE" | shasum -a 256 -c -)
+  unzip -q "$WORK/$ARCHIVE" -d "$WORK"
+done
+lipo -create "$WORK/bun-darwin-aarch64/bun" "$WORK/bun-darwin-x64-baseline/bun" -output "$DEST/bun"
+chmod +x "$DEST/bun"
+codesign --force --preserve-metadata=entitlements --sign - "$DEST/bun"
+lipo "$DEST/bun" -verify_arch arm64 x86_64
+"$DEST/bun" --version

--- a/macos/scripts/test-sidecar.sh
+++ b/macos/scripts/test-sidecar.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Exercise the production supervisor without starting the app or using credentials.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+mkdir -p "$TEST_ROOT/Sources/Burrow" "$TEST_ROOT/Tests/BurrowTests"
+cp "$ROOT/Sources/IMessageSidecar.swift" "$TEST_ROOT/Sources/Burrow/"
+cp "$ROOT/Tests/"IMessageSidecar*Tests.swift "$TEST_ROOT/Tests/BurrowTests/"
+cat > "$TEST_ROOT/Package.swift" <<'SWIFT'
+// swift-tools-version: 5.9
+import PackageDescription
+let package = Package(name: "SidecarChecks", platforms: [.macOS(.v13)],
+    targets: [.target(name: "Burrow"), .testTarget(name: "BurrowTests", dependencies: ["Burrow"])])
+SWIFT
+cat > "$TEST_ROOT/Sources/Burrow/Store.swift" <<'SWIFT'
+enum Store {
+    static let iMessageOwnerPhone = ""
+    static let iMessageProjectId = ""
+    static let iMessageProjectSecret = ""
+    static let iMessageAgentEnabled = false
+    static let iMessageLLMProvider = ""
+    static let iMessageLLMModel = ""
+    static let iMessageLLMBaseURL = ""
+    static let iMessageLLMKey = ""
+}
+SWIFT
+swift test --package-path "$TEST_ROOT"

--- a/tools/burrow-alerts/.gitignore
+++ b/tools/burrow-alerts/.gitignore
@@ -1,6 +1,4 @@
 node_modules/
-bun.lock
-bun.lockb
 *.state.json
 config.local.json
 .scguard/

--- a/tools/burrow-alerts/README.md
+++ b/tools/burrow-alerts/README.md
@@ -15,7 +15,7 @@ so it never spams.
 
 Debounce is a port of Burrow's own `AlertEngine`: hysteresis (fire at `high`,
 re-arm only below `low`) + cooldown, so you get one nudge per *episode*, not per
-sample. State persists in `alerts.state.json` across runs.
+sample. State persists in `~/Library/Application Support/Burrow/iMessage/alerts.state.json` across runs (`BURROW_ALERT_STATE_DIR` overrides this for isolated runs).
 
 ## Delivery — Photon spectrum-ts
 
@@ -76,7 +76,7 @@ Then text the Burrow line (e.g. "how's my disk?" / "what's eating CPU?").
 - **Safety:** only answers YOUR number (also the reply-loop guard); tools are
   **read-only**, enforced twice (allowlist to the model + refused in the exec);
   rate-limited (6/min), single-flight, 800-char reply cap; prompt ignores
-  instructions embedded in messages; metadata-only audit log (`logs/agent.audit.jsonl`).
+  instructions embedded in messages; metadata-only audit log (`~/Library/Application Support/Burrow/iMessage/logs/agent.audit.jsonl`).
 
 ## Setup & tests
 
@@ -100,3 +100,18 @@ local `claude` CLI); alerts alone need no key.
 - `src/sender.ts` — spectrum-ts cloud/local send
 - `tracer.ts` — the original one-shot disk tracer (kept for quick manual tests)
 - `FRICTION.md` — QA log of Photon SDK friction hit while building this
+
+## Bundled app development
+
+Prepare the pinned universal runtime before building the Mac app:
+
+```sh
+bash macos/scripts/fetch-sidecar-bun.sh /tmp/burrow-sidecar-bun
+export BUN_BIN=/tmp/burrow-sidecar-bun/bun
+```
+
+Run those commands from the repository root. Builds fail if the runtime, locked dependencies, or a target CPU architecture is missing. The bundle keeps Bun's JIT entitlements and runtime assets; mutable state and audit logs stay in Application Support. CI tests the sidecar before building and release signing includes Bun.
+
+The native supervisor runs checks every ten minutes and a weekly digest after Sunday 09:00 local time, catching up after sleep. It avoids overlapping checks and terminates both the agent and active check on quit. Settings still take effect on relaunch.
+
+The assistant accepts incoming owner DMs only. The local Claude provider disables built-in tools, user/project settings, hooks, and session persistence, and connects to a read-only MCP proxy that rejects every tool outside the same allowlist used by API providers. It follows the running app's `BURROW_BIN`, including nonstandard install paths. `bun test` uses fake processes and network responses; `bash macos/scripts/test-sidecar.sh` tests the native supervisor with local shell fixtures. Neither command sends messages.

--- a/tools/burrow-alerts/agent.ts
+++ b/tools/burrow-alerts/agent.ts
@@ -20,10 +20,12 @@ import { readFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { selectProvider, type LLMConfig } from "./src/llm.ts";
-import { resolveLLM } from "./src/config.ts";
+import { resolveLLM, resolveDelivery, stateDirectory, burrowMcpConfig } from "./src/config.ts";
+import { useCloud } from "./src/sender.ts";
+import { installShutdown } from "./src/lifecycle.ts";
 import { BurrowMCP } from "./src/burrow.ts";
 import { READONLY_TOOL_SPECS, READONLY_MCP_TOOL_IDS, makeBurrowExec } from "./src/burrow-tools.ts";
-import { isAuthorized, capReply, digits, RateLimiter } from "./src/safety.ts";
+import { isOwnerQuestion, capReply, digits, positiveInteger, RateLimiter } from "./src/safety.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ONCE = process.argv.includes("--once");
@@ -41,8 +43,9 @@ const CFG: Config = (() => {
   catch { return { recipient: process.env.BURROW_ALERT_TO ?? "" }; }
 })();
 
-const AUTHORIZED = digits(process.env.BURROW_ALERT_TO ?? CFG.recipient);
-const USE_CLOUD = !CFG.forceLocal && Boolean(CFG.projectId && CFG.projectSecret);
+const delivery = resolveDelivery(process.env, CFG, process.argv.includes("--local"));
+const AUTHORIZED = delivery.recipient;
+const USE_CLOUD = useCloud(delivery);
 const LLM: LLMConfig = resolveLLM(process.env, CFG.llm); // env (from Swift) → config → claude-cli
 
 const SYSTEM_PROMPT = [
@@ -57,7 +60,7 @@ const SYSTEM_PROMPT = [
 // One brain for the process. CLI provider delegates tools to its own MCP; API
 // providers get Burrow's read-only tool specs + a per-message MCP exec.
 const brain = selectProvider(LLM, {
-  cli: { mcpConfigPath: join(HERE, "agent", "burrow-mcp.json"), allowedTools: READONLY_MCP_TOOL_IDS, useJan: USE_JAN },
+  cli: { mcpConfigPath: burrowMcpConfig(process.env, { command: process.execPath, entry: join(HERE, "src", "readonly-mcp.ts") }), allowedTools: READONLY_MCP_TOOL_IDS, useJan: USE_JAN },
 });
 
 function stripMarkdown(t: string): string {
@@ -86,13 +89,13 @@ async function answer(question: string): Promise<string> {
 }
 
 // ---- multi-user safety ------------------------------------------------------
-const MAX_REPLY_CHARS = Number(process.env.AGENT_MAX_REPLY ?? 800);
-const limiter = new RateLimiter(Number(process.env.AGENT_RATE_MAX ?? 6), Number(process.env.AGENT_RATE_WINDOW_MS ?? 60_000));
-const AUDIT_PATH = join(HERE, "logs", "agent.audit.jsonl");
+const MAX_REPLY_CHARS = positiveInteger(process.env.AGENT_MAX_REPLY, 800);
+const limiter = new RateLimiter(positiveInteger(process.env.AGENT_RATE_MAX, 6), positiveInteger(process.env.AGENT_RATE_WINDOW_MS, 60_000));
+const AUDIT_PATH = join(stateDirectory(), "logs", "agent.audit.jsonl");
 let busy = false; // single-flight: one query at a time (cost + contention)
 
 function audit(rec: Record<string, unknown>) {
-  try { mkdirSync(dirname(AUDIT_PATH), { recursive: true }); appendFileSync(AUDIT_PATH, JSON.stringify({ ts: new Date().toISOString(), ...rec }) + "\n"); } catch {}
+  try { mkdirSync(dirname(AUDIT_PATH), { recursive: true, mode: 0o700 }); appendFileSync(AUDIT_PATH, JSON.stringify({ ts: new Date().toISOString(), ...rec }) + "\n", { mode: 0o600 }); } catch {}
 }
 async function say(space: any, msg: string) {
   const { text } = await import("spectrum-ts");
@@ -100,14 +103,13 @@ async function say(space: any, msg: string) {
 }
 
 async function handle(space: any, message: any): Promise<void> {
-  if (message?.content?.type !== "text") return;
-  if (!isAuthorized(message?.sender?.id ?? "", AUTHORIZED)) return; // loop guard + only-owner
+  if (!isOwnerQuestion(message, AUTHORIZED)) return;
   const question = String(message.content.text ?? "").trim();
   if (!question) return;
 
   const who = "…" + digits(message?.sender?.id ?? "").slice(-4); // metadata only
-  if (!limiter.allow(Date.now())) { audit({ event: "rate_limited", who, qLen: question.length }); await say(space, "One sec — too many messages at once. Try again in a moment."); return; }
-  if (busy) { audit({ event: "busy_rejected", who, qLen: question.length }); await say(space, "Still working on your last question — hang on."); return; }
+  if (!limiter.allow(Date.now())) { audit({ event: "rate_limited", who, qLen: question.length }); return; }
+  if (busy) { audit({ event: "busy_rejected", who, qLen: question.length }); return; }
 
   busy = true;
   const t0 = Date.now();
@@ -131,25 +133,28 @@ async function main() {
   if (!AUTHORIZED) throw new Error("no recipient configured (config.local.json.recipient)");
   const { Spectrum } = await import("spectrum-ts");
   const { imessage } = await import("spectrum-ts/providers/imessage");
-  const app = USE_CLOUD
-    ? await Spectrum({ projectId: CFG.projectId!, projectSecret: CFG.projectSecret!, providers: [imessage.config()] })
+  let app: Awaited<ReturnType<typeof Spectrum>> | undefined;
+  const shutdown = installShutdown(async () => { await app?.stop(); });
+  const startupDeadline = setTimeout(() => { void shutdown(); }, 30_000);
+  app = USE_CLOUD
+    ? await Spectrum({ projectId: delivery.projectId!, projectSecret: delivery.projectSecret!, providers: [imessage.config()] })
     : await Spectrum({ providers: [imessage.config({ local: true })] });
+  clearTimeout(startupDeadline);
 
   console.log(`[agent] listening (${USE_CLOUD ? "cloud" : "local"}); brain=${LLM.provider}; authorized=…${AUTHORIZED.slice(-4)}; once=${ONCE}`);
 
-  const shutdown = async () => { try { await app.stop(); } finally { process.exit(0); } };
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
 
   for await (const [space, message] of app.messages) {
     try {
-      const handled = message?.content?.type === "text" && isAuthorized(message?.sender?.id ?? "", AUTHORIZED);
-      await handle(space, message);
-      if (ONCE && handled) { await shutdown(); return; }
+      const handled = isOwnerQuestion(message, AUTHORIZED);
+      if (ONCE && handled) { await handle(space, message); await shutdown(); return; }
+      // Keep consuming while a question runs so single-flight rejects bursts
+      // when they arrive, instead of answering an unbounded stale backlog.
+      void handle(space, message).catch(() => console.error("[agent] handler failed"));
     } catch (e: any) {
       console.error(`[agent] handler error: ${e?.message ?? e}`);
     }
   }
 }
 
-main().catch((err) => { console.error("[agent] fatal:", err?.message ?? err); process.exit(1); });
+if (import.meta.main) main().catch((err) => { console.error("[agent] fatal:", err?.message ?? err); process.exit(1); });

--- a/tools/burrow-alerts/bun.lock
+++ b/tools/burrow-alerts/bun.lock
@@ -1,0 +1,400 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "burrow-alerts",
+      "dependencies": {
+        "@photon-ai/imessage-kit": "3.0.0",
+        "spectrum-ts": "9.1.0",
+      },
+      "devDependencies": {
+        "@types/bun": "1.3.14",
+        "typescript": "7.0.2",
+      },
+    },
+  },
+  "packages": {
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.14.1", "", {}, "sha512-agRJn3+EJDUe8AvxTx/LnHA/GErvLE62pSaSk7+MwFOtOv8eWBu/qCq2qoZjBjVZ3C2aiFJCveuSs17KMkYGOw=="],
+
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.11.0", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-Tr79DyWI8itsBdg+jH+opjfrwLzX+erk1/ExkIwhWoAVjVrJIn2y5+cGjTC0Vy8fyNIA/y8wuJPZwr1T3xCZeQ=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.11.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/sdk-logs": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ=="],
+
+    "@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.29.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.219.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.11.0", "", { "dependencies": { "@opentelemetry/core": "2.11.0", "@opentelemetry/resources": "2.11.0", "@opentelemetry/sdk-trace": "2.11.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@parseaple/bplist": ["@parseaple/bplist@1.0.1", "", {}, "sha512-HHZKfvCaY8r5lwc6YCiAIhpAwH56YR29JPQa/9ZW0UqzjqdzFidGgoWVIhIF8tPXCwivIt93vbyT0O5bpC1Twg=="],
+
+    "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
+
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.12.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-cqSq/ew48P3S+4xXpQmS/mDgpa+ijlKYKkQ4MExsQEjHfrJ0DpPJGuY5VHgzfTqV9wYVGyA3TNkDfse/ZRDxoA=="],
+
+    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
+
+    "@photon-ai/otel": ["@photon-ai/otel@3.7.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.218.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/core": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.218.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0", "@opentelemetry/exporter-trace-otlp-http": "^0.218.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.218.0", "@opentelemetry/sdk-metrics": "^2.7.1", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.41.1" }, "optionalDependencies": { "@opentelemetry/instrumentation": "^0.219.0", "@opentelemetry/instrumentation-undici": "^0.29.0" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-N+fwhvvx/T2tNR8747vFJQgUuLxqyjAVMMLwmakEupgcE4X2M8nbqrfZNSPKN5DL/lpLXYP27a/ACW+jSWAqyA=="],
+
+    "@photon-ai/proto": ["@photon-ai/proto@0.2.4", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "nice-grpc-common": "^2.0.3" } }, "sha512-DQANEp0gHvtwqpMGEF0ufa0hs1nniRdsSuo0Q/TG6GoL1WjC5tp59tHFSLUeIm6fvnAuRjREsGzURz3+/69g7g=="],
+
+    "@photon-ai/slack": ["@photon-ai/slack@0.2.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "@grpc/grpc-js": "^1.14.3", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3" } }, "sha512-k3XzGKIVS1EsjrPz9pbWvrvScmiy/iqKdA2npS5xu1CtCoycBkdFsqJKyB6iIyDR02Q3/38kQh7MvKsCzUyo3Q=="],
+
+    "@photon-ai/telegram-ts": ["@photon-ai/telegram-ts@10.0.0", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-kYGj/ieKOCG+OxoD1R69xHoT7zHl9dboF52LMPUl4FnorbwA8b2pid0uFoDYF55WIfoeo+VSqwlmY84GgpSedg=="],
+
+    "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.2.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-FL5hKSZcgXCiZO1hVbu2A2Bd226ZfDEcbvlVWCEJUukWPUL7Gcs0RSwsJm57FnF0J/KhZ1DiwMWLoSL06N+fGw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@repeaterjs/repeater": ["@repeaterjs/repeater@3.1.0", "", {}, "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ=="],
+
+    "@spectrum-ts/core": ["@spectrum-ts/core@9.1.0", "", { "dependencies": { "@photon-ai/otel": "^3.1.0", "@photon-ai/proto": "^0.2.4", "@repeaterjs/repeater": "^3.0.6", "marked": "^18.0.5", "mime-types": "^3.0.1", "open-graph-scraper": "^6.11.0", "vcf": "^2.1.2", "zod": "^4.2.1" }, "peerDependencies": { "ffmpeg-static": "^5", "typescript": "^5 || ^6.0.0" }, "optionalPeers": ["ffmpeg-static"] }, "sha512-2fjET5YCJ+c1MOOXYp51QG8/y6Fp0o7LbWOTZZ82HSoBvnjgcsCBoVMk1HBDUttr+rkgW6rrH2kQc4EtUP+jZA=="],
+
+    "@spectrum-ts/imessage": ["@spectrum-ts/imessage@9.1.0", "", { "dependencies": { "@photon-ai/advanced-imessage": "^0.12.0", "@photon-ai/imessage-kit": "^3.0.0", "@photon-ai/otel": "^3.1.0", "lru-cache": "^11.0.0", "marked": "^18.0.5", "zod": "^4.2.1" }, "peerDependencies": { "@spectrum-ts/core": "^9.0.0", "typescript": "^5 || ^6.0.0" } }, "sha512-yZnvUOs6RLDI0wA/VcoEtgksC0vLPZcQES7fwU1SDtWyjoYzoFfAkI/3+IzQ9AjRIcPDmx97GAEYgJohTn4oYQ=="],
+
+    "@spectrum-ts/slack": ["@spectrum-ts/slack@9.1.0", "", { "dependencies": { "@photon-ai/slack": "^0.2.0", "zod": "^4.2.1" }, "peerDependencies": { "@spectrum-ts/core": "^9.0.0", "typescript": "^5 || ^6.0.0" } }, "sha512-N5djETmUU4JybDOsmd61xR7kel0sFtH86ZFMuJRcxkSYHNdzLNYXww5XUi7Su/KSncGCe6I5ZXSBAw++GnUUYg=="],
+
+    "@spectrum-ts/telegram": ["@spectrum-ts/telegram@9.1.0", "", { "dependencies": { "@photon-ai/telegram-ts": "10.0.0", "marked": "^18.0.5", "zod": "^4.2.1" }, "peerDependencies": { "@spectrum-ts/core": "^9.0.0", "typescript": "^5 || ^6.0.0" } }, "sha512-n2oLpBOvicyoTLQBdoxX/1A1B09Q4Gfo6qkB0SVCSLmaIL+4g8S3BraWVRxU0P4wUbV9fMWQKZwKJ241MHzgug=="],
+
+    "@spectrum-ts/terminal": ["@spectrum-ts/terminal@9.1.0", "", { "dependencies": { "zod": "^4.2.1" }, "peerDependencies": { "@spectrum-ts/core": "^9.0.0", "typescript": "^5 || ^6.0.0" } }, "sha512-wUr4HcTJnWmNo1BXx1jOw3VhkhgHxfSt2mZzsXNJahrdRkwVj3v1WYmUa3MC9iJQYdBikgz27M8JzRF9M7yIGQ=="],
+
+    "@spectrum-ts/whatsapp-business": ["@spectrum-ts/whatsapp-business@9.1.0", "", { "dependencies": { "@photon-ai/whatsapp-business": "^0.2.0", "mime-types": "^3.0.1", "zod": "^4.2.1" }, "peerDependencies": { "@spectrum-ts/core": "^9.0.0", "typescript": "^5 || ^6.0.0" } }, "sha512-Q+AJt/pESyKaBGI5HbCsPBRO2V5IJVpU6hIwUC14kcznbTYVak2JR7f8heTit3jlSfs3wTC0P+5ZhSdDANZWsQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "better-sqlite3": ["better-sqlite3@12.11.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "chardet": ["chardet@2.2.0", "", {}, "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA=="],
+
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.1", "", {}, "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
+    "foldline": ["foldline@1.1.0", "", {}, "sha512-9SheyADS50hjvFYjFJ3OB/GlDz2mD1T2CHd7auIk4Uto5YYWPBcw8iYo3F+gENJ+/SOeH9tT0loHZSqlUlumTA=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "import-in-the-middle": ["import-in-the-middle@3.4.0", "", { "dependencies": { "cjs-module-lexer": "^2.2.0", "es-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
+    "marked": ["marked@18.0.11", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "nice-grpc": ["nice-grpc@2.1.17", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.4" } }, "sha512-pu9xYPlWSeqoYQOCqb2ftQqZi/P2DaI70PSuwnxvoyIRiilaOVtktyPe6LmuXegWB4Ic1sPuDGCnCCASbwzK0w=="],
+
+    "nice-grpc-common": ["nice-grpc-common@2.0.4", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-gOEXlD6ShXZMZ8k+49wm/bA2j1+3IKbEFV9WYREJcvZV4kM5L1KkILYTX9VYBzZF2OuYCe1wp8c82bQkvR0fHw=="],
+
+    "node-abi": ["node-abi@3.96.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "open-graph-scraper": ["open-graph-scraper@6.12.0", "", { "dependencies": { "chardet": "^2.2.0", "cheerio": "^1.2.0", "iconv-lite": "^0.7.2", "undici": "^7.28.0" } }, "sha512-x0fS3eHxdCox+rFBhQSVe+qBznSPn1pspp8A4BoaVEkiECZEwagEb8z06swLfaFFE2gefj1BvEBeJmdeGTDnYw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "protobufjs": ["protobufjs@8.8.0", "", { "dependencies": { "long": "^5.3.2" } }, "sha512-N3xhQ5yyBx3vQq4gubBfASzYhJGNzeDbjqBpu61g7UVylsN/qyffU96TKWD3GbbLOKF82VGNRNvv1+BFgE31Eg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "spectrum-ts": ["spectrum-ts@9.1.0", "", { "dependencies": { "@spectrum-ts/core": "9.1.0", "@spectrum-ts/imessage": "9.1.0", "@spectrum-ts/slack": "9.1.0", "@spectrum-ts/telegram": "9.1.0", "@spectrum-ts/terminal": "9.1.0", "@spectrum-ts/whatsapp-business": "9.1.0" } }, "sha512-i7xbiPWl3wOsOvSmgOVQmjDc3m8+BrwYBgwYhrI/m+E05BctfWdBKshyqvmImwkOrXCEaWK8lycqIQavsSHoiw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
+    "ts-error": ["ts-error@1.0.6", "", {}, "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "undici": ["undici@7.29.1", "", {}, "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vcf": ["vcf@2.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "foldline": "^1.1.0" } }, "sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "zod": ["zod@4.5.4", "", {}, "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA=="],
+
+    "@grpc/proto-loader/protobufjs": ["protobufjs@7.6.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg=="],
+
+    "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-http/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
+
+    "@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+  }
+}

--- a/tools/burrow-alerts/check.ts
+++ b/tools/burrow-alerts/check.ts
@@ -19,7 +19,9 @@ import { dirname, join } from "node:path";
 import {
   BurrowMCP, getSnapshot, getForecast, getSustainedCpu, getTopHogs, getReport,
 } from "./src/burrow.ts";
-import { AlertStore, step, type ThresholdRule } from "./src/alertengine.ts";
+import { AlertStore, step, digestDue, type ThresholdRule } from "./src/alertengine.ts";
+import { resolveDelivery, stateDirectory } from "./src/config.ts";
+import { installShutdown, stopChildren } from "./src/lifecycle.ts";
 import { formatDiskAlert, formatCpuAlert, formatDigest } from "./src/format.ts";
 import { sendText, sendCard, useCloud, type SendConfig } from "./src/sender.ts";
 import { diskCard, diskCardFrom, type MiniAppInput } from "./src/card.ts";
@@ -49,13 +51,8 @@ function loadConfig(): Config {
 }
 
 const CFG = loadConfig();
-const send: SendConfig = {
-  recipient: process.env.BURROW_ALERT_TO ?? CFG.recipient,
-  projectId: process.env.PHOTON_PROJECT_ID ?? CFG.projectId,
-  projectSecret: process.env.PHOTON_PROJECT_SECRET ?? CFG.projectSecret,
-  forceLocal: CFG.forceLocal || process.argv.includes("--local"),
-  card: CFG.card,
-};
+const send = resolveDelivery(process.env, CFG, process.argv.includes("--local"));
+const STATE_PATH = join(stateDirectory(), "alerts.state.json");
 
 // Defaults mirror Burrow's own thresholds (Doctor: <10% free = warn; ThresholdAlerts: CPU 90).
 const DISK = { high: 90, low: 85, cooldownSeconds: 6 * 3600, hogsTimeoutMs: 25_000, ...CFG.disk };
@@ -68,7 +65,7 @@ async function deliver(label: string, body: string, card?: MiniAppInput) {
   const asCard = Boolean(card && send.card && useCloud(send)); // cards are cloud-only
   console.log(`\n----- ${label}${asCard ? " (card)" : ""} -----\n${body}\n${"-".repeat(label.length + 12)}`);
   if (DRY_RUN) { console.log("[dry-run] not sending"); return; }
-  if (!send.recipient) { console.log("[skip] no recipient configured"); return; }
+  if (!send.recipient) throw new Error("no recipient configured");
   if (asCard) await sendCard(send, card!, body);   // text is the fallback
   else await sendText(send, body);
   console.log(`[sent ✅] ${label} via spectrum-ts (${useCloud(send) ? "cloud" : "local"})`);
@@ -83,14 +80,14 @@ async function runDigest(mcp: BurrowMCP) {
 }
 
 async function runChecks(mcp: BurrowMCP) {
-  const store = new AlertStore(join(HERE, "alerts.state.json"));
+  const store = new AlertStore(STATE_PATH);
   const ts = now();
 
   // 1) Fast signals up front — all read Burrow's DB and return quickly. We do
   //    them before any slow `analyze`, which would block this serial connection.
   const snap = await getSnapshot(mcp);
   const forecast = await getForecast(mcp).catch(() => null);
-  const cpu = await getSustainedCpu(mcp, CPU.windowMinutes, 5);
+  const cpu = await getSustainedCpu(mcp, CPU.windowMinutes, 100);
 
   // 2) Evaluate rules and stage next states. We do NOT persist state until after
   //    sends succeed, so a mid-run kill re-alerts rather than swallowing.
@@ -125,12 +122,14 @@ async function runChecks(mcp: BurrowMCP) {
 
   const needSamples = Math.max(CPU.minSamples, Math.ceil(cpu.sampleCount * 0.5));
   const worst = cpu.processes.filter((p) => p.samples >= needSamples).sort((a, b) => b.avg_cpu - a.avg_cpu)[0];
-  if (worst) {
-    const rule: ThresholdRule = { id: `cpu:${worst.name}`, high: CPU.high, low: CPU.low, cooldownSeconds: CPU.cooldownSeconds };
-    const { state, fired } = step(rule, worst.avg_cpu, ts, store.get(rule.id));
+  if (cpu.sampleCount >= CPU.minSamples) {
+    // Track the sustained-load episode itself. A process can recover, exit or
+    // leave the ranked list; per-name states would otherwise remain firing forever.
+    const rule: ThresholdRule = { id: "cpu:sustained", high: CPU.high, low: CPU.low, cooldownSeconds: CPU.cooldownSeconds };
+    const { state, fired } = step(rule, worst?.avg_cpu ?? 0, ts, store.get(rule.id));
     staged.push({ id: rule.id, state });
-    console.log(`[cpu] worst="${worst.name}" avg ${worst.avg_cpu.toFixed(0)}% over ${CPU.windowMinutes}m (samples ${worst.samples}/${cpu.sampleCount}, need ${needSamples}) fired=${fired}`);
-    if (fired) sends.push({ id: rule.id, label: "cpu alert", produce: async () => ({ text: formatCpuAlert({ name: worst.name, peak_cpu: worst.avg_cpu }, CPU.windowMinutes) }) });
+    if (worst) console.log(`[cpu] worst="${worst.name}" avg ${worst.avg_cpu.toFixed(0)}% over ${CPU.windowMinutes}m fired=${fired}`);
+    if (fired && worst) sends.push({ id: rule.id, label: "cpu alert", produce: async () => ({ text: formatCpuAlert({ name: worst.name, peak_cpu: worst.avg_cpu }, CPU.windowMinutes) }) });
   } else {
     console.log(`[cpu] no process sustained ≥${CPU.high}% over ${CPU.windowMinutes}m (sampleCount ${cpu.sampleCount})`);
   }
@@ -160,6 +159,10 @@ async function runChecks(mcp: BurrowMCP) {
 }
 
 async function main() {
+  installShutdown();
+  // Bounds SDK connection/send shutdown too, including standalone launchd runs.
+  setTimeout(() => { void stopChildren().finally(() => process.exit(1)); }, 180_000).unref();
+  if (!DRY_RUN && !send.recipient) throw new Error("no recipient configured");
   // Delivery-only smoke test (setup wizard's "Send test message"). No MCP needed.
   if (TEST) {
     await deliver("test", "✅ Burrow is connected. You'll get disk, CPU, and weekly-cleanup alerts here.");
@@ -177,13 +180,26 @@ async function main() {
   const mcp = new BurrowMCP();
   try {
     if (DIGEST) await runDigest(mcp);
-    else await runChecks(mcp);
+    else {
+      await runChecks(mcp);
+      if (process.argv.includes("--scheduled") && !DRY_RUN) {
+        const store = new AlertStore(STATE_PATH);
+        const last = store.get("weekly_digest").lastFiredTS;
+        // The first run establishes the schedule; enabling the feature doesn't
+        // send an unsolicited historical digest immediately.
+        if (last !== null && digestDue(last, new Date())) await runDigest(mcp);
+        if (last === null || digestDue(last, new Date())) {
+          store.set("weekly_digest", { firing: false, lastFiredTS: now() });
+          store.save();
+        }
+      }
+    }
   } finally {
     await mcp.close();
   }
 }
 
-main().catch((err) => {
+if (import.meta.main) main().catch((err) => {
   console.error("[check] failed:", err?.message ?? err);
   process.exit(1);
 });

--- a/tools/burrow-alerts/config.example.json
+++ b/tools/burrow-alerts/config.example.json
@@ -17,7 +17,7 @@
   "llm": { "provider": "claude-cli" },
 
   "_card": "OPTIONAL (cloud only): render disk alerts as an iMessage mini-app card (rich bubble + lock-screen summary + tap-to-open URL) instead of plain text. Needs a real iMessage extension's identifiers; without one, recipients see the summary + app name and the tap may no-op. Falls back to text automatically. Remove this block to keep plain-text alerts.",
-  "_card_example": { "appName": "Burrow", "extensionBundleId": "dev.caezium.Burrow.imessage", "teamId": "ABCDE12345", "url": "https://burrow.henryzh.dev", "appStoreId": 0 },
+  "_card_example": { "appName": "Burrow", "extensionBundleId": "dev.caezium.Burrow.cards.extension", "teamId": "ABCDE12345", "url": "https://burrow.henryzh.dev", "appStoreId": 0 },
 
   "disk": { "high": 90, "low": 85, "cooldownSeconds": 21600, "hogsTimeoutMs": 25000 },
   "cpu": { "high": 90, "low": 70, "windowMinutes": 10, "minSamples": 3, "cooldownSeconds": 3600 }

--- a/tools/burrow-alerts/launchd/install.sh
+++ b/tools/burrow-alerts/launchd/install.sh
@@ -24,8 +24,11 @@ if [[ "${1:-}" == "--uninstall" ]]; then
 fi
 
 if [[ ! -f "$DIR/config.local.json" ]]; then
-  echo "⚠️  $DIR/config.local.json not found — the jobs won't have a recipient/creds." >&2
+  echo "error: $DIR/config.local.json not found — configure delivery before installing jobs." >&2
+  exit 1
 fi
+[[ -x "$BUN" ]] || { echo "error: Bun runtime not found at $BUN" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "error: Python 3 is required to generate launchd plists." >&2; exit 1; }
 
 mkdir -p "$AGENTS" "$DIR/logs"
 unload   # clean slate
@@ -33,7 +36,19 @@ unload   # clean slate
 for TPL in "$DIR"/launchd/*.plist.template; do
   L="$(basename "$TPL" .plist.template)"
   OUT="$AGENTS/$L.plist"
-  sed -e "s#__BUN__#$BUN#g" -e "s#__DIR__#$DIR#g" "$TPL" > "$OUT"
+  python3 - "$TPL" "$OUT" "$BUN" "$DIR" <<'PYPLIST'
+import plistlib, sys
+source, target, bun, directory = sys.argv[1:]
+with open(source, "rb") as stream:
+    data = plistlib.load(stream)
+def replace(value):
+    if isinstance(value, str): return value.replace("__BUN__", bun).replace("__DIR__", directory)
+    if isinstance(value, list): return [replace(item) for item in value]
+    if isinstance(value, dict): return {key: replace(item) for key, item in value.items()}
+    return value
+with open(target, "wb") as stream:
+    plistlib.dump(replace(data), stream)
+PYPLIST
   plutil -lint "$OUT" >/dev/null
   launchctl bootstrap "gui/$(id -u)" "$OUT"
   echo "loaded $L"

--- a/tools/burrow-alerts/package.json
+++ b/tools/burrow-alerts/package.json
@@ -15,10 +15,15 @@
     "check:card": "bun run check.ts --test-card",
     "digest": "bun run check.ts --digest",
     "tracer": "bun run tracer.ts",
-    "install-launchd": "./launchd/install.sh"
+    "install-launchd": "./launchd/install.sh",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@photon-ai/imessage-kit": "3.0.0",
     "spectrum-ts": "9.1.0"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.14",
+    "typescript": "7.0.2"
   }
 }

--- a/tools/burrow-alerts/src/alertengine.test.ts
+++ b/tools/burrow-alerts/src/alertengine.test.ts
@@ -1,5 +1,29 @@
 import { test, expect } from "bun:test";
-import { step, type ThresholdRule, type AlertState } from "./alertengine.ts";
+import { step, digestDue, AlertStore, type ThresholdRule, type AlertState } from "./alertengine.ts";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+test("weekly digest runs after Sunday 09:00 and catches up after sleep only once", () => {
+  const sent = new Date(2026, 8, 5, 10).getTime() / 1000;
+  expect(digestDue(sent, new Date(2026, 8, 6, 8, 59))).toBe(false);
+  expect(digestDue(sent, new Date(2026, 8, 6, 9))).toBe(true);
+  expect(digestDue(sent, new Date(2026, 8, 7, 14))).toBe(true);
+  expect(digestDue(new Date(2026, 8, 7, 14).getTime() / 1000, new Date(2026, 8, 8, 10))).toBe(false);
+});
+
+test("malformed state cannot break checks; saved debounce survives another invocation", () => {
+  const dir = mkdtempSync(join(tmpdir(), "burrow-state-test-"));
+  try {
+    const path = join(dir, "alerts.state.json");
+    writeFileSync(path, "null");
+    const store = new AlertStore(path);
+    expect(store.get("disk")).toEqual({ firing: false, lastFiredTS: null });
+    store.set("disk", { firing: true, lastFiredTS: 123 }); store.save();
+    expect(new AlertStore(path).get("disk")).toEqual({ firing: true, lastFiredTS: 123 });
+    expect(JSON.parse(readFileSync(path, "utf8")).disk.firing).toBe(true);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
 
 const rule: ThresholdRule = { id: "disk", high: 90, low: 85, cooldownSeconds: 100 };
 

--- a/tools/burrow-alerts/src/alertengine.ts
+++ b/tools/burrow-alerts/src/alertengine.ts
@@ -9,7 +9,7 @@
  * launchd invocations (each run is a fresh process).
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { dirname } from "node:path";
 
 export type ThresholdRule = {
@@ -56,9 +56,16 @@ export class AlertStore {
   constructor(path: string) {
     this.path = path;
     try {
-      this.data = JSON.parse(readFileSync(path, "utf8"));
+      const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+      this.data = Object.create(null);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        for (const [key, value] of Object.entries(parsed)) {
+          if (value && typeof value.firing === "boolean"
+            && (value.lastFiredTS === null || Number.isFinite(value.lastFiredTS))) this.data[key] = value;
+        }
+      }
     } catch {
-      this.data = {};
+      this.data = Object.create(null);
     }
   }
 
@@ -71,7 +78,20 @@ export class AlertStore {
   }
 
   save() {
-    mkdirSync(dirname(this.path), { recursive: true });
-    writeFileSync(this.path, JSON.stringify(this.data, null, 2) + "\n");
+    mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
+    const temporary = `${this.path}.${process.pid}.tmp`;
+    try {
+      writeFileSync(temporary, JSON.stringify(this.data, null, 2) + "\n", { mode: 0o600 });
+      renameSync(temporary, this.path);
+    } finally { rmSync(temporary, { force: true }); }
   }
+}
+
+/** Sunday at 09:00 local time, with catch-up after sleep or app downtime. */
+export function digestDue(lastSentSeconds: number, now: Date): boolean {
+  const boundary = new Date(now);
+  boundary.setDate(boundary.getDate() - boundary.getDay());
+  boundary.setHours(9, 0, 0, 0);
+  if (boundary > now) boundary.setDate(boundary.getDate() - 7);
+  return lastSentSeconds * 1000 < boundary.getTime();
 }

--- a/tools/burrow-alerts/src/burrow.test.ts
+++ b/tools/burrow-alerts/src/burrow.test.ts
@@ -4,23 +4,51 @@
  */
 import { test, expect } from "bun:test";
 
-// Point at a path that cannot exist BEFORE importing the module (BURROW_BIN is read at load).
-process.env.BURROW_BIN = "/definitely/not/real/burrow-binary-xyz-does-not-exist";
-const { BurrowMCP } = await import("./burrow.ts");
+import { BurrowMCP } from "./burrow.ts";
+const missingBinary = "/definitely/not/real/burrow-binary-xyz-does-not-exist";
 
 test("a missing burrow binary rejects the call instead of throwing uncaught", async () => {
-  const mcp = new BurrowMCP();
+  const mcp = new BurrowMCP(missingBinary);
   // Spawn ENOENT fires 'error' async → die() rejects `ready` and all pending calls.
   await expect(mcp.toolText("burrow_snapshot")).rejects.toThrow();
   await mcp.close();
 });
 
 test("further calls after death reject fast and don't hang", async () => {
-  const mcp = new BurrowMCP();
+  const mcp = new BurrowMCP(missingBinary);
   await expect(mcp.toolText("burrow_snapshot")).rejects.toThrow();
   // Second call after the child is dead: immediate rejection, no 15s timeout wait.
   const t0 = Date.now();
   await expect(mcp.toolText("burrow_disk_forecast")).rejects.toThrow();
   expect(Date.now() - t0).toBeLessThan(1_000);
   await mcp.close();
+});
+
+test("a clean child exit rejects a pending initialization immediately", async () => {
+  const mcp = new BurrowMCP(process.execPath, ["-e", "process.exit(0)"]);
+  const started = Date.now();
+  try {
+    await expect(mcp.toolText("burrow_snapshot")).rejects.toThrow("exited");
+    expect(Date.now() - started).toBeLessThan(1000);
+  } finally { await mcp.close(); }
+});
+
+test("MCP preserves Unicode split between chunks and surfaces tool errors", async () => {
+  const source = `
+    import {createInterface} from 'node:readline';
+    for await (const line of createInterface({input:process.stdin})) {
+      const request=JSON.parse(line); if (!request.id) continue;
+      const result=request.method==='initialize' ? {} : {isError:request.params.name==='fail',content:[{type:'text',text:'healthy 🌕'}]};
+      const bytes=Buffer.from(JSON.stringify({jsonrpc:'2.0',id:request.id,result})+'\\n');
+      const split=bytes.indexOf(Buffer.from('🌕'))+1;
+      process.stdout.write(bytes.subarray(0,split));
+      await Bun.sleep(5);
+      process.stdout.write(bytes.subarray(split));
+    }
+  `;
+  const mcp = new BurrowMCP(process.execPath, ["-e", source]);
+  try {
+    expect(await mcp.toolText("ok")).toBe("healthy 🌕");
+    await expect(mcp.toolText("fail")).rejects.toThrow("healthy 🌕");
+  } finally { await mcp.close(); }
 });

--- a/tools/burrow-alerts/src/burrow.ts
+++ b/tools/burrow-alerts/src/burrow.ts
@@ -13,6 +13,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { trackChild, terminateChild } from "./lifecycle.ts";
 
 const BURROW_BIN =
   process.env.BURROW_BIN ?? "/Applications/Burrow.app/Contents/MacOS/Burrow";
@@ -34,8 +35,8 @@ export class BurrowMCP {
   private dead = false;
   private deadError: Error | null = null;
 
-  constructor() {
-    this.proc = spawn(BURROW_BIN, ["--mcp"], { stdio: ["pipe", "pipe", "ignore"] });
+  constructor(command = BURROW_BIN, args = ["--mcp"]) {
+    this.proc = trackChild(spawn(command, args, { stdio: ["pipe", "pipe", "ignore"], detached: true }));
     // A missing/moved Burrow.app makes spawn emit 'error' on the child. With no listener Node
     // RE-THROWS it as an uncaught exception — bypassing every `.catch`/await and, in the
     // long-lived agent (one BurrowMCP per message), turning a fresh Mac without Burrow into a
@@ -43,10 +44,13 @@ export class BurrowMCP {
     // rejection on `ready`/pending calls instead.
     this.proc.on("error", (e) => this.die(e instanceof Error ? e : new Error(String(e))));
     this.proc.on("exit", (code, signal) => {
-      if (code !== 0) this.die(new Error(`burrow --mcp exited early (code ${code ?? "null"}, signal ${signal ?? "null"})`));
+      this.die(new Error(`burrow --mcp exited (code ${code ?? "null"}, signal ${signal ?? "null"})`));
     });
-    this.proc.stdout!.on("data", (d) => this.onData(String(d)));
+    this.proc.stdin!.on("error", (error) => this.die(error));
+    this.proc.stdout!.setEncoding("utf8");
+    this.proc.stdout!.on("data", (d: string) => this.onData(d));
     this.ready = this.init();
+    void this.ready.catch(() => {}); // A failed idle session is observed by its next call.
   }
 
   /** Tear down on a fatal child failure: reject every in-flight call (and `ready`, one of them)
@@ -74,6 +78,11 @@ export class BurrowMCP {
 
   private onData(chunk: string) {
     this.buf += chunk;
+    if (this.buf.length > 8_000_000) {
+      this.die(new Error("MCP response exceeded limit"));
+      void terminateChild(this.proc);
+      return;
+    }
     let i: number;
     while ((i = this.buf.indexOf("\n")) >= 0) {
       const line = this.buf.slice(0, i);
@@ -119,6 +128,7 @@ export class BurrowMCP {
     await this.ready;
     const res = await this.rpc("tools/call", { name, arguments: args }, timeoutMs);
     const text = res?.content?.[0]?.text;
+    if (res?.isError) throw new Error(`${name}: ${typeof text === "string" ? text : "tool failed"}`);
     if (typeof text !== "string") throw new Error(`${name}: no text content`);
     return text;
   }
@@ -129,8 +139,8 @@ export class BurrowMCP {
   }
 
   async close() {
-    try { this.proc.stdin!.end(); } catch {}
-    this.proc.kill();
+    this.die(new Error("MCP session closed"));
+    await terminateChild(this.proc);
   }
 }
 

--- a/tools/burrow-alerts/src/burrowlayout.test.ts
+++ b/tools/burrow-alerts/src/burrowlayout.test.ts
@@ -26,6 +26,14 @@ test("encode/decode round-trips the layout through a base64url ?p= URL (Photon t
   expect(back).toEqual(l);
 });
 
+test("card URLs replace old payloads and keep fragments out of the query", () => {
+  const layout = diskLayout({ usedPercent: 91, freeBytes: 20e9 });
+  const encoded = encodeLayoutURL("https://example.com/card?p=stale&mode=small#details", layout);
+  expect(new URL(encoded).hash).toBe("#details");
+  expect(new URL(encoded).searchParams.getAll("p")).toHaveLength(1);
+  expect(decodeLayoutURL(encoded)).toEqual(layout);
+});
+
 function findNode(n: any, pred: (n: any) => boolean): any {
   if (pred(n)) return n;
   for (const c of n.children ?? []) {

--- a/tools/burrow-alerts/src/burrowlayout.ts
+++ b/tools/burrow-alerts/src/burrowlayout.ts
@@ -93,8 +93,9 @@ const toBase64Url = (json: string) => Buffer.from(json, "utf8").toString("base64
 const fromBase64Url = (p: string) => Buffer.from(p, "base64url").toString("utf8");
 
 export function encodeLayoutURL(baseUrl: string, layout: BurrowLayout): string {
-  const sep = baseUrl.includes("?") ? "&" : "?";
-  return `${baseUrl}${sep}p=${toBase64Url(JSON.stringify(layout))}`;
+  const url = new URL(baseUrl);
+  url.searchParams.set("p", toBase64Url(JSON.stringify(layout)));
+  return url.toString();
 }
 
 export function decodeLayoutURL(url: string): BurrowLayout {

--- a/tools/burrow-alerts/src/card.test.ts
+++ b/tools/burrow-alerts/src/card.test.ts
@@ -4,7 +4,7 @@ import { decodeLayoutURL } from "./burrowlayout.ts";
 
 const meta: MiniAppMeta = {
   appName: "Burrow",
-  extensionBundleId: "dev.caezium.Burrow.imessage",
+  extensionBundleId: "dev.caezium.Burrow.cards.extension",
   teamId: "ABCDE12345",
   url: "https://burrow.henryzh.dev",
 };
@@ -12,10 +12,10 @@ const meta: MiniAppMeta = {
 test("diskCard builds a mini-app card: caption, subcaption, lock-screen summary, deep link", () => {
   const c = diskCard(meta, { usedPercent: 98.9, freeBytes: 6.1e9, daysUntilFull: 6, hogs: [] });
   expect(c.appName).toBe("Burrow");
-  expect(c.extensionBundleId).toBe("dev.caezium.Burrow.imessage");
+  expect(c.extensionBundleId).toBe("dev.caezium.Burrow.cards.extension");
   expect(c.teamId).toBe("ABCDE12345");
   // url carries the BurrowLayout as a base64url ?p= payload the extension decodes
-  expect(c.url.startsWith("https://burrow.henryzh.dev?p=")).toBe(true);
+  expect(c.url.startsWith("https://burrow.henryzh.dev/?p=")).toBe(true);
   expect(decodeLayoutURL(c.url).title).toContain("99% full");
   expect(c.layout.caption).toContain("99% full");
   expect(c.layout.subcaption).toContain("6.1 GB free");

--- a/tools/burrow-alerts/src/card.ts
+++ b/tools/burrow-alerts/src/card.ts
@@ -25,7 +25,7 @@ export type MiniAppLayout = {
   trailingCaption?: string;
   trailingSubcaption?: string;
   /** Bubble image bytes (JPEG — Photon rejects PNG). Attached at send time. */
-  image?: Uint8Array;
+  image?: Uint8Array<ArrayBuffer>;
   imageTitle?: string;
   imageSubtitle?: string;
   summary?: string;

--- a/tools/burrow-alerts/src/config.test.ts
+++ b/tools/burrow-alerts/src/config.test.ts
@@ -1,5 +1,25 @@
 import { test, expect } from "bun:test";
-import { resolveLLM } from "./config.ts";
+import { resolveLLM, resolveDelivery, stateDirectory, burrowMcpConfig } from "./config.ts";
+import { useCloud } from "./sender.ts";
+
+test("the native app's environment selects cloud delivery and preserves owner handles", () => {
+  const cfg = resolveDelivery({ BURROW_ALERT_TO: "owner42@example.com", PHOTON_PROJECT_ID: "p", PHOTON_PROJECT_SECRET: "s" });
+  expect(useCloud(cfg)).toBe(true);
+  expect(cfg.recipient).toBe("owner42@example.com");
+  expect(useCloud(resolveDelivery({}, cfg, true))).toBe(false);
+});
+
+test("runtime files live in Application Support, and MCP follows the running app", () => {
+  expect(stateDirectory({}, "/Users/Test")).toBe("/Users/Test/Library/Application Support/Burrow/iMessage");
+  expect(stateDirectory({ BURROW_ALERT_STATE_DIR: "/tmp/test-state" })).toBe("/tmp/test-state");
+  expect(JSON.parse(burrowMcpConfig({ BURROW_BIN: "/tmp/Test Burrow.app/Contents/MacOS/Burrow" })).mcpServers.burrow.command)
+    .toBe("/tmp/Test Burrow.app/Contents/MacOS/Burrow");
+});
+
+test("an empty Anthropic model uses the provider default", () => {
+  expect(resolveLLM({ BURROW_LLM_PROVIDER: "anthropic", BURROW_LLM_KEY: "k", BURROW_LLM_MODEL: "" }))
+    .toEqual({ provider: "anthropic", apiKey: "k" });
+});
 
 test("resolveLLM reads a named provider from env", () => {
   expect(resolveLLM({ BURROW_LLM_PROVIDER: "openrouter", BURROW_LLM_KEY: "k", BURROW_LLM_MODEL: "m" }))

--- a/tools/burrow-alerts/src/config.ts
+++ b/tools/burrow-alerts/src/config.ts
@@ -4,8 +4,35 @@
  */
 
 import type { LLMConfig } from "./llm.ts";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { SendConfig } from "./sender.ts";
 
 type Env = Record<string, string | undefined>;
+
+/** Swift and standalone runners use the same delivery precedence. */
+export function resolveDelivery(env: Env, config: Partial<SendConfig> = {}, local = false): SendConfig {
+  return {
+    recipient: (env.BURROW_ALERT_TO ?? config.recipient ?? "").trim(),
+    projectId: env.PHOTON_PROJECT_ID ?? config.projectId,
+    projectSecret: env.PHOTON_PROJECT_SECRET ?? config.projectSecret,
+    forceLocal: local || config.forceLocal,
+    card: config.card,
+  };
+}
+
+/** Runtime writes must never modify Contents/Resources in the signed app. */
+export function stateDirectory(env: Env = process.env, home = homedir()): string {
+  return env.BURROW_ALERT_STATE_DIR || join(home, "Library", "Application Support", "Burrow", "iMessage");
+}
+
+export function burrowMcpConfig(env: Env = process.env, proxy?: { command: string; entry: string }): string {
+  return JSON.stringify({ mcpServers: { burrow: {
+    command: proxy?.command ?? (env.BURROW_BIN || "/Applications/Burrow.app/Contents/MacOS/Burrow"),
+    args: proxy ? ["run", proxy.entry] : ["--mcp"],
+    ...(proxy ? { env: { BURROW_BIN: env.BURROW_BIN || "/Applications/Burrow.app/Contents/MacOS/Burrow" } } : {}),
+  } } });
+}
 
 export function resolveLLM(env: Env, fromConfig?: LLMConfig): LLMConfig {
   const p = env.BURROW_LLM_PROVIDER;
@@ -19,7 +46,7 @@ export function resolveLLM(env: Env, fromConfig?: LLMConfig): LLMConfig {
       case "openai-compat":
         return { provider: p, baseUrl: env.BURROW_LLM_BASEURL ?? "", apiKey, model };
       case "anthropic":
-        return { provider: p, apiKey, model };
+        return { provider: p, apiKey, ...(model.trim() ? { model } : {}) };
       case "claude-cli":
         return { provider: "claude-cli", ...(env.BURROW_LLM_MODEL ? { model } : {}) };
     }

--- a/tools/burrow-alerts/src/lifecycle.ts
+++ b/tools/burrow-alerts/src/lifecycle.ts
@@ -1,0 +1,61 @@
+import type { ChildProcess } from "node:child_process";
+
+const children = new Set<ChildProcess>();
+
+/** These children have their own process group so their MCP helpers stop too. */
+export function trackChild(child: ChildProcess): ChildProcess {
+  children.add(child);
+  child.once("close", () => children.delete(child));
+  return child;
+}
+
+function signalGroup(child: ChildProcess, signal: NodeJS.Signals) {
+  if (!child.pid) return;
+  try { process.kill(-child.pid, signal); }
+  catch { try { child.kill(signal); } catch {} }
+}
+
+export async function terminateChild(child: ChildProcess, graceMs = 300): Promise<void> {
+  signalGroup(child, "SIGTERM");
+  // Even a reaped parent may have descendants holding stdout. Kill the group
+  // after the grace period, then release local pipe handles deterministically.
+  await new Promise<void>((resolve) => setTimeout(resolve, graceMs));
+  signalGroup(child, "SIGKILL");
+  child.stdin?.destroy(); child.stdout?.destroy(); child.stderr?.destroy();
+  children.delete(child);
+}
+
+export async function stopChildren(): Promise<void> {
+  await Promise.all([...children].map((child) => terminateChild(child)));
+}
+
+/** Works for standalone runs too; no handlers or timers are installed by imports. */
+export function installShutdown(stop: () => Promise<void> = async () => {}) {
+  let stopping = false;
+  const shutdown = async () => {
+    if (stopping) return;
+    stopping = true;
+    const forced = setTimeout(() => process.exit(1), 1_500);
+    await stopChildren();
+    try { await stop(); } finally { clearTimeout(forced); process.exit(0); }
+  };
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
+  const parent = Number(process.env.BURROW_PARENT_PID);
+  if (Number.isSafeInteger(parent) && parent > 1) {
+    setInterval(() => {
+      try { process.kill(parent, 0); } catch { void shutdown(); }
+    }, 1_000).unref();
+  }
+  return shutdown;
+}
+
+/** Abort covers both response headers and body consumption. */
+export async function fetchJson(fetchImpl: typeof fetch, url: string, init: RequestInit, timeoutMs = 30_000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("model request timed out")), timeoutMs);
+  try {
+    const response = await fetchImpl(url, { ...init, signal: controller.signal });
+    return { ok: response.ok, status: response.status, body: response.ok ? await response.json() : undefined };
+  } finally { clearTimeout(timer); }
+}

--- a/tools/burrow-alerts/src/llm.test.ts
+++ b/tools/burrow-alerts/src/llm.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { makeOpenAICompatBrain, makeClaudeCliBrain, selectProvider } from "./llm.ts";
+import { makeOpenAICompatBrain, makeClaudeCliBrain, selectProvider, defaultRunCli } from "./llm.ts";
 
 // A fake OpenAI-compatible /chat/completions endpoint that returns queued
 // responses in order, so we can drive the brain deterministically.
@@ -59,11 +59,30 @@ test("claude-cli brain shells claude with the burrow mcp config and returns its 
   const a = await brain.ask("how's my disk?", { system: "be brief", tools: [], exec: async () => "" });
 
   expect(a).toBe("6 GB free (via claude).");
+  expect(seen.args.slice(seen.args.indexOf("--tools"), seen.args.indexOf("--tools") + 2)).toEqual(["--tools", ""]);
+  expect(seen.args).toEqual(expect.arrayContaining(["--permission-mode", "dontAsk", "--setting-sources", "", "--no-session-persistence"]));
   expect(seen.args).toEqual(expect.arrayContaining([
     "-p", "how's my disk?", "--mcp-config", "/x/burrow-mcp.json",
     "--strict-mcp-config", "--allowedTools", "mcp__burrow__burrow_snapshot",
     "--append-system-prompt", "be brief",
   ]));
+});
+
+test("both API providers abort a stalled request", async () => {
+  for (const provider of ["openai", "anthropic"] as const) {
+    const fetchImpl = ((_url: unknown, init: RequestInit) => new Promise((_resolve, reject) => {
+      init.signal!.addEventListener("abort", () => reject(init.signal!.reason));
+    })) as typeof fetch;
+    const brain = selectProvider({ provider, apiKey: "fake", model: "fake" }, { fetchImpl, timeoutMs: 10 });
+    await expect(brain.ask("test", { system: "test", tools: [], exec: async () => "" })).rejects.toThrow("timed out");
+  }
+});
+
+test("CLI drains stderr and surfaces failure or timeout without running a real model", async () => {
+  const run = defaultRunCli(false, process.execPath, 1_000);
+  expect(await run(["-e", "process.stderr.write('x'.repeat(200000)); console.log('answer')"])).toBe("answer");
+  await expect(run(["-e", "process.exit(3)"])).rejects.toThrow("exited (3)");
+  await expect(defaultRunCli(false, process.execPath, 30)(["-e", "setInterval(() => {}, 1000)"])).rejects.toThrow("timed out");
 });
 
 test("anthropic brain returns text and can run a tool round", async () => {

--- a/tools/burrow-alerts/src/llm.ts
+++ b/tools/burrow-alerts/src/llm.ts
@@ -6,6 +6,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { trackChild, terminateChild, fetchJson } from "./lifecycle.ts";
 
 export type ToolSpec = { name: string; description: string; schema: object };
 export type ToolExec = (name: string, args: any) => Promise<string>;
@@ -17,6 +18,7 @@ export interface Brain {
 export type OpenAICompatCfg = { baseUrl: string; apiKey: string; model: string };
 type Deps = {
   fetchImpl?: typeof fetch;
+  timeoutMs?: number;
   // App-level context for the claude-cli provider (not part of user LLMConfig).
   cli?: { mcpConfigPath: string; allowedTools: string[]; runCli?: (args: string[]) => Promise<string>; useJan?: boolean };
 };
@@ -62,17 +64,26 @@ export function selectProvider(cfg: LLMConfig, deps: Deps = {}): Brain {
 export type ClaudeCliCfg = { model?: string; mcpConfigPath: string; allowedTools: string[]; useJan?: boolean };
 type CliDeps = { runCli?: (args: string[]) => Promise<string> };
 
-function defaultRunCli(useJan: boolean): (args: string[]) => Promise<string> {
+export function defaultRunCli(useJan: boolean, command = "claude", timeoutMs = 180_000): (args: string[]) => Promise<string> {
   return (args) =>
-    new Promise((resolve) => {
+    new Promise((resolve, reject) => {
       const env = { ...process.env };
       if (!useJan) { delete env.ANTHROPIC_BASE_URL; delete env.ANTHROPIC_AUTH_TOKEN; }
-      const child = spawn("claude", args, { stdio: ["ignore", "pipe", "pipe"], env });
+      const child = trackChild(spawn(command, args, { stdio: ["ignore", "pipe", "pipe"], env, detached: true }));
       let out = "";
-      const timer = setTimeout(() => child.kill("SIGKILL"), 180_000);
-      child.stdout.on("data", (d) => (out += d));
-      child.on("close", () => { clearTimeout(timer); resolve(out.trim()); });
-      child.on("error", () => { clearTimeout(timer); resolve(""); });
+      const timer = setTimeout(() => {
+        void terminateChild(child);
+        reject(new Error("Claude CLI timed out"));
+      }, timeoutMs);
+      child.stdout!.setEncoding("utf8");
+      child.stdout!.on("data", (d: string) => {
+        if (out.length + d.length > 1_000_000) {
+          clearTimeout(timer); void terminateChild(child); reject(new Error("Claude CLI output exceeded limit"));
+        } else out += d;
+      });
+      child.stderr!.resume(); // Never let diagnostics fill a pipe and block the answer.
+      child.on("close", (code) => { clearTimeout(timer); code === 0 ? resolve(out.trim()) : reject(new Error(`Claude CLI exited (${code})`)); });
+      child.on("error", (error) => { clearTimeout(timer); reject(error); });
     });
 }
 
@@ -85,6 +96,12 @@ export function makeClaudeCliBrain(cfg: ClaudeCliCfg, deps: CliDeps = {}): Brain
         "-p", question,
         "--mcp-config", cfg.mcpConfigPath,
         "--strict-mcp-config",
+        "--tools", "", // allowedTools grants permissions; it does not remove built-in tools.
+        "--permission-mode", "dontAsk",
+        "--setting-sources", "",
+        "--settings", JSON.stringify({ disableAllHooks: true }),
+        "--disable-slash-commands",
+        "--no-session-persistence",
         "--allowedTools", ...cfg.allowedTools,
         "--append-system-prompt", system,
         ...model,
@@ -106,7 +123,7 @@ export function makeAnthropicBrain(cfg: AnthropicCfg, deps: Deps = {}): Brain {
         : undefined;
 
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-        const res = await doFetch(url, {
+        const res = await fetchJson(doFetch, url, {
           method: "POST",
           headers: {
             "content-type": "application/json",
@@ -114,11 +131,11 @@ export function makeAnthropicBrain(cfg: AnthropicCfg, deps: Deps = {}): Brain {
             "anthropic-version": "2023-06-01",
           },
           body: JSON.stringify({ model: cfg.model, max_tokens: 1024, system, messages, tools: toolPayload }),
-        } as any);
+        }, deps.timeoutMs);
         // Without this an auth/rate-limit/5xx returns a body with no `content`, the brain yields
         // "", and the agent texts the owner a BLANK bubble. Surface the failure instead.
         if (!(res as any).ok) return `I couldn't reach the model (HTTP ${(res as any).status}).`;
-        const json = await (res as any).json();
+        const json = res.body;
         const content: any[] = json.content ?? [];
 
         if (json.stop_reason === "tool_use") {
@@ -154,14 +171,14 @@ export function makeOpenAICompatBrain(cfg: OpenAICompatCfg, deps: Deps = {}): Br
         : undefined;
 
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-        const res = await doFetch(`${cfg.baseUrl}/chat/completions`, {
+        const res = await fetchJson(doFetch, `${cfg.baseUrl}/chat/completions`, {
           method: "POST",
           headers: { "content-type": "application/json", authorization: `Bearer ${cfg.apiKey}` },
           body: JSON.stringify({ model: cfg.model, messages, tools: toolPayload }),
-        } as any);
+        }, deps.timeoutMs);
         // See the Anthropic brain: a non-2xx here otherwise becomes an empty reply → blank iMessage.
         if (!(res as any).ok) return `I couldn't reach the model (HTTP ${(res as any).status}).`;
-        const json = await (res as any).json();
+        const json = res.body;
         const msg = json.choices?.[0]?.message ?? {};
 
         const toolCalls = msg.tool_calls ?? [];

--- a/tools/burrow-alerts/src/readonly-mcp.test.ts
+++ b/tools/burrow-alerts/src/readonly-mcp.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "bun:test";
+import { reply } from "./readonly-mcp.ts";
+
+test("the CLI MCP server blocks every unlisted tool even if CLI permissions allow it", async () => {
+  const calls: string[] = [];
+  const exec = async (name: string) => { calls.push(name); return "healthy"; };
+  for (const name of ["burrow_clean", "burrow_remove", "burrow_analyze", "future_mutator"]) {
+    const response = await reply({ id: 1, method: "tools/call", params: { name } }, exec);
+    expect(response).toMatchObject({ result: { isError: true } });
+  }
+  expect(calls).toEqual([]);
+  expect(await reply({ id: 2, method: "tools/call", params: { name: "burrow_snapshot" } }, exec))
+    .toMatchObject({ result: { content: [{ text: "healthy" }] } });
+  expect(calls).toEqual(["burrow_snapshot"]);
+});

--- a/tools/burrow-alerts/src/readonly-mcp.ts
+++ b/tools/burrow-alerts/src/readonly-mcp.ts
@@ -1,0 +1,51 @@
+/** CLI-side MCP boundary: only the same read-only tools exposed to API brains. */
+import { createInterface } from "node:readline";
+import { BurrowMCP } from "./burrow.ts";
+import { READONLY_TOOL_SPECS, makeBurrowExec } from "./burrow-tools.ts";
+import { installShutdown, stopChildren } from "./lifecycle.ts";
+
+type Request = { id?: string | number; method?: string; params?: { name?: string; arguments?: Record<string, unknown> } };
+export async function reply(request: Request, exec: (name: string, args: Record<string, unknown>) => Promise<string>) {
+  if (request.id === undefined) return undefined;
+  let result: object;
+  switch (request.method) {
+    case "initialize":
+      result = { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "burrow-readonly", version: "0.1.0" } };
+      break;
+    case "tools/list":
+      result = { tools: READONLY_TOOL_SPECS.map(({ name, description, schema }) => ({ name, description, inputSchema: schema })) };
+      break;
+    case "tools/call": {
+      const name = request.params?.name ?? "";
+      if (!READONLY_TOOL_SPECS.some((tool) => tool.name === name)) {
+        result = { isError: true, content: [{ type: "text", text: "Tool is not read-only or not allowed." }] };
+      } else {
+        result = { content: [{ type: "text", text: await exec(name, request.params?.arguments ?? {}) }] };
+      }
+      break;
+    }
+    case "ping": result = {}; break;
+    default: return { jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "Method not found" } };
+  }
+  return { jsonrpc: "2.0", id: request.id, result };
+}
+
+async function main() {
+  let mcp: BurrowMCP | undefined;
+  const execute = async (name: string, args: Record<string, unknown>) => {
+    mcp ??= new BurrowMCP();
+    return makeBurrowExec(mcp)(name, args);
+  };
+  installShutdown();
+  try {
+    for await (const line of createInterface({ input: process.stdin })) {
+      try {
+        const result = await reply(JSON.parse(line) as Request, execute);
+        if (result) process.stdout.write(JSON.stringify(result) + "\n");
+      } catch {
+        process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Invalid request" } }) + "\n");
+      }
+    }
+  } finally { await stopChildren(); }
+}
+if (import.meta.main) void main();

--- a/tools/burrow-alerts/src/safety.test.ts
+++ b/tools/burrow-alerts/src/safety.test.ts
@@ -1,5 +1,21 @@
 import { test, expect } from "bun:test";
-import { isAuthorized, capReply, RateLimiter } from "./safety.ts";
+import { isAuthorized, isOwnerQuestion, capReply, RateLimiter } from "./safety.ts";
+import { toE164 } from "./sender.ts";
+
+test("numeric email handles cannot impersonate the owner or turn into phone recipients", () => {
+  expect(isAuthorized("15551234567@attacker.example", "+15551234567")).toBe(false);
+  expect(isAuthorized("owner42@attacker.example", "owner42@example.com")).toBe(false);
+  expect(isAuthorized("OWNER42@EXAMPLE.COM", "owner42@example.com")).toBe(true);
+  expect(toE164("5551234567@example.com")).toBe("5551234567@example.com");
+});
+
+test("only incoming owner DMs can cause a health reply", () => {
+  const message = { direction: "inbound", sender: { id: "+15551234567" }, space: { type: "dm" }, content: { type: "text", text: "disk?" } };
+  expect(isOwnerQuestion(message, "+15551234567")).toBe(true);
+  expect(isOwnerQuestion({ ...message, direction: "outbound" }, "+15551234567")).toBe(false);
+  expect(isOwnerQuestion({ ...message, space: { type: "group" } }, "+15551234567")).toBe(false);
+  expect(isOwnerQuestion({ ...message, direction: undefined }, "+15551234567")).toBe(false);
+});
 
 test("RateLimiter allows up to max per window, blocks beyond, and recovers", () => {
   const rl = new RateLimiter(2, 1000); // 2 per 1000ms; time injected

--- a/tools/burrow-alerts/src/safety.ts
+++ b/tools/burrow-alerts/src/safety.ts
@@ -18,14 +18,37 @@ function canonPhone(d: string): string {
 
 /** True only for the configured owner. Numeric handles compare by canonical digits (formatting /
  *  +1 tolerated); email or other non-numeric handles compare case-insensitively verbatim. */
+export function isPhoneHandle(handle: string): boolean {
+  return /^\+?[\d\s().-]+$/.test(handle.trim()) && digits(handle).length > 0;
+}
+
 export function isAuthorized(senderId: string, ownerDigits: string): boolean {
   const sd = digits(senderId);
   const od = digits(ownerDigits);
-  if (sd && od) return canonPhone(sd) === canonPhone(od);
+  if (isPhoneHandle(senderId) && isPhoneHandle(ownerDigits)) return canonPhone(sd) === canonPhone(od);
   // No digits on one side ⇒ an email/handle: exact, case-insensitive match (never a suffix).
   const s = (senderId ?? "").trim().toLowerCase();
   const o = (ownerDigits ?? "").trim().toLowerCase();
   return s !== "" && s === o;
+}
+
+export type IncomingMessage = {
+  direction?: string;
+  sender?: { id?: string };
+  content?: { type?: string; text?: string };
+  space?: { id?: string; type?: string };
+};
+
+/** Mac health is private even when the owner also participates in group chats. */
+export function isOwnerQuestion(message: IncomingMessage, owner: string): boolean {
+  return message.direction === "inbound" && message.space?.type === "dm"
+    && message.content?.type === "text" && isAuthorized(message.sender?.id ?? "", owner)
+    && Boolean(message.content.text?.trim());
+}
+
+export function positiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export function capReply(s: string, max: number): string {

--- a/tools/burrow-alerts/src/sender.ts
+++ b/tools/burrow-alerts/src/sender.ts
@@ -9,6 +9,7 @@
  */
 
 import type { MiniAppInput } from "./card.ts";
+import { isPhoneHandle } from "./safety.ts";
 
 export type SendConfig = {
   recipient: string;
@@ -29,6 +30,7 @@ const dmGuid = (addr: string) => `any;-;${addr}`;
 
 export function toE164(phone: string): string {
   const raw = phone.trim();
+  if (!isPhoneHandle(raw)) return raw;
   const digits = raw.replace(/\D/g, "");
   if (raw.startsWith("+")) return `+${digits}`;
   if (digits.length === 10) return `+1${digits}`;
@@ -66,7 +68,7 @@ export async function sendText(cfg: SendConfig, body: string): Promise<void> {
  * Load the bundled Burrow bubble image (JPEG). Best-effort — a missing asset
  * just means the card ships without an image (captions/summary still render).
  */
-async function bubbleImage(): Promise<Uint8Array | undefined> {
+async function bubbleImage(): Promise<Uint8Array<ArrayBuffer> | undefined> {
   try {
     const path = new URL("../assets/burrow-card.jpg", import.meta.url);
     return await Bun.file(path).bytes();

--- a/tools/burrow-alerts/src/setup.ts
+++ b/tools/burrow-alerts/src/setup.ts
@@ -8,7 +8,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { writeFileSync, chmodSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { LLMConfig } from "./llm.ts";
@@ -45,9 +45,11 @@ export function assembleConfig(parts: SetupParts): BurrowConfig {
 
 // Photon egress is direct here; strip the shell proxy so the CLI reaches it.
 const NOPROXY = { ...process.env, HTTP_PROXY: "", HTTPS_PROXY: "", ALL_PROXY: "", http_proxy: "", https_proxy: "", all_proxy: "", NO_PROXY: "*", no_proxy: "*" };
-const photon = (args: string[]) => spawnSync("photon", args, { env: NOPROXY, encoding: "utf8" });
+const photon = (args: string[]) => spawnSync("photon", args, { env: NOPROXY, encoding: "utf8", timeout: 30_000 });
 
 function runSetup() {
+  const recipient = process.env.BURROW_ALERT_TO ?? "";
+  assembleConfig({ recipient }); // Validate before creating a remote project.
   console.log(onboardingText());
   console.log("\n──────────────────────────────────────────\n");
 
@@ -55,9 +57,9 @@ function runSetup() {
   const who = photon(["whoami"]);
   if (who.status !== 0) {
     console.log("Log in to Photon (a device code will appear — approve it in your browser):\n");
-    const login = photon(["login", "--no-browser"]);
-    process.stdout.write(login.stdout ?? "");
-    if (login.status !== 0) { console.error("Photon login failed:", login.stderr); process.exit(1); }
+    // The owner must see the device code while login is waiting for approval.
+    const login = spawnSync("photon", ["login", "--no-browser"], { env: NOPROXY, stdio: "inherit", timeout: 300_000 });
+    if (login.status !== 0) { console.error("Photon login failed"); process.exit(1); }
   }
 
   // 2) Create the project + read its secret.
@@ -67,14 +69,14 @@ function runSetup() {
   const secret = JSON.parse(photon(["projects", "secret", "--project", projectId, "--json"]).stdout).projectSecret as string;
 
   // 3) Register the owner number + surface the assigned line to text once (opt-in).
-  const recipient = process.env.BURROW_ALERT_TO ?? "";
   const user = photon(["spectrum", "users", "add", "--project", projectId, "--phone", recipient, "--first-name", "Owner", "--last-name", "Burrow", "--email", "owner@example.com", "--invite", "--json"]);
   const assigned = user.status === 0 ? JSON.parse(user.stdout).assignedPhoneNumber : "(see dashboard)";
 
   // 4) Write config (LLM stays claude-cli unless env overrides).
   const cfg = assembleConfig({ recipient, projectId, projectSecret: secret });
   const out = join(dirname(fileURLToPath(import.meta.url)), "..", "config.local.json");
-  writeFileSync(out, JSON.stringify(cfg, null, 2) + "\n");
+  writeFileSync(out, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
+  chmodSync(out, 0o600); // Existing manually-created config files may have been 0644.
 
   console.log(`\n✅ Wrote ${out}\n`);
   console.log(`One-time opt-in: from your iPhone, text anything to ${assigned}. Then:\n  bun run check.ts --test\n`);

--- a/tools/burrow-alerts/tracer.ts
+++ b/tools/burrow-alerts/tracer.ts
@@ -21,6 +21,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { readFileSync } from "node:fs";
+import { toE164 } from "./src/sender.ts";
 
 const pexec = promisify(execFile);
 
@@ -36,7 +37,7 @@ function loadConfig(): Config {
 }
 const CFG = loadConfig();
 
-const MO = "/opt/homebrew/bin/mo";
+const MO = process.env.MO_BIN || "mo";
 const THRESHOLD = Number(process.env.THRESHOLD ?? CFG.threshold ?? 90); // disk used% that fires
 const DRY_RUN = process.argv.includes("--dry-run");
 const CONNECT_TEST = process.argv.includes("--connect-test");
@@ -51,7 +52,7 @@ type Disk = { mount: string; used: number; total: number; used_percent: number }
 type AnalyzeEntry = { name: string; path: string; size: number; is_dir: boolean };
 
 async function moStatus(): Promise<{ disks: Disk[] }> {
-  const { stdout } = await pexec(MO, ["status", "--json"], { maxBuffer: 64 << 20 });
+  const { stdout } = await pexec(MO, ["status", "--json"], { maxBuffer: 64 << 20, timeout: 15_000, killSignal: "SIGKILL" });
   const j = JSON.parse(stdout);
   return j.snapshot ?? j; // MCP wraps under .snapshot; bare `mo` does not
 }
@@ -99,15 +100,6 @@ function formatAlert(root: Disk, hogs: AnalyzeEntry[]): string {
 }
 
 // ---- delivery (Photon spectrum-ts, LOCAL mode) -----------------------------
-
-function toE164(phone: string): string {
-  const raw = phone.trim();
-  const digits = raw.replace(/\D/g, "");
-  if (raw.startsWith("+")) return `+${digits}`;
-  if (digits.length === 10) return `+1${digits}`;
-  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
-  return raw; // email or already-odd handle: pass through untouched
-}
 
 // DM chat-guid spectrum-ts uses to resolve a space for a bare address
 // (packages/imessage/src/remote/ids.ts: `any;-;<addr>`). imessage-kit's
@@ -192,7 +184,7 @@ async function main() {
   console.log("[tracer] sent ✅");
 }
 
-main().catch((err) => {
+if (import.meta.main) main().catch((err) => {
   console.error("[tracer] failed:", err?.message ?? err);
   process.exit(1);
 });

--- a/tools/burrow-alerts/tsconfig.json
+++ b/tools/burrow-alerts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["bun"]
+  },
+  "include": ["*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
The review of #249 found that GUI-supplied Photon credentials selected the wrong provider, owner matching admitted unrelated handles, and the Claude path could access tools beyond Burrow's advertised read-only set. This PR targets the existing unmerged feature branch and fixes its authorization, transport, lifecycle and packaging boundaries.

- Share environment/config delivery resolution, require exact owner DMs, and isolate state outside the signed bundle.
- Put Claude behind a read-only MCP proxy, disable built-ins and ambient settings/hooks, pass the actual running app path, and bound API/process lifetimes and output.
- Handle premature MCP exits, split Unicode, tool errors and subprocess cleanup correctly; discard bursts during an active request.
- Retain and stop native check/agent children, prevent overlapping checks, recover from launch failures, schedule the promised weekly digest, and reset CPU alert episodes after recovery.
- Stage a checksum-pinned universal Bun from frozen dependencies, preserve JIT entitlements, and fail builds on missing runtime assets rather than shipping an inert sidecar.
- Stream device-login instructions, write private config, serialize launchd paths, and repair the Cards extension identifier, payload encoding and unsupported-link feedback.

Validation: **44 Bun tests / 175 expectations**, strict TypeScript checking, eight native supervisor tests, full unsigned macOS Debug app build with real sidecar staging, and full iOS Simulator host/extension build passed. Both bundled runtime architectures imported the pinned SDK; ad-hoc hardened signing retained JIT functionality. No actual messages, provider calls, login/project creation, notifications, app installation or release signing were performed. Real receiving-device behavior and Developer ID notarization remain integration checks for this draft feature.
