### PR TITLE
fix(helper): retry the daemon's account lookup and name refusals (#425)

### DIFF
--- a/macos/HelperSources/HelperService.swift
+++ b/macos/HelperSources/HelperService.swift
@@ -556,27 +556,20 @@ final class HelperService: NSObject, BurrowHelperProtocol {
     }
 
     /// Nothing running and no request between arrival and execution. The
-    /// second half matters because the identity gate can now pause for a few
+    /// second half matters because the identity gate can pause for a few
     /// seconds: a request that lands in the last seconds of the idle window
-    /// must not have the daemon exit underneath it.
-    var isIdle: Bool {
-        guard !runner.hasWork else { return false }
-        inFlightLock.lock(); defer { inFlightLock.unlock() }
-        return inFlightRequests == 0
+    /// must not have the daemon exit underneath it. This is the timer's
+    /// reading of the clock only; the decision to exit is `commitIdleExit`.
+    var isIdle: Bool { !runner.hasWork && !gate.hasRequestsInFlight }
+
+    /// Commit to exiting, or refuse because something arrived. Decided under
+    /// the same lock `execute` admits requests with, so nothing can be
+    /// admitted between a true answer and the `exit` that follows it.
+    func commitIdleExit() -> Bool {
+        gate.closeIfIdle(stillBusy: { runner.hasWork })
     }
 
-    private let inFlightLock = NSLock()
-    private var inFlightRequests = 0
-
-    private func requestBegan() {
-        inFlightLock.lock(); defer { inFlightLock.unlock() }
-        inFlightRequests += 1
-    }
-
-    private func requestEnded() {
-        inFlightLock.lock(); defer { inFlightLock.unlock() }
-        inFlightRequests -= 1
-    }
+    private let gate = HelperAdmissionGate()
 
     /// Every network interface that actually exists on this machine.
     ///
@@ -626,8 +619,17 @@ final class HelperService: NSObject, BurrowHelperProtocol {
     }
 
     func execute(requestData: Data, authorization: Data, withReply reply: @escaping (Data) -> Void) {
-        requestBegan()
-        defer { requestEnded() }
+        guard gate.admit() else {
+            // The idle timer committed to exit under this same lock a moment
+            // ago, so this process is going away and must not start an
+            // identity lookup it cannot finish. No reply: the client's
+            // connection-error handler reports it exactly as a daemon that
+            // had already exited would, and launchd starts a fresh one on the
+            // next connection.
+            helperTrace("request refused: daemon is exiting")
+            return
+        }
+        defer { gate.release() }
 
         func respond(_ outcome: HelperResponse.Outcome) {
             let encoded = (try? JSONEncoder().encode(HelperResponse(outcome: outcome))) ?? Data()

--- a/macos/HelperSources/HelperService.swift
+++ b/macos/HelperSources/HelperService.swift
@@ -102,6 +102,27 @@ enum HelperDaemonIdentityResolver {
     }
 
     private static func account(for uid: uid_t) throws -> HelperInvokingUserAccount {
+        // An empty answer is not yet a fact on a fresh process — see
+        // `HelperAccountLookupRetry` for why libinfo's "no such user" also
+        // covers "the directory did not answer" — so it is asked again.
+        let found = HelperAccountLookupRetry.lookup(
+            sleep: { Thread.sleep(forTimeInterval: $0) },
+            attempt: { record(for: uid) })
+        guard let found else {
+            helperTrace("account lookup for uid \(uid) returned no record after \(HelperAccountLookupRetry.delays.count + 1) attempts")
+            throw HelperInvokingUserResolutionError.missingAccount
+        }
+        if found.attempts > 1 {
+            // Worth a line even though the request goes on: this is the race
+            // being absorbed, and the count says how close it came to refusal.
+            helperTrace("account lookup for uid \(uid) succeeded on attempt \(found.attempts)")
+        }
+        return found.account
+    }
+
+    /// One `getpwuid_r` call. nil means the call produced no record, whatever
+    /// the reason; the caller decides whether to ask again.
+    private static func record(for uid: uid_t) -> HelperInvokingUserAccount? {
         var record = passwd()
         var result: UnsafeMutablePointer<passwd>?
         let configured = sysconf(_SC_GETPW_R_SIZE_MAX)
@@ -112,7 +133,7 @@ enum HelperDaemonIdentityResolver {
         }
         guard status == 0, result != nil,
               let name = record.pw_name, let home = record.pw_dir else {
-            throw HelperInvokingUserResolutionError.missingAccount
+            return nil
         }
         return HelperInvokingUserAccount(uid: UInt32(record.pw_uid),
                                          username: String(cString: name),
@@ -534,7 +555,28 @@ final class HelperService: NSObject, BurrowHelperProtocol {
         super.init()
     }
 
-    var isIdle: Bool { !runner.hasWork }
+    /// Nothing running and no request between arrival and execution. The
+    /// second half matters because the identity gate can now pause for a few
+    /// seconds: a request that lands in the last seconds of the idle window
+    /// must not have the daemon exit underneath it.
+    var isIdle: Bool {
+        guard !runner.hasWork else { return false }
+        inFlightLock.lock(); defer { inFlightLock.unlock() }
+        return inFlightRequests == 0
+    }
+
+    private let inFlightLock = NSLock()
+    private var inFlightRequests = 0
+
+    private func requestBegan() {
+        inFlightLock.lock(); defer { inFlightLock.unlock() }
+        inFlightRequests += 1
+    }
+
+    private func requestEnded() {
+        inFlightLock.lock(); defer { inFlightLock.unlock() }
+        inFlightRequests -= 1
+    }
 
     /// Every network interface that actually exists on this machine.
     ///
@@ -584,6 +626,9 @@ final class HelperService: NSObject, BurrowHelperProtocol {
     }
 
     func execute(requestData: Data, authorization: Data, withReply reply: @escaping (Data) -> Void) {
+        requestBegan()
+        defer { requestEnded() }
+
         func respond(_ outcome: HelperResponse.Outcome) {
             let encoded = (try? JSONEncoder().encode(HelperResponse(outcome: outcome))) ?? Data()
             reply(encoded)
@@ -626,9 +671,14 @@ final class HelperService: NSObject, BurrowHelperProtocol {
                 peerUID: connection.effectiveUserIdentifier,
                 claim: request.invokingUser)
         } catch {
-            // Numeric uid is useful for auditing account-switch/mismatch
+            // Name the check that failed. It is a closed enum, so it is safe
+            // in a world-readable log, and it is the one fact that tells a
+            // directory hiccup apart from a real mismatch — the report behind
+            // issue #425 had to reason by elimination because this line did
+            // not say. The numeric uid is useful for auditing account-switch
             // failures. Never log the account name, home, or claim text.
-            helperTrace("request refused: invoking identity mismatch for uid \(connection.effectiveUserIdentifier)")
+            let check = (error as? HelperInvokingUserResolutionError).map { "\($0)" } ?? "unknown"
+            helperTrace("request refused: invoking identity mismatch (\(check)) for uid \(connection.effectiveUserIdentifier)")
             return respond(.rejected(.invalidInvokingUser))
         }
         helperTrace("invoking identity accepted for uid \(invokingUser.uid); canonical home matched")

--- a/macos/HelperSources/main.swift
+++ b/macos/HelperSources/main.swift
@@ -76,14 +76,15 @@ enum HelperMain {
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
         timer.schedule(deadline: .now() + 10, repeating: 10)
         timer.setEventHandler {
-            if service.isIdle {
-                if Date().timeIntervalSince(idleSince) >= idleTimeout {
-                    helperTrace("idle timeout reached; exiting")
-                    exit(0)
-                }
-            } else {
-                idleSince = Date()
-            }
+            guard service.isIdle else { idleSince = Date(); return }
+            guard Date().timeIntervalSince(idleSince) >= idleTimeout else { return }
+            // The decision and the exit are one step: `commitIdleExit`
+            // closes the admission gate under the lock `execute` admits
+            // with, so a request cannot slip in between the two. A request
+            // that beat it means the daemon is not idle after all.
+            guard service.commitIdleExit() else { idleSince = Date(); return }
+            helperTrace("idle timeout reached; exiting")
+            exit(0)
         }
         timer.resume()
 

--- a/macos/Resources/de.lproj/Localizable.strings
+++ b/macos/Resources/de.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "Extragroß";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Skaliert Text und Symbole in der gesamten App und im Menüleisten-Popup – ohne Neustart. Das Menüleisten-Element selbst behält seine eigene Textgröße, die pro Widget unter „Menüleiste“ eingestellt wird.";
 "Release Notes" = "Versionshinweise";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "Das privilegierte Hilfsprogramm konnte nicht bestätigen, welches Konto dies angefordert hat, deshalb wurde nichts ausgeführt. Versuche es erneut.";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "Das privilegierte Hilfsprogramm stammt aus einer anderen Burrow-Version, deshalb wurde nichts ausgeführt. Installiere es unter „Einstellungen ▸ Erweitert“ neu.";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "Das privilegierte Hilfsprogramm hat eines der geprüften Elemente abgelehnt, deshalb wurde nichts bereinigt. Scanne erneut, bevor du es noch einmal versuchst.";
+"The privileged helper did not recognize the network interface, so nothing ran." = "Das privilegierte Hilfsprogramm hat die Netzwerkschnittstelle nicht erkannt, deshalb wurde nichts ausgeführt.";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "Das privilegierte Hilfsprogramm hat die Anfrage als fehlerhaft abgelehnt, deshalb wurde nichts ausgeführt. Versuche es erneut.";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "Nichts ausgeführt: Das privilegierte Hilfsprogramm hat die Anfrage abgelehnt. Das Ausführungsprotokoll nennt den Grund.";

--- a/macos/Resources/es.lproj/Localizable.strings
+++ b/macos/Resources/es.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "Extragrande";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Escala el texto y los iconos en toda la app y en el panel de la barra de menús, sin necesidad de reiniciar. El elemento de la barra de menús conserva su propio tamaño de texto, configurado por widget en «Barra de menús».";
 "Release Notes" = "Notas de la versión";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "El asistente con privilegios no pudo confirmar qué cuenta hizo la petición, así que no se ejecutó nada. Inténtalo de nuevo.";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "El asistente con privilegios es de otra versión de Burrow, así que no se ejecutó nada. Reinstálalo desde Ajustes ▸ Avanzado.";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "El asistente con privilegios rechazó uno de los elementos revisados, así que no se limpió nada. Vuelve a analizar antes de intentarlo de nuevo.";
+"The privileged helper did not recognize the network interface, so nothing ran." = "El asistente con privilegios no reconoció la interfaz de red, así que no se ejecutó nada.";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "El asistente con privilegios rechazó la petición por estar mal formada, así que no se ejecutó nada. Inténtalo de nuevo.";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "No se ejecutó nada: el asistente con privilegios rechazó la petición. El registro de la ejecución indica el motivo.";

--- a/macos/Resources/fr.lproj/Localizable.strings
+++ b/macos/Resources/fr.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "Très grande";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Met à l'échelle le texte et les icônes dans toute l'app et dans le panneau de la barre des menus — sans relancer. L'élément de la barre des menus conserve sa propre taille de texte, réglée par widget dans « Barre des menus ».";
 "Release Notes" = "Notes de version";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "L'assistant privilégié n'a pas pu confirmer quel compte a fait la demande ; rien n'a été exécuté. Réessaie.";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "L'assistant privilégié provient d'une autre version de Burrow ; rien n'a été exécuté. Réinstalle-le depuis Réglages ▸ Avancé.";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "L'assistant privilégié a refusé l'un des éléments vérifiés ; rien n'a été nettoyé. Relance l'analyse avant de réessayer.";
+"The privileged helper did not recognize the network interface, so nothing ran." = "L'assistant privilégié n'a pas reconnu l'interface réseau ; rien n'a été exécuté.";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "L'assistant privilégié a refusé la demande, jugée mal formée ; rien n'a été exécuté. Réessaie.";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "Rien n'a été exécuté : l'assistant privilégié a refusé la demande. Le journal d'exécution en indique la raison.";

--- a/macos/Resources/ja.lproj/Localizable.strings
+++ b/macos/Resources/ja.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "特大";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "アプリ全体とメニューバーのポップアップの文字とアイコンを拡大縮小します。再起動は不要です。メニューバー項目自体の文字サイズは「メニューバー」でウィジェットごとに個別に設定します。";
 "Release Notes" = "リリースノート";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "特権ヘルパーがどのアカウントからの要求か確認できなかったため、何も実行していません。もう一度お試しください。";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "特権ヘルパーが別のバージョンの Burrow のものであるため、何も実行していません。「設定 ▸ 詳細」から再インストールしてください。";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "特権ヘルパーが確認済み項目の 1 つを拒否したため、何もクリーンしていません。再スキャンしてからやり直してください。";
+"The privileged helper did not recognize the network interface, so nothing ran." = "特権ヘルパーがネットワークインターフェイスを認識できなかったため、何も実行していません。";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "特権ヘルパーが要求を不正な形式として拒否したため、何も実行していません。もう一度お試しください。";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "何も実行していません: 特権ヘルパーが要求を拒否しました。理由は実行ログに記録されています。";

--- a/macos/Resources/ko.lproj/Localizable.strings
+++ b/macos/Resources/ko.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "아주 크게";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "앱 전체와 메뉴 막대 팝업의 텍스트와 아이콘 크기를 조절합니다. 재실행이 필요 없습니다. 메뉴 막대 항목 자체의 텍스트 크기는 '메뉴 막대'에서 위젯별로 따로 설정합니다.";
 "Release Notes" = "릴리스 노트";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "권한 있는 도우미가 어느 계정의 요청인지 확인하지 못해 아무것도 실행하지 않았습니다. 다시 시도하세요.";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "권한 있는 도우미가 다른 버전의 Burrow에서 설치된 것이어서 아무것도 실행하지 않았습니다. '설정 ▸ 고급'에서 다시 설치하세요.";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "권한 있는 도우미가 검토한 항목 중 하나를 거부해 아무것도 정리하지 않았습니다. 다시 검사한 뒤 시도하세요.";
+"The privileged helper did not recognize the network interface, so nothing ran." = "권한 있는 도우미가 네트워크 인터페이스를 인식하지 못해 아무것도 실행하지 않았습니다.";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "권한 있는 도우미가 요청 형식이 잘못되었다고 거부해 아무것도 실행하지 않았습니다. 다시 시도하세요.";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "아무것도 실행하지 않았습니다: 권한 있는 도우미가 요청을 거부했습니다. 이유는 실행 로그에 있습니다.";

--- a/macos/Resources/pt-BR.lproj/Localizable.strings
+++ b/macos/Resources/pt-BR.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "Extragrande";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Ajusta o texto e os ícones em todo o app e no painel da barra de menus — sem precisar reiniciar. O item da barra de menus mantém seu próprio tamanho de texto, definido por widget em “Barra de menus”.";
 "Release Notes" = "Notas de versão";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "O auxiliar com privilégios não conseguiu confirmar qual conta fez o pedido, então nada foi executado. Tente de novo.";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "O auxiliar com privilégios é de outra versão do Burrow, então nada foi executado. Reinstale-o em Ajustes ▸ Avançado.";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "O auxiliar com privilégios recusou um dos itens revisados, então nada foi limpo. Verifique de novo antes de tentar outra vez.";
+"The privileged helper did not recognize the network interface, so nothing ran." = "O auxiliar com privilégios não reconheceu a interface de rede, então nada foi executado.";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "O auxiliar com privilégios recusou o pedido por estar malformado, então nada foi executado. Tente de novo.";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "Nada foi executado: o auxiliar com privilégios recusou o pedido. O registro da execução explica o motivo.";

--- a/macos/Resources/ru.lproj/Localizable.strings
+++ b/macos/Resources/ru.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "Очень крупный";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Масштабирует текст и значки во всём приложении и во всплывающем окне строки меню — без перезапуска. Размер текста самого элемента строки меню настраивается отдельно для каждого виджета в разделе «Строка меню».";
 "Release Notes" = "Примечания к выпуску";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "Привилегированный вспомогательный компонент не смог подтвердить, от какой учётной записи поступил запрос, поэтому ничего не было выполнено. Попробуйте ещё раз.";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "Привилегированный вспомогательный компонент относится к другой версии Burrow, поэтому ничего не было выполнено. Переустановите его в разделе «Настройки ▸ Дополнительно».";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "Привилегированный вспомогательный компонент отклонил один из проверенных элементов, поэтому ничего не было очищено. Пересканируйте, прежде чем повторить попытку.";
+"The privileged helper did not recognize the network interface, so nothing ran." = "Привилегированный вспомогательный компонент не распознал сетевой интерфейс, поэтому ничего не было выполнено.";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "Привилегированный вспомогательный компонент отклонил запрос как некорректный, поэтому ничего не было выполнено. Попробуйте ещё раз.";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "Ничего не выполнено: привилегированный вспомогательный компонент отклонил запрос. Причина указана в журнале выполнения.";

--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -879,3 +879,11 @@
 "Extra Large" = "特大";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "缩放整个应用与菜单栏弹窗中的文字和图标，无需重新启动。菜单栏项目自身的文字大小仍在“菜单栏”设置中按组件单独调整。";
 "Release Notes" = "发行说明";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "特权辅助程序无法确认是哪个账户发出的请求，因此没有执行任何操作。请重试。";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "特权辅助程序来自另一个 Burrow 版本，因此没有执行任何操作。请在“设置 ▸ 高级”中重新安装。";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "特权辅助程序拒绝了其中一个已审核项目，因此什么都没有清理。请重新扫描后再试。";
+"The privileged helper did not recognize the network interface, so nothing ran." = "特权辅助程序无法识别该网络接口，因此没有执行任何操作。";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "特权辅助程序认为请求格式无效并已拒绝，因此没有执行任何操作。请重试。";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "未执行任何操作：特权辅助程序拒绝了请求。运行日志中说明了原因。";

--- a/macos/Resources/zh-Hant.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hant.lproj/Localizable.strings
@@ -864,3 +864,11 @@
 "Extra Large" = "特大";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "縮放整個應用程式與選單列彈出視窗中的文字和圖示，無需重新啟動。選單列項目本身的文字大小仍在「選單列」設定中按元件單獨調整。";
 "Release Notes" = "版本說明";
+
+/* Privileged helper refusals (#425) */
+"The privileged helper could not confirm which account asked for this, so nothing ran. Try again." = "特權輔助程式無法確認是哪個帳號發出的請求，因此沒有執行任何操作。請再試一次。";
+"The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced." = "特權輔助程式來自另一個 Burrow 版本，因此沒有執行任何操作。請在「設定 ▸ 進階」中重新安裝。";
+"The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again." = "特權輔助程式拒絕了其中一個已審核項目，因此什麼都沒有清理。請重新掃描後再試。";
+"The privileged helper did not recognize the network interface, so nothing ran." = "特權輔助程式無法辨識該網路介面，因此沒有執行任何操作。";
+"The privileged helper refused the request as malformed, so nothing ran. Try again." = "特權輔助程式認為請求格式無效並已拒絕，因此沒有執行任何操作。請再試一次。";
+"Nothing ran: the privileged helper refused the request. The run log says why." = "未執行任何操作：特權輔助程式拒絕了請求。執行記錄中說明了原因。";

--- a/macos/Sources/Connectivity.swift
+++ b/macos/Sources/Connectivity.swift
@@ -263,6 +263,7 @@ enum Connectivity {
         switch outcome {
         case .exited(0):     return (true, ok)
         case .authCancelled: return (false, NSLocalizedString("Cancelled.", comment: ""))
+        case .refused(let reason): return (false, reason.userExplanation)
         default:             return (false, fail)
         }
     }

--- a/macos/Sources/OperationFlow.swift
+++ b/macos/Sources/OperationFlow.swift
@@ -52,6 +52,11 @@ protocol ProcessPort: Sendable {
 enum FeatureOperationFailureCategory: String, Equatable {
     case boundaryChanged = "boundary_changed"
     case privilegedLaunchRefused = "privileged_launch_refused"
+    /// The helper daemon refused the request before authorization. Its own
+    /// category because a run of these is a helper problem, not an engine or
+    /// launch one — the failure rate issue #425 describes would have shown up
+    /// here.
+    case privilegedRequestRefused = "privileged_request_refused"
     case engineNonzero = "engine_nonzero"
 }
 
@@ -69,6 +74,8 @@ enum FeatureOperationFailurePolicy {
              ElevatedExitCode.executableRefused,
              ElevatedExitCode.launchFailed:
             return .privilegedLaunchRefused
+        case ElevatedExitCode.requestRefused:
+            return .privilegedRequestRefused
         default:
             return .engineNonzero
         }
@@ -453,6 +460,13 @@ final class OperationFlow<Report: Sendable>: ObservableObject {
              ElevatedExitCode.launchFailed:
             return NSLocalizedString(
                 "Nothing ran: Burrow could not verify the program it was about to run as an administrator.",
+                comment: "")
+        case ElevatedExitCode.requestRefused:
+            // The helper named its reason and the transcript carries it
+            // (`HelperRequestRejection.userExplanation`); this line points
+            // there rather than guessing.
+            return NSLocalizedString(
+                "Nothing ran: the privileged helper refused the request. The run log says why.",
                 comment: "")
         default:
             return isCleanup

--- a/macos/Sources/PrivilegeBroker.swift
+++ b/macos/Sources/PrivilegeBroker.swift
@@ -41,6 +41,12 @@ enum ElevatedOutcome: Equatable {
     /// The osascript spawn itself failed to launch (no usable `mo`, Process
     /// threw). Distinct from a command that ran and failed.
     case launchFailed
+    /// The privileged helper refused the request before authorization, and
+    /// named why. Only the helper route produces this — osascript has no
+    /// request to refuse — but it lives in the shared taxonomy so the GUI
+    /// renders a refusal as a refusal instead of folding it into
+    /// `launchFailed` and blaming program verification (issue #425).
+    case refused(HelperRequestRejection)
 }
 
 extension ElevatedOutcome {
@@ -52,6 +58,7 @@ extension ElevatedOutcome {
         case .exited(let code): return code
         case .authCancelled: return 1
         case .launchFailed: return 127
+        case .refused: return ElevatedExitCode.requestRefused
         }
     }
 }
@@ -186,7 +193,8 @@ enum ElevatedEngineRun {
                     // launch-refused exit; surface it as the failure rather than as engine output.
                     if code == ElevatedExitCode.executableRefused
                         || code == ElevatedExitCode.logSinkUnavailable
-                        || code == ElevatedExitCode.launchFailed {
+                        || code == ElevatedExitCode.launchFailed
+                        || code == ElevatedExitCode.requestRefused {
                         outcome = .launchFailed(reason: transcript)
                     } else {
                         outcome = .captured(Captured(stdout: transcript, stderr: "", exitCode: code))

--- a/macos/Sources/PrivilegedHelper/ElevatedExitCode.swift
+++ b/macos/Sources/PrivilegedHelper/ElevatedExitCode.swift
@@ -12,4 +12,10 @@ enum ElevatedExitCode {
     static let executableRefused: Int32 = 126
     /// The elevated process could not be spawned at all.
     static let launchFailed: Int32 = 127
+    /// The privileged helper refused the request before authorization, for a
+    /// reason it named (`HelperRequestRejection`).  Nothing ran.  EX_CONFIG,
+    /// the value `HelperResponse.Outcome.exitCode` already reserves for a
+    /// rejection, and deliberately not 127: a refused request is not a
+    /// program that failed verification, and the two must not share wording.
+    static let requestRefused: Int32 = 78
 }

--- a/macos/Sources/PrivilegedHelper/HelperContract.swift
+++ b/macos/Sources/PrivilegedHelper/HelperContract.swift
@@ -405,6 +405,50 @@ enum HelperInvokingUserResolver {
     }
 }
 
+// MARK: - Account lookup retry
+
+/// How the daemon repeats its own `getpwuid_r` call when it comes back empty.
+///
+/// libinfo answers "no such user" for two different situations: the uid has
+/// no record, and opendirectoryd did not answer. Its `ds` module gives up
+/// after two XPC attempts and returns NULL for any transport error other than
+/// a closed pipe, and `getpwuid_r` then reports success with no record — the
+/// same shape as a genuinely unknown uid. A freshly spawned root daemon whose
+/// first act is that lookup hits the second situation often enough that the
+/// first request of every helper session was refused as an identity mismatch
+/// while the retry seconds later sailed through (issue #425).
+///
+/// So an empty answer is retried, briefly and a bounded number of times. That
+/// relaxes nothing: every attempt asks the same authoritative source, and the
+/// record it returns still has to pass every check in
+/// `HelperInvokingUserResolver`. A uid that truly has no account costs the
+/// whole schedule and is then refused exactly as before.
+enum HelperAccountLookupRetry {
+    /// The pause before each retry, in seconds; the first attempt is
+    /// immediate. Sub-second at first because the race is over as soon as
+    /// opendirectoryd answers, growing so a slow directory still gets a fair
+    /// chance — just under four seconds in all, which is the longest a client
+    /// can be held for a uid that does not exist.
+    static let delays: [TimeInterval] = [0.1, 0.25, 0.5, 1.0, 2.0]
+
+    /// Calls `attempt` until it returns a record, pausing per `delays` between
+    /// calls. `sleep` is injected so the schedule is testable without waiting
+    /// for it. Returns the record and the attempt that produced it; nil once
+    /// the schedule is exhausted.
+    static func lookup<Account>(delays: [TimeInterval] = delays,
+                                sleep: (TimeInterval) -> Void,
+                                attempt: () -> Account?) -> (account: Account, attempts: Int)? {
+        var pending = delays[...]
+        var attempts = 0
+        while true {
+            attempts += 1
+            if let account = attempt() { return (account, attempts) }
+            guard let delay = pending.popFirst() else { return nil }
+            sleep(delay)
+        }
+    }
+}
+
 // MARK: - Reviewed cleanup targets
 
 /// The original review identities survive the authentication dialog and the XPC boundary.
@@ -522,7 +566,7 @@ enum HelperReviewedPathPolicy {
 /// Why a request never reached the authorization step. Named so the GUI can
 /// explain the refusal instead of showing a bare failure, and so a rejection
 /// is never confused with "the command ran and failed".
-enum HelperRequestRejection: String, Codable, Equatable, Sendable {
+enum HelperRequestRejection: String, Codable, Equatable, Sendable, CaseIterable {
     /// The payload wasn't decodable as a request at all.
     case malformedPayload
     /// The operation ID wasn't a UUID (see `HelperRequest.operationID`).

--- a/macos/Sources/PrivilegedHelper/HelperContract.swift
+++ b/macos/Sources/PrivilegedHelper/HelperContract.swift
@@ -449,6 +449,55 @@ enum HelperAccountLookupRetry {
     }
 }
 
+// MARK: - Admission versus idle exit
+
+/// The one boundary between "may this request start" and "may the daemon
+/// exit".
+///
+/// The idle timer used to read a busy flag and then call `exit`, and a
+/// request could be admitted in the gap between the two — a root process
+/// dying with a request in its identity gate. Checking the flag under one
+/// lock and exiting under another is the same gap with extra steps, so both
+/// decisions are made here, under the same lock: once `closeIfIdle` has
+/// returned true no later `admit` succeeds, and while anything is admitted
+/// `closeIfIdle` returns false.
+final class HelperAdmissionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var inFlight = 0
+    private var closed = false
+
+    /// Admit a request. False once shutdown has committed: the process is
+    /// about to exit and must not start work it cannot finish.
+    func admit() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard !closed else { return false }
+        inFlight += 1
+        return true
+    }
+
+    /// The request admitted earlier has finished, however it finished.
+    func release() {
+        lock.lock(); defer { lock.unlock() }
+        inFlight -= 1
+    }
+
+    var hasRequestsInFlight: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return inFlight > 0
+    }
+
+    /// Commit to shutdown if nothing is admitted and `stillBusy` says no,
+    /// both judged under the lock `admit` takes. Once this returns true the
+    /// gate stays closed: the caller is expected to exit, and nothing that
+    /// arrives afterwards can start.
+    func closeIfIdle(stillBusy: () -> Bool = { false }) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard inFlight == 0, !stillBusy() else { return false }
+        closed = true
+        return true
+    }
+}
+
 // MARK: - Reviewed cleanup targets
 
 /// The original review identities survive the authentication dialog and the XPC boundary.

--- a/macos/Sources/PrivilegedHelperClient.swift
+++ b/macos/Sources/PrivilegedHelperClient.swift
@@ -50,11 +50,48 @@ extension HelperResponse.Outcome {
     ///
     /// `authorizationDenied` folds into `.authCancelled` because from the
     /// user's side both mean "you weren't authenticated, so nothing ran".
+    ///
+    /// A rejection keeps its reason. Folding it into `.launchFailed` made
+    /// every refusal — a build mismatch, a stale reviewed list, an identity
+    /// check that failed — read as "Burrow could not verify the program",
+    /// which was never what had happened.
     var elevatedOutcome: ElevatedOutcome {
         switch self {
         case .exited(let code): return .exited(code)
         case .authorizationCancelled, .authorizationDenied: return .authCancelled
-        case .rejected, .engineUnavailable: return .launchFailed
+        case .rejected(let reason): return .refused(reason)
+        case .engineUnavailable: return .launchFailed
+        }
+    }
+}
+
+extension HelperRequestRejection {
+    /// One sentence for the run log. The daemon names the check that refused
+    /// the request; this turns that name into something a person can act on.
+    /// Every sentence says that nothing ran, because a refusal happens before
+    /// authorization, let alone execution.
+    var userExplanation: String {
+        switch self {
+        case .invalidInvokingUser:
+            return NSLocalizedString(
+                "The privileged helper could not confirm which account asked for this, so nothing ran. Try again.",
+                comment: "")
+        case .buildMismatch:
+            return NSLocalizedString(
+                "The privileged helper is from a different Burrow version, so nothing ran. Reinstall it from Settings ▸ Advanced.",
+                comment: "")
+        case .invalidReviewedPaths:
+            return NSLocalizedString(
+                "The privileged helper refused one of the reviewed items, so nothing was cleaned. Rescan before trying again.",
+                comment: "")
+        case .invalidInterface:
+            return NSLocalizedString(
+                "The privileged helper did not recognize the network interface, so nothing ran.",
+                comment: "")
+        case .malformedPayload, .malformedOperationID, .replayedOperationID:
+            return NSLocalizedString(
+                "The privileged helper refused the request as malformed, so nothing ran. Try again.",
+                comment: "")
         }
     }
 }
@@ -352,6 +389,12 @@ final class PrivilegedHelperClient: @unchecked Sendable {
         (proxy as? BurrowHelperProtocol)?.execute(requestData: payload,
                                                   authorization: authorization) { data in
             if let response = try? JSONDecoder().decode(HelperResponse.self, from: data) {
+                if case .rejected(let reason) = response.outcome {
+                    // The daemon writes its own trail to /Library/Logs; this
+                    // puts the reason in the app's log beside the routing
+                    // lines, so one `log show` tells the whole story.
+                    helperClientLog.notice("daemon refused the request: \(reason.rawValue, privacy: .public)")
+                }
                 outcome = response.outcome.elevatedOutcome
             }
             semaphore.signal()
@@ -450,6 +493,14 @@ struct HelperAwareProcessPort: ProcessPort {
                         continuation.yield(.exited(code))
                     case .authCancelled:
                         continuation.yield(.authCancelled)
+                    case .refused(let reason):
+                        // The daemon named the check that refused the request.
+                        // Put the reason in the transcript — the same empty-
+                        // transcript hazard as `.launchFailed` below — and
+                        // exit with the code the flow renders as a refusal,
+                        // not as a program that failed verification.
+                        continuation.yield(.line(reason.userExplanation))
+                        continuation.yield(.exited(ElevatedExitCode.requestRefused))
                     case .launchFailed:
                         // Nothing ran. The report parser reduces an EMPTY
                         // transcript to a cheerful "Done — caches cleared",

--- a/macos/Tests/ElevatedEngineRunTests.swift
+++ b/macos/Tests/ElevatedEngineRunTests.swift
@@ -45,6 +45,14 @@ final class ElevatedEngineRunTests: XCTestCase {
         XCTAssertEqual(outcome, .launchFailed(reason: "executable failed the bundle seal check"))
     }
 
+    func testCollect_aHelperRefusalIsALaunchFailureWithTheDaemonsReason() {
+        // The helper route explains a refused request the same way — reason
+        // lines, then its own sentinel exit — and it too never ran the engine.
+        let reason = HelperRequestRejection.buildMismatch.userExplanation
+        let outcome = ElevatedEngineRun.collect(stream([.line(reason), .exited(ElevatedExitCode.requestRefused)]))
+        XCTAssertEqual(outcome, .launchFailed(reason: reason))
+    }
+
     func testCollect_aStreamThatEndsWithoutAnExit_isALaunchFailure() {
         guard case .launchFailed = ElevatedEngineRun.collect(stream([.line("half")])) else {
             return XCTFail("no exit status must never read as a run that happened")

--- a/macos/Tests/HelperContractTests.swift
+++ b/macos/Tests/HelperContractTests.swift
@@ -206,6 +206,53 @@ final class HelperContractTests: XCTestCase {
                        "back off, never in")
     }
 
+    // MARK: - Admission versus idle exit
+
+    func testAdmissionGate_refusesToCloseWhileARequestIsInFlight() {
+        let gate = HelperAdmissionGate()
+        XCTAssertTrue(gate.admit())
+        XCTAssertTrue(gate.hasRequestsInFlight)
+        XCTAssertFalse(gate.closeIfIdle(), "a daemon with a request in its gate is not idle")
+        gate.release()
+        XCTAssertFalse(gate.hasRequestsInFlight)
+        XCTAssertTrue(gate.closeIfIdle())
+    }
+
+    func testAdmissionGate_onceClosedAdmitsNothing() {
+        let gate = HelperAdmissionGate()
+        XCTAssertTrue(gate.closeIfIdle())
+        XCTAssertFalse(gate.admit(), "a request arriving after the exit decision must not start")
+        XCTAssertFalse(gate.hasRequestsInFlight)
+    }
+
+    func testAdmissionGate_deferToTheRunnersOwnNotionOfBusy() {
+        let gate = HelperAdmissionGate()
+        XCTAssertFalse(gate.closeIfIdle(stillBusy: { true }))
+        XCTAssertTrue(gate.admit(), "a refused close leaves the gate open")
+    }
+
+    /// The race the gate exists for: a request and the idle-exit decision
+    /// arrive at the same instant. Exactly one of them may win — never both
+    /// (a request admitted into a process that has committed to exit) and
+    /// never neither (a refused request in a process that then stays up).
+    func testAdmissionGate_admissionAndExitDecisionCannotBothWin() {
+        for _ in 0..<500 {
+            let gate = HelperAdmissionGate()
+            let admitted = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
+            let closed = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
+            defer { admitted.deallocate(); closed.deallocate() }
+            DispatchQueue.concurrentPerform(iterations: 2) { index in
+                if index == 0 {
+                    admitted.pointee = gate.admit()
+                } else {
+                    closed.pointee = gate.closeIfIdle()
+                }
+            }
+            XCTAssertNotEqual(admitted.pointee, closed.pointee,
+                              "admitted=\(admitted.pointee) closed=\(closed.pointee)")
+        }
+    }
+
     // MARK: - The closed operation set
     //
     // The approved scope is exactly: privileged scan, clean, optimize, the

--- a/macos/Tests/HelperContractTests.swift
+++ b/macos/Tests/HelperContractTests.swift
@@ -158,6 +158,54 @@ final class HelperContractTests: XCTestCase {
             }
     }
 
+    // MARK: - Account lookup retry (issue #425)
+    //
+    // libinfo reports "opendirectoryd did not answer" exactly like "no such
+    // uid", and a freshly spawned daemon hits the former on its very first
+    // lookup. The daemon therefore asks again on an empty answer — briefly,
+    // a bounded number of times, and without weakening any check.
+
+    func testAccountLookupRetry_aFirstHitCostsNoWaiting() {
+        var slept: [TimeInterval] = []
+        let found = HelperAccountLookupRetry.lookup(sleep: { slept.append($0) }) { "record" }
+        XCTAssertEqual(found?.account, "record")
+        XCTAssertEqual(found?.attempts, 1)
+        XCTAssertEqual(slept, [], "the common case must not pay for the rare one")
+    }
+
+    func testAccountLookupRetry_absorbsAnEmptyAnswerAndReportsTheAttempt() {
+        var slept: [TimeInterval] = []
+        var answers: [String?] = [nil, nil, "record"]
+        let found = HelperAccountLookupRetry.lookup(sleep: { slept.append($0) }) { answers.removeFirst() }
+        XCTAssertEqual(found?.account, "record")
+        XCTAssertEqual(found?.attempts, 3, "the count is what the daemon logs, so it must be the real one")
+        XCTAssertEqual(slept, Array(HelperAccountLookupRetry.delays.prefix(2)),
+                       "one pause per miss, in schedule order")
+    }
+
+    func testAccountLookupRetry_givesUpAfterTheScheduleAndNotBefore() {
+        var slept: [TimeInterval] = []
+        var calls = 0
+        let found: (account: String, attempts: Int)? =
+            HelperAccountLookupRetry.lookup(sleep: { slept.append($0) }) { calls += 1; return nil }
+        XCTAssertNil(found, "a uid with no record is still refused")
+        XCTAssertEqual(calls, HelperAccountLookupRetry.delays.count + 1,
+                       "every scheduled retry is used before the daemon refuses")
+        XCTAssertEqual(slept, HelperAccountLookupRetry.delays)
+    }
+
+    func testAccountLookupRetry_scheduleIsShortEnoughToHoldAClientFor() {
+        // The client blocks on the XPC reply for the whole schedule when the
+        // uid genuinely has no account. Seconds, not the half-minute a
+        // 1/2/4/8/16 backoff would cost, and never a first pause that makes
+        // the healthy race wait longer than it needs to.
+        let total = HelperAccountLookupRetry.delays.reduce(0, +)
+        XCTAssertLessThan(total, 5)
+        XCTAssertLessThanOrEqual(HelperAccountLookupRetry.delays.first ?? 1, 0.25)
+        XCTAssertEqual(HelperAccountLookupRetry.delays, HelperAccountLookupRetry.delays.sorted(),
+                       "back off, never in")
+    }
+
     // MARK: - The closed operation set
     //
     // The approved scope is exactly: privileged scan, clean, optimize, the
@@ -540,6 +588,31 @@ final class HelperContractTests: XCTestCase {
         XCTAssertEqual(HelperResponse.Outcome.authorizationCancelled.elevatedOutcome, .authCancelled)
         XCTAssertEqual(HelperResponse.Outcome.engineUnavailable.elevatedOutcome, .launchFailed)
         XCTAssertEqual(HelperResponse.Outcome.authorizationDenied.elevatedOutcome, .authCancelled)
+    }
+
+    /// A refusal is not a launch failure. Folding the two together is how a
+    /// daemon-side identity check surfaced as "Burrow could not verify the
+    /// program it was about to run" (issue #425); the reason must survive the
+    /// bridge so the GUI can say what actually happened.
+    func testResponse_aRejectionKeepsItsReasonAcrossTheBridge() {
+        for reason in HelperRequestRejection.allCases {
+            XCTAssertEqual(HelperResponse.Outcome.rejected(reason).elevatedOutcome, .refused(reason))
+            XCTAssertNotEqual(HelperResponse.Outcome.rejected(reason).elevatedOutcome, .launchFailed)
+        }
+    }
+
+    /// Every rejection the daemon can name has a sentence for the run log,
+    /// and every sentence says nothing ran — a refusal happens before
+    /// authorization, so there is never a partial result to hedge about.
+    func testEveryRejectionExplainsItselfAndSaysNothingRan() {
+        for reason in HelperRequestRejection.allCases {
+            let text = reason.userExplanation
+            XCTAssertFalse(text.isEmpty, "\(reason) has no explanation")
+            XCTAssertTrue(text.contains("nothing ran") || text.contains("nothing was cleaned"),
+                          "\(reason): \(text)")
+        }
+        XCTAssertTrue(HelperRequestRejection.invalidReviewedPaths.userExplanation.contains("Rescan"),
+                      "a stale reviewed list is fixed by rescanning, and the text must say so")
     }
 }
 

--- a/macos/Tests/OperationFlowTests.swift
+++ b/macos/Tests/OperationFlowTests.swift
@@ -109,6 +109,15 @@ final class OperationFlowTests: XCTestCase {
         }
         XCTAssertEqual(
             FeatureOperationFailurePolicy.category(
+                forExitCode: ElevatedExitCode.requestRefused,
+                elevated: true,
+                isCleanup: false
+            ),
+            .privilegedRequestRefused,
+            "a helper refusal is its own signal, not a launch failure and not an engine exit"
+        )
+        XCTAssertEqual(
+            FeatureOperationFailurePolicy.category(
                 forExitCode: 1,
                 elevated: true,
                 isCleanup: false
@@ -314,6 +323,28 @@ final class OperationFlowTests: XCTestCase {
         XCTAssertTrue(message.contains("Rescan"), message)
         XCTAssertNil(flow.report, "a refused cleanup must not render the preview's summary")
         XCTAssertEqual(center.ops.first?.phase, .failed)
+    }
+
+    /// The helper refusing a request (issue #425: the daemon's identity gate
+    /// said no before authorization) is NOT "Burrow could not verify the
+    /// program". The helper route puts its reason in the transcript and exits
+    /// with the refusal code; the flow must render that as a refusal and keep
+    /// the reason where the user can read it.
+    func testHelperRefusalReadsAsARefusal_notAsProgramVerification() async throws {
+        let reason = HelperRequestRejection.invalidInvokingUser.userExplanation
+        let flow = makeFlow(FakeProcessPort(script: [
+            .line(reason), .exited(ElevatedExitCode.requestRefused),
+        ]))
+        flow.start(Self.cleanOp(elevated: true))
+        await settle(flow)
+
+        guard case .finished(.failed(let message)) = flow.state else {
+            return XCTFail("a refused request must not become done")
+        }
+        XCTAssertTrue(message.contains("Nothing ran"), message)
+        XCTAssertTrue(message.contains("refused"), message)
+        XCTAssertFalse(message.contains("verify the program"), message)
+        XCTAssertTrue(flow.rawLog.contains(reason), "the daemon's reason must reach the run log")
     }
 
     /// A cleanup that ran and could not remove everything is a DIFFERENT

--- a/macos/Tests/PrivilegeBrokerTests.swift
+++ b/macos/Tests/PrivilegeBrokerTests.swift
@@ -103,6 +103,10 @@ final class PrivilegeBrokerTests: XCTestCase {
         XCTAssertEqual(ElevatedOutcome.exited(3).exitCode, 3)
         XCTAssertNotEqual(ElevatedOutcome.authCancelled.exitCode, 0, "a dismissed prompt is a failure to callers")
         XCTAssertEqual(ElevatedOutcome.launchFailed.exitCode, 127, "matches the old 'no trusted mo' sentinel")
+        XCTAssertEqual(ElevatedOutcome.refused(.invalidInvokingUser).exitCode, ElevatedExitCode.requestRefused)
+        XCTAssertNotEqual(ElevatedOutcome.refused(.buildMismatch).exitCode, 0, "a refusal is a failure to callers")
+        XCTAssertNotEqual(ElevatedOutcome.refused(.buildMismatch).exitCode, ElevatedExitCode.launchFailed,
+                          "a refused request must not be rendered as a program that failed verification")
     }
 
     // MARK: - osascript spec quoting through the broker (injection cases)


### PR DESCRIPTION
The first privileged request of every helper session was refused as an
"invoking identity mismatch"; the same request seconds later went
through. The daemon exits after two idle minutes, so nearly every action
was a first request, and the user saw "Nothing ran: Burrow could not
verify the program it was about to run as an administrator".

The daemon resolves the invoking account with a single getpwuid_r call.
libinfo's ds module gives up after two XPC attempts and returns NULL for
any transport error other than a closed pipe, and getpwuid_r then
reports success with no record — the same answer as a uid that does not
exist. A freshly spawned root daemon whose first act is that lookup hits
it often enough to fail on install day and every day since.

The lookup now retries an empty answer on a short bounded schedule
(0.1/0.25/0.5/1/2 s). Nothing is relaxed: every attempt asks the same
source and the record still passes every identity check; a uid with no
account waits the schedule and is refused as before. The refusal log
line names the failing check (a closed enum), which is the fact the
report had to reason around. An in-flight request now also counts as
work for the idle timer, so a retry in the last seconds of the window
cannot have the daemon exit underneath it.

The message was wrong for every rejection, not just this one: the client
folded rejected(reason) into launchFailed and the flow rendered that as
a program-verification failure. ElevatedOutcome gains refused(reason),
the helper route writes a per-reason explanation into the run log and
exits with its own code (78, the value the contract already reserved),
the flow says "the privileged helper refused the request", and telemetry
classifies it as privileged_request_refused rather than a launch
failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privileged-operation reliability by retrying account lookups and preventing the helper from exiting while requests are in progress.
  * Privileged request refusals are now distinguished from launch failures and program verification issues.
  * Failure messages explain that no operation ran, include the helper’s reason, and direct users to the run log.
  * Added clearer guidance for refusal scenarios, including cases requiring a rescan.

* **Localization**
  * Added refusal-message translations in German, Spanish, French, Japanese, Korean, Portuguese (Brazil), Russian, and Simplified and Traditional Chinese.
  * Updated Spanish and Portuguese (Brazil) translations for Software updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->