### PR TITLE
fix(updates): split Mac apps from Homebrew, stop hiding brew failures, honor HOMEBREW_* mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ stdio bridge, CI, tests, and unsigned release packaging.
 | **Purge** | Reclaim space from dev projects: `node_modules`, build dirs, `target/`, `__pycache__`, and more — preview streams in, one confirmation, everything found goes to the Trash. | `mo purge` |
 | **Installers** | Find and remove leftover `.dmg`/`.pkg` installer files in bulk. | `mo installer` |
 | **Optimize** | One-tap safe maintenance: rebuild caches, repair metadata, flush DNS, restart Dock/Finder. | `mo optimize` |
-| **Software** | Installed-app list with search/sort (size, name, recent, source) and multi-select uninstall; an **Updates** tab with Mac apps and Homebrew side by side. | `mo uninstall --list`, `brew outdated` |
+| **Software** | Installed-app list with search/sort (size, name, recent, source) and multi-select uninstall; an **Updates** tab with a Mac apps / Homebrew picker, each half with its own check and update-all. | `mo uninstall --list`, `brew outdated` |
 | **Analyze** | Squarified treemap of your disk; drill into any folder, reveal in Finder. | `mo analyze --json` |
 
 Every scan offers a **no-risk preview** (`--dry-run`) first, a clear

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ stdio bridge, CI, tests, and unsigned release packaging.
 | **Purge** | Reclaim space from dev projects: `node_modules`, build dirs, `target/`, `__pycache__`, and more — preview streams in, one confirmation, everything found goes to the Trash. | `mo purge` |
 | **Installers** | Find and remove leftover `.dmg`/`.pkg` installer files in bulk. | `mo installer` |
 | **Optimize** | One-tap safe maintenance: rebuild caches, repair metadata, flush DNS, restart Dock/Finder. | `mo optimize` |
-| **Software** | Installed-app list with search/sort (size, name, recent, source) and multi-select uninstall; a Homebrew **Updates** tab. | `mo uninstall --list`, `brew outdated` |
+| **Software** | Installed-app list with search/sort (size, name, recent, source) and multi-select uninstall; an **Updates** tab with Mac apps and Homebrew side by side. | `mo uninstall --list`, `brew outdated` |
 | **Analyze** | Squarified treemap of your disk; drill into any folder, reveal in Finder. | `mo analyze --json` |
 
 Every scan offers a **no-risk preview** (`--dry-run`) first, a clear
@@ -428,7 +428,8 @@ duplicate finding. The honest privacy picture:
 - **Local-only surfaces:** the MCP/HTTP surfaces bind to loopback only
   (`127.0.0.1`) and history is stored locally. On Windows, the HTTP REST toggle
   disables REST endpoints but keeps the local `/mcp` bridge route available for
-  stdio MCP clients. The macOS Updates tab runs `brew outdated`, the same check
+  stdio MCP clients. The macOS Updates tab reads Homebrew's local index when it
+  opens and runs `brew update` only when you click Refresh, the same fetch
   `brew` does for itself.
 - **Distribution signatures:** new official macOS tags fail unless Developer ID
   signing, notarization, and the signed Sparkle ZIP/feed checks pass; local

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -235,11 +235,15 @@ This is the part people rightly scrutinize in cleaners. Burrow's model:
     through the same opt-out telemetry switch, without request URLs or a
     Sparkle device profile. Turn the toggle off to make checks fully manual; the
     menu and Settings buttons still work.
-  - The Software → **Updates** tab runs `brew outdated`, which contacts
-    Homebrew's update feeds — the same check `brew` does for itself. It reads
-    version info; it sends nothing about you. App version checks (Sparkle
-    appcasts, App Store lookups) still happen only when you click "Check for
-    updates".
+  - The Software → **Updates** tab lists Homebrew's outdated formulae and
+    casks from Homebrew's local index when it opens (`brew outdated` with
+    auto-update off), which needs no network. Clicking **Refresh** runs
+    `brew update`, which contacts Homebrew's update feeds — the same fetch
+    `brew` does for itself. It reads version info; it sends nothing about
+    you. Burrow runs `brew` with the `HOMEBREW_*` variables from your login
+    shell, so a configured mirror is honored, and imports nothing else from
+    that shell. App version checks (Sparkle appcasts, App Store lookups)
+    still happen only when you click "Check for updates".
   - The engine inside `Burrow.app` never self-updates because changing a file
     inside the bundle would invalidate its Developer ID seal. It updates only
     with a signed Burrow release. Source builds using an external engine keep

--- a/macos/Resources/de.lproj/Localizable.strings
+++ b/macos/Resources/de.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "Extragroß";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Skaliert Text und Symbole in der gesamten App und im Menüleisten-Popup – ohne Neustart. Das Menüleisten-Element selbst behält seine eigene Textgröße, die pro Widget unter „Menüleiste“ eingestellt wird.";
 "Release Notes" = "Versionshinweise";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Mac-Apps";
+"Checking app versions contacts Apple and vendor servers." = "Die Versionsprüfung kontaktiert Server von Apple und den Anbietern.";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Aus dem lokalen Homebrew-Index – „Aktualisieren“ kontaktiert die Update-Feeds von Homebrew.";
+"Homebrew is no longer available." = "Homebrew ist nicht mehr verfügbar.";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew wurde mit Status %d beendet. Behebe die Meldung und versuche es erneut.";
+"Homebrew didn't respond in time." = "Homebrew hat nicht rechtzeitig geantwortet.";
+"Homebrew exited with status %d." = "Homebrew wurde mit Status %d beendet.";
+"Homebrew couldn't refresh: %@" = "Homebrew konnte nicht aktualisieren: %@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew konnte veraltete Pakete nicht auflisten: %@";
+"Stop after current" = "Nach dem aktuellen stoppen";
+"Stopping after current…" = "Stoppt nach dem aktuellen …";
+"Checking…" = "Prüfe …";
+"%d of %d update steps processed" = "%1$d von %2$d Update-Schritten verarbeitet";
+"%d update checks failed. Known versions were preserved." = "%d Update-Prüfungen fehlgeschlagen. Bekannte Versionen wurden beibehalten.";
+"Retry" = "Erneut versuchen";
+"Open updater" = "Updater öffnen";
+"Open App Store" = "App Store öffnen";
+"Install & Restart" = "Installieren & neu starten";
+"Not Yet" = "Noch nicht";
+"Release notes" = "Versionshinweise";

--- a/macos/Resources/es.lproj/Localizable.strings
+++ b/macos/Resources/es.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "Extragrande";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Escala el texto y los iconos en toda la app y en el panel de la barra de menús, sin necesidad de reiniciar. El elemento de la barra de menús conserva su propio tamaño de texto, configurado por widget en «Barra de menús».";
 "Release Notes" = "Notas de la versión";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Apps de Mac";
+"Checking app versions contacts Apple and vendor servers." = "Comprobar las versiones contacta con los servidores de Apple y de los desarrolladores.";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Listado desde el índice local de Homebrew: «Actualizar» contacta con las fuentes de actualización de Homebrew.";
+"Homebrew is no longer available." = "Homebrew ya no está disponible.";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew terminó con el estado %d. Resuelve su mensaje y vuelve a intentarlo.";
+"Homebrew didn't respond in time." = "Homebrew no respondió a tiempo.";
+"Homebrew exited with status %d." = "Homebrew terminó con el estado %d.";
+"Homebrew couldn't refresh: %@" = "Homebrew no pudo actualizarse: %@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew no pudo listar los paquetes desactualizados: %@";
+"Stop after current" = "Detener tras el actual";
+"Stopping after current…" = "Deteniendo tras el actual…";
+"Checking…" = "Comprobando…";
+"%d of %d update steps processed" = "%1$d de %2$d pasos de actualización procesados";
+"%d update checks failed. Known versions were preserved." = "%d comprobaciones de actualización fallaron. Se conservaron las versiones conocidas.";
+"Retry" = "Reintentar";
+"Open updater" = "Abrir el actualizador";
+"Open App Store" = "Abrir App Store";
+"Install & Restart" = "Instalar y reiniciar";
+"Not Yet" = "Ahora no";
+"Release notes" = "Notas de la versión";

--- a/macos/Resources/fr.lproj/Localizable.strings
+++ b/macos/Resources/fr.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "Très grande";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Met à l'échelle le texte et les icônes dans toute l'app et dans le panneau de la barre des menus — sans relancer. L'élément de la barre des menus conserve sa propre taille de texte, réglée par widget dans « Barre des menus ».";
 "Release Notes" = "Notes de version";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Apps Mac";
+"Checking app versions contacts Apple and vendor servers." = "La vérification des versions contacte les serveurs d'Apple et des éditeurs.";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Liste issue de l'index local de Homebrew — « Actualiser » contacte les flux de mise à jour de Homebrew.";
+"Homebrew is no longer available." = "Homebrew n'est plus disponible.";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew s'est terminé avec le statut %d. Résolvez son message, puis réessayez.";
+"Homebrew didn't respond in time." = "Homebrew n'a pas répondu à temps.";
+"Homebrew exited with status %d." = "Homebrew s'est terminé avec le statut %d.";
+"Homebrew couldn't refresh: %@" = "Homebrew n'a pas pu s'actualiser : %@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew n'a pas pu lister les paquets obsolètes : %@";
+"Stop after current" = "Arrêter après l'élément en cours";
+"Stopping after current…" = "Arrêt après l'élément en cours…";
+"Checking…" = "Vérification…";
+"%d of %d update steps processed" = "%1$d étapes de mise à jour sur %2$d traitées";
+"%d update checks failed. Known versions were preserved." = "%d vérifications de mise à jour ont échoué. Les versions connues ont été conservées.";
+"Retry" = "Réessayer";
+"Open updater" = "Ouvrir l'outil de mise à jour";
+"Open App Store" = "Ouvrir l'App Store";
+"Install & Restart" = "Installer et redémarrer";
+"Not Yet" = "Pas maintenant";
+"Release notes" = "Notes de version";

--- a/macos/Resources/ja.lproj/Localizable.strings
+++ b/macos/Resources/ja.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "特大";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "アプリ全体とメニューバーのポップアップの文字とアイコンを拡大縮小します。再起動は不要です。メニューバー項目自体の文字サイズは「メニューバー」でウィジェットごとに個別に設定します。";
 "Release Notes" = "リリースノート";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Mac アプリ";
+"Checking app versions contacts Apple and vendor servers." = "アプリのバージョン確認では Apple と開発元のサーバーに接続します。";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Homebrew のローカルインデックスから表示しています。「更新」で Homebrew の更新フィードに接続します。";
+"Homebrew is no longer available." = "Homebrew は利用できなくなりました。";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew がステータス %d で終了しました。メッセージを解決してから再試行してください。";
+"Homebrew didn't respond in time." = "Homebrew が時間内に応答しませんでした。";
+"Homebrew exited with status %d." = "Homebrew がステータス %d で終了しました。";
+"Homebrew couldn't refresh: %@" = "Homebrew を更新できませんでした：%@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew が古いパッケージを一覧できませんでした：%@";
+"Stop after current" = "現在の項目の後で停止";
+"Stopping after current…" = "現在の項目の後で停止します…";
+"Checking…" = "確認中…";
+"%d of %d update steps processed" = "%1$d / %2$d 件のアップデート手順を処理しました";
+"%d update checks failed. Known versions were preserved." = "%d 件のアップデート確認に失敗しました。既知のバージョンは保持されています。";
+"Retry" = "再試行";
+"Open updater" = "アップデーターを開く";
+"Open App Store" = "App Store を開く";
+"Install & Restart" = "インストールして再起動";
+"Not Yet" = "あとで";
+"Release notes" = "リリースノート";

--- a/macos/Resources/ko.lproj/Localizable.strings
+++ b/macos/Resources/ko.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "아주 크게";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "앱 전체와 메뉴 막대 팝업의 텍스트와 아이콘 크기를 조절합니다. 재실행이 필요 없습니다. 메뉴 막대 항목 자체의 텍스트 크기는 '메뉴 막대'에서 위젯별로 따로 설정합니다.";
 "Release Notes" = "릴리스 노트";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Mac 앱";
+"Checking app versions contacts Apple and vendor servers." = "앱 버전을 확인하면 Apple 및 개발사 서버에 접속합니다.";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Homebrew의 로컬 인덱스에서 가져온 목록입니다. ‘새로 고침’은 Homebrew 업데이트 피드에 접속합니다.";
+"Homebrew is no longer available." = "Homebrew를 더 이상 사용할 수 없습니다.";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew가 상태 %d(으)로 종료되었습니다. 메시지를 해결한 뒤 다시 시도하세요.";
+"Homebrew didn't respond in time." = "Homebrew가 제시간에 응답하지 않았습니다.";
+"Homebrew exited with status %d." = "Homebrew가 상태 %d(으)로 종료되었습니다.";
+"Homebrew couldn't refresh: %@" = "Homebrew를 새로 고칠 수 없습니다: %@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew가 오래된 패키지를 나열하지 못했습니다: %@";
+"Stop after current" = "현재 항목 후 중지";
+"Stopping after current…" = "현재 항목 후 중지 중…";
+"Checking…" = "확인 중…";
+"%d of %d update steps processed" = "업데이트 단계 %1$d / %2$d 처리됨";
+"%d update checks failed. Known versions were preserved." = "업데이트 확인 %d건이 실패했습니다. 알려진 버전은 유지됩니다.";
+"Retry" = "다시 시도";
+"Open updater" = "업데이터 열기";
+"Open App Store" = "App Store 열기";
+"Install & Restart" = "설치 후 재시동";
+"Not Yet" = "나중에";
+"Release notes" = "릴리스 노트";

--- a/macos/Resources/pt-BR.lproj/Localizable.strings
+++ b/macos/Resources/pt-BR.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "Extragrande";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Ajusta o texto e os ícones em todo o app e no painel da barra de menus — sem precisar reiniciar. O item da barra de menus mantém seu próprio tamanho de texto, definido por widget em “Barra de menus”.";
 "Release Notes" = "Notas de versão";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Apps do Mac";
+"Checking app versions contacts Apple and vendor servers." = "Verificar as versões contata os servidores da Apple e dos desenvolvedores.";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Listado a partir do índice local do Homebrew — “Atualizar” contata as fontes de atualização do Homebrew.";
+"Homebrew is no longer available." = "O Homebrew não está mais disponível.";
+"Homebrew exited with status %d. Retry after resolving its message." = "O Homebrew saiu com o status %d. Resolva a mensagem dele e tente de novo.";
+"Homebrew didn't respond in time." = "O Homebrew não respondeu a tempo.";
+"Homebrew exited with status %d." = "O Homebrew saiu com o status %d.";
+"Homebrew couldn't refresh: %@" = "O Homebrew não conseguiu atualizar: %@";
+"Homebrew couldn't list outdated packages: %@" = "O Homebrew não conseguiu listar os pacotes desatualizados: %@";
+"Stop after current" = "Parar após o atual";
+"Stopping after current…" = "Parando após o atual…";
+"Checking…" = "Verificando…";
+"%d of %d update steps processed" = "%1$d de %2$d etapas de atualização processadas";
+"%d update checks failed. Known versions were preserved." = "%d verificações de atualização falharam. As versões conhecidas foram mantidas.";
+"Retry" = "Tentar de novo";
+"Open updater" = "Abrir o atualizador";
+"Open App Store" = "Abrir a App Store";
+"Install & Restart" = "Instalar e reiniciar";
+"Not Yet" = "Agora não";
+"Release notes" = "Notas da versão";

--- a/macos/Resources/ru.lproj/Localizable.strings
+++ b/macos/Resources/ru.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "Очень крупный";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "Масштабирует текст и значки во всём приложении и во всплывающем окне строки меню — без перезапуска. Размер текста самого элемента строки меню настраивается отдельно для каждого виджета в разделе «Строка меню».";
 "Release Notes" = "Примечания к выпуску";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Приложения Mac";
+"Checking app versions contacts Apple and vendor servers." = "Проверка версий обращается к серверам Apple и разработчиков.";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "Список из локального индекса Homebrew — «Обновить» обращается к лентам обновлений Homebrew.";
+"Homebrew is no longer available." = "Homebrew больше недоступен.";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew завершился со статусом %d. Устраните причину из его сообщения и повторите.";
+"Homebrew didn't respond in time." = "Homebrew не ответил вовремя.";
+"Homebrew exited with status %d." = "Homebrew завершился со статусом %d.";
+"Homebrew couldn't refresh: %@" = "Homebrew не удалось обновить индекс: %@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew не удалось перечислить устаревшие пакеты: %@";
+"Stop after current" = "Остановить после текущего";
+"Stopping after current…" = "Остановка после текущего…";
+"Checking…" = "Проверка…";
+"%d of %d update steps processed" = "Обработано %1$d из %2$d шагов обновления";
+"%d update checks failed. Known versions were preserved." = "%d проверок обновлений не удалось. Известные версии сохранены.";
+"Retry" = "Повторить";
+"Open updater" = "Открыть средство обновления";
+"Open App Store" = "Открыть App Store";
+"Install & Restart" = "Установить и перезапустить";
+"Not Yet" = "Не сейчас";
+"Release notes" = "Примечания к выпуску";

--- a/macos/Resources/zh-Hans.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hans.lproj/Localizable.strings
@@ -879,3 +879,25 @@
 "Extra Large" = "特大";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "缩放整个应用与菜单栏弹窗中的文字和图标，无需重新启动。菜单栏项目自身的文字大小仍在“菜单栏”设置中按组件单独调整。";
 "Release Notes" = "发行说明";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Mac 应用";
+"Checking app versions contacts Apple and vendor servers." = "检查应用版本会连接 Apple 与开发者的服务器。";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "列表来自 Homebrew 的本地索引——「刷新」会连接 Homebrew 的更新源。";
+"Homebrew is no longer available." = "Homebrew 已不可用。";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew 以状态 %d 退出。请先解决其提示信息，再重试。";
+"Homebrew didn't respond in time." = "Homebrew 未在规定时间内响应。";
+"Homebrew exited with status %d." = "Homebrew 以状态 %d 退出。";
+"Homebrew couldn't refresh: %@" = "Homebrew 无法刷新：%@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew 无法列出过期的软件包：%@";
+"Stop after current" = "完成当前项后停止";
+"Stopping after current…" = "完成当前项后停止…";
+"Checking…" = "正在检查…";
+"%d of %d update steps processed" = "已处理 %1$d / %2$d 个更新步骤";
+"%d update checks failed. Known versions were preserved." = "%d 项更新检查失败。已保留已知版本。";
+"Retry" = "重试";
+"Open updater" = "打开更新器";
+"Open App Store" = "打开 App Store";
+"Install & Restart" = "安装并重新启动";
+"Not Yet" = "暂不";
+"Release notes" = "发行说明";

--- a/macos/Resources/zh-Hant.lproj/Localizable.strings
+++ b/macos/Resources/zh-Hant.lproj/Localizable.strings
@@ -864,3 +864,25 @@
 "Extra Large" = "特大";
 "Scales text and icons across the whole app and the menu-bar popup — no relaunch needed. The menu-bar item itself keeps its own per-widget text size, set under Menu Bar." = "縮放整個應用程式與選單列彈出視窗中的文字和圖示，無需重新啟動。選單列項目本身的文字大小仍在「選單列」設定中按元件單獨調整。";
 "Release Notes" = "版本說明";
+
+// Software › Updates (#424): Mac apps / Homebrew split, brew problems, batch controls
+"Mac apps" = "Mac 應用程式";
+"Checking app versions contacts Apple and vendor servers." = "檢查應用程式版本會連線 Apple 與開發者的伺服器。";
+"Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds." = "列表來自 Homebrew 的本機索引——「重新整理」會連線 Homebrew 的更新來源。";
+"Homebrew is no longer available." = "Homebrew 已無法使用。";
+"Homebrew exited with status %d. Retry after resolving its message." = "Homebrew 以狀態 %d 結束。請先解決其提示訊息，再重試。";
+"Homebrew didn't respond in time." = "Homebrew 未在時限內回應。";
+"Homebrew exited with status %d." = "Homebrew 以狀態 %d 結束。";
+"Homebrew couldn't refresh: %@" = "Homebrew 無法重新整理：%@";
+"Homebrew couldn't list outdated packages: %@" = "Homebrew 無法列出過期的套件：%@";
+"Stop after current" = "完成目前項目後停止";
+"Stopping after current…" = "完成目前項目後停止…";
+"Checking…" = "正在檢查…";
+"%d of %d update steps processed" = "已處理 %1$d / %2$d 個更新步驟";
+"%d update checks failed. Known versions were preserved." = "%d 項更新檢查失敗。已保留已知版本。";
+"Retry" = "重試";
+"Open updater" = "打開更新程式";
+"Open App Store" = "打開 App Store";
+"Install & Restart" = "安裝並重新啟動";
+"Not Yet" = "暫不";
+"Release notes" = "發行說明";

--- a/macos/Sources/BrewClient.swift
+++ b/macos/Sources/BrewClient.swift
@@ -2,17 +2,23 @@
 //  BrewClient.swift
 //  Burrow
 //
-//  Shared Homebrew invocation seam. The Updates pane already shells `brew`
-//  for outdated/upgrade; the Services + Snapshot features reuse the same
+//  Shared Homebrew invocation seam. The Updates pane shells `brew` for
+//  outdated/update/upgrade; the Services + Snapshot features reuse the same
 //  resolution (known Homebrew prefixes, never a PATH lookup a user-writable
-//  dir could shadow) and the same EngineRunner capture path. Pure parsers live
-//  alongside their callers and are unit-tested; this is just the spawn seam.
+//  dir could shadow), the same environment, and the same EngineRunner capture
+//  path. Pure parsers live alongside their callers and are unit-tested; this
+//  is just the spawn seam.
 //
 
 import Foundation
 
 enum BrewClient {
-    struct Result { let out: String; let err: String; let code: Int32 }
+    struct Result {
+        let out: String
+        let err: String
+        let code: Int32
+        var timedOut: Bool = false
+    }
 
     /// The Homebrew binary, or nil if Homebrew isn't installed.
     static func path() -> String? {
@@ -21,17 +27,38 @@ enum BrewClient {
         return nil
     }
 
-    /// Run `brew <args>` with a sane PATH (brew shells out to git etc.), capturing
-    /// output. Returns a nonzero code rather than throwing when brew is missing.
-    static func run(_ args: [String], timeout: TimeInterval = 120) -> Result {
-        guard let brew = path() else { return Result(out: "", err: "brew not found", code: -1) }
-        var env = Foundation.ProcessInfo.processInfo.environment
+    /// The environment every brew child gets: the app's own, a PATH that
+    /// starts at brew's prefix (brew shells out to git, curl, ruby), the
+    /// user's `HOMEBREW_*` exports from their login shell (#424), and —
+    /// when `autoUpdate` is false — `HOMEBREW_NO_AUTO_UPDATE=1`, so a read
+    /// like `brew outdated` reports the local index instead of first fetching
+    /// taps from GitHub. Pure given `imported`, so the layering is testable.
+    static func environment(
+        brew: String,
+        autoUpdate: Bool = true,
+        base: [String: String] = Foundation.ProcessInfo.processInfo.environment,
+        imported: [String: String] = HomebrewEnvironment.imported
+    ) -> [String: String] {
+        var env = base
+        for (key, value) in imported where HomebrewEnvironment.isValidKey(key) {
+            env[key] = value
+        }
         let dir = (brew as NSString).deletingLastPathComponent
-        env["PATH"] = "\(dir):/usr/bin:/bin:/usr/sbin:/sbin:" + (env["PATH"] ?? "")
+        env["PATH"] = "\(dir):/usr/bin:/bin:/usr/sbin:/sbin:" + (base["PATH"] ?? "")
+        if !autoUpdate { env["HOMEBREW_NO_AUTO_UPDATE"] = "1" }
+        return env
+    }
+
+    /// Run `brew <args>`, capturing output. Returns a nonzero code rather than
+    /// throwing when brew is missing; `timedOut` says the deadline, not brew,
+    /// ended the run.
+    static func run(_ args: [String], timeout: TimeInterval = 120, autoUpdate: Bool = true) -> Result {
+        guard let brew = path() else { return Result(out: "", err: "brew not found", code: -1) }
         do {
             let r = try EngineRunner.shared.capture(
-                MoCommand(target: .executable(brew), args: args, environment: env, timeout: timeout))
-            return Result(out: r.stdout, err: r.stderr, code: r.exitCode)
+                MoCommand(target: .executable(brew), args: args,
+                          environment: environment(brew: brew, autoUpdate: autoUpdate), timeout: timeout))
+            return Result(out: r.stdout, err: r.stderr, code: r.exitCode, timedOut: r.timedOut)
         } catch {
             return Result(out: "", err: "\(error)", code: -1)
         }

--- a/macos/Sources/BrewClient.swift
+++ b/macos/Sources/BrewClient.swift
@@ -49,9 +49,10 @@ enum BrewClient {
         return env
     }
 
-    /// Run `brew <args>`, capturing output. Returns a nonzero code rather than
-    /// throwing when brew is missing; `timedOut` says the deadline, not brew,
-    /// ended the run.
+    /// A missing brew is reported the same way as a failing one (nonzero
+    /// code, message in `err`) so every caller has exactly one failure path
+    /// to render; `timedOut` is kept separate because "brew never answered"
+    /// deserves different copy from "brew said no".
     static func run(_ args: [String], timeout: TimeInterval = 120, autoUpdate: Bool = true) -> Result {
         guard let brew = path() else { return Result(out: "", err: "brew not found", code: -1) }
         do {

--- a/macos/Sources/HomebrewEnvironment.swift
+++ b/macos/Sources/HomebrewEnvironment.swift
@@ -1,0 +1,102 @@
+//
+//  HomebrewEnvironment.swift
+//  Burrow
+//
+//  The user's own Homebrew configuration (issue #424). A Finder-launched app
+//  inherits launchd's environment, not the login shell's, so every
+//  `HOMEBREW_*` export in ~/.zshrc — most importantly the mirror variables
+//  (`HOMEBREW_API_DOMAIN`, `HOMEBREW_BOTTLE_DOMAIN`, the `*_GIT_REMOTE`
+//  pair) that users behind a slow or blocked path to GitHub rely on — was
+//  invisible to the `brew` Burrow spawns. Inside the app, brew then went
+//  straight to github.com and ghcr.io, stalled, and the Updates pane showed
+//  an empty list.
+//
+//  This asks the login shell once for its environment and keeps ONLY the
+//  `HOMEBREW_`-prefixed entries. Nothing else crosses over: PATH stays the
+//  app's own fixed one (brew is still resolved from its known prefixes, never
+//  a PATH lookup), and no other variable from the shell can reach a child
+//  process. The probe is the user's shell running the user's rc files as the
+//  user — the same code `brew` itself would run from a terminal.
+//
+
+import Foundation
+
+enum HomebrewEnvironment {
+    /// The `HOMEBREW_*` entries of the user's interactive login shell,
+    /// probed once per process on first use. Empty when the probe fails or
+    /// the shell exports nothing relevant.
+    static let imported: [String: String] = probe()
+
+    /// Keep only well-formed `HOMEBREW_*` assignments from `env` output. Pure
+    /// so the filter is unit-tested against captured shell output: a banner
+    /// line, an `alias` echo, or an unrelated export must never leak through.
+    static func parse(_ envOutput: String) -> [String: String] {
+        var out: [String: String] = [:]
+        for rawLine in envOutput.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine)
+            guard line.hasPrefix("HOMEBREW_"), let eq = line.firstIndex(of: "=") else { continue }
+            let key = String(line[line.startIndex..<eq])
+            let value = String(line[line.index(after: eq)...])
+            guard isValidKey(key), !value.isEmpty, !value.contains("\0") else { continue }
+            out[key] = value
+        }
+        return out
+    }
+
+    /// `HOMEBREW_` followed by shell-identifier characters only.
+    static func isValidKey(_ key: String) -> Bool {
+        guard key.hasPrefix("HOMEBREW_"), key.count > "HOMEBREW_".count else { return false }
+        return key.unicodeScalars.allSatisfy { scalar in
+            (scalar >= "A" && scalar <= "Z") || (scalar >= "0" && scalar <= "9") || scalar == "_"
+        }
+    }
+
+    /// Absolute path of the user's login shell, or nil when it isn't one we
+    /// can run. `SHELL` is set by launchd from the user record for every
+    /// app it launches; `/bin/zsh` is the macOS default when it isn't.
+    static func loginShell(environment: [String: String] = Foundation.ProcessInfo.processInfo.environment) -> String? {
+        let candidate = environment["SHELL"].flatMap { $0.isEmpty ? nil : $0 } ?? "/bin/zsh"
+        guard candidate.hasPrefix("/"), FileManager.default.isExecutableFile(atPath: candidate) else { return nil }
+        return candidate
+    }
+
+    /// Run `<shell> -i -l -c env` with a short deadline and parse it. Failing
+    /// closed (empty) is fine: brew then runs exactly as it did before this
+    /// existed.
+    private static func probe() -> [String: String] {
+        guard let shell = loginShell() else { return [:] }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-i", "-l", "-c", "env"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        let handle = pipe.fileHandleForReading
+        var buffer = Data()
+        let drained = DispatchSemaphore(value: 0)
+        handle.readabilityHandler = { fh in
+            let chunk = fh.availableData
+            if chunk.isEmpty {
+                fh.readabilityHandler = nil
+                drained.signal()
+            } else {
+                buffer.append(chunk)
+            }
+        }
+        do { try process.run() } catch {
+            handle.readabilityHandler = nil
+            return [:]
+        }
+        let killer = DispatchWorkItem { if process.isRunning { process.terminate() } }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5, execute: killer)
+        process.waitUntilExit()
+        killer.cancel()
+        // Wait for EOF so a fast exit can't race the last chunk; the child is
+        // gone, so this returns promptly.
+        _ = drained.wait(timeout: .now() + 1)
+        handle.readabilityHandler = nil
+        guard process.terminationStatus == 0 else { return [:] }
+        return parse(String(decoding: buffer, as: UTF8.self))
+    }
+}

--- a/macos/Sources/HomebrewEnvironment.swift
+++ b/macos/Sources/HomebrewEnvironment.swift
@@ -43,7 +43,6 @@ enum HomebrewEnvironment {
         return out
     }
 
-    /// `HOMEBREW_` followed by shell-identifier characters only.
     static func isValidKey(_ key: String) -> Bool {
         guard key.hasPrefix("HOMEBREW_"), key.count > "HOMEBREW_".count else { return false }
         return key.unicodeScalars.allSatisfy { scalar in

--- a/macos/Sources/UpdatesView.swift
+++ b/macos/Sources/UpdatesView.swift
@@ -20,12 +20,33 @@
 import SwiftUI
 import AppKit
 
-struct OutdatedItem: Identifiable {
+struct OutdatedItem: Identifiable, Equatable {
     let id: String
     let name: String
     let installed: String
     let latest: String
     let kind: String   // "formula" | "cask"
+}
+
+/// What one `brew outdated` pass produced: the rows, or why there are none.
+/// A failed or timed-out brew used to come back as an empty list, which the
+/// pane showed as "nothing to update" (#424); now the reason travels with it.
+struct BrewOutdated: Equatable {
+    enum Problem: Equatable {
+        case notInstalled
+        case failed(String)
+    }
+    var items: [OutdatedItem] = []
+    var problem: Problem?
+    static let empty = BrewOutdated()
+}
+
+/// The two halves of the pane. They have different network stories — Mac
+/// apps are checked only on click, Homebrew's local index is free — so each
+/// gets its own header with its own single action instead of one shared
+/// button sitting above a mixed list.
+enum UpdatesSource: Hashable {
+    case apps, homebrew
 }
 
 /// One GUI app in the unified list.
@@ -112,110 +133,206 @@ struct UpdatesView: View {
     var apps: [InstalledApp] = []
 
     var body: some View {
-        Group {
-            if model.checking && model.appItems.isEmpty {
-                center { ProgressView("Checking update sources…").controlSize(.large).tint(Tool.apps.accent).font(Brand.mono(11)) }
-            } else {
-                VStack(spacing: 0) {
-                    header.padding(.horizontal, 18).padding(.vertical, 11)
-                    Rectangle().fill(Brand.hairline).frame(height: 1)
-                    list
-                }
+        VStack(spacing: 0) {
+            header.padding(.horizontal, 18).padding(.vertical, 11)
+            Rectangle().fill(Brand.hairline).frame(height: 1)
+            switch model.source {
+            case .apps: appsList
+            case .homebrew: brewList
             }
         }
         .onAppear { model.prepare(apps: apps); model.autoSurface() }
         .onChange(of: apps) { _, latest in model.prepare(apps: latest) }
     }
 
+    // MARK: Header — source picker on the left, that source's actions on the right
+
     private var header: some View {
         HStack(spacing: 10) {
-            if model.checked || !model.brewItems.isEmpty {
-                let n = model.availableItems.count + model.brewItems.count
-                Text(String(format: NSLocalizedString(n == 1 ? "%d update" : "%d updates", comment: ""), n))
-                    .font(Brand.mono(12)).foregroundStyle(Brand.textSecondary)
-            } else {
-                Text("Homebrew shown automatically — checking app versions contacts Apple and vendor servers.")
-                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+            HStack(spacing: 2) {
+                sourceTab("Mac apps", .apps, count: model.checked && !model.availableItems.isEmpty ? model.availableItems.count : nil)
+                sourceTab("Homebrew", .homebrew, count: model.brewItems.isEmpty ? nil : model.brewItems.count)
             }
+            .padding(2)
+            .background(Capsule().fill(Brand.hairline.opacity(0.5)))
             Spacer()
-            if model.checking || model.brewSurfacing {
-                HStack(spacing: 6) {
-                    ProgressView().controlSize(.small)
-                    Text(model.checking ? NSLocalizedString("Checking…", comment: "")
-                                        : NSLocalizedString("Checking Homebrew…", comment: ""))
-                        .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
-                }
-            }
-            PillButton(title: model.checked ? "Check again" : "Check for updates", filled: !model.checked) {
-                model.checkNow()
-            }
-            .keyboardShortcut("r", modifiers: .command)
-            if model.updateAllRunning {
-                Text(verbatim: "\(model.updateAllCompleted)/\(model.updateAllTotal)")
-                    .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
-                    .accessibilityLabel(String(
-                        format: NSLocalizedString("%d of %d update steps processed", comment: ""),
-                        model.updateAllCompleted,
-                        model.updateAllTotal
-                    ))
-                PillButton(title: model.cancelUpdateAllAfterCurrent
-                            ? "Stopping after current…" : "Stop after current",
-                           filled: false) {
-                    model.cancelUpdateAll()
-                }
-                .disabled(model.cancelUpdateAllAfterCurrent)
-            } else if model.checked, model.availableItems.count + model.brewItems.count > 1 {
-                PillButton(title: "Update All", filled: false) {
-                    model.updateAll()
-                }
+            switch model.source {
+            case .apps: appsActions
+            case .homebrew: brewActions
             }
         }
     }
 
+    private func sourceTab(_ title: String, _ value: UpdatesSource, count: Int?) -> some View {
+        let on = model.source == value
+        return Button { model.source = value } label: {
+            HStack(spacing: 5) {
+                Text(NSLocalizedString(title, comment: "")).font(Brand.mono(11, on ? .semibold : .regular))
+                if let count {
+                    Text(verbatim: "\(count)").font(Brand.mono(10, .semibold))
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .background(Capsule().fill(on ? Brand.onInverse.opacity(0.18) : Tool.apps.accent.opacity(0.14)))
+                }
+            }
+            .foregroundStyle(on ? Brand.onInverse : Brand.textSecondary)
+            .padding(.horizontal, 12).padding(.vertical, 5)
+            .background { if on { Capsule().fill(Brand.inverse) } }
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(count.map { String(format: NSLocalizedString($0 == 1 ? "%d update" : "%d updates", comment: ""), $0) }
+                            .map { "\(NSLocalizedString(title, comment: "")) — \($0)" } ?? NSLocalizedString(title, comment: ""))
+        .accessibilityAddTraits(on ? .isSelected : [])
+    }
+
+    /// Mac apps: the explicit network check, then the batch once results exist.
     @ViewBuilder
-    private var list: some View {
+    private var appsActions: some View {
+        if model.checking {
+            progressLabel(NSLocalizedString("Checking…", comment: ""))
+        } else if !model.checked {
+            Text("Checking app versions contacts Apple and vendor servers.")
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+        }
+        PillButton(title: model.checked ? "Check again" : "Check for updates", filled: !model.checked) {
+            model.checkNow()
+        }
+        .keyboardShortcut("r", modifiers: .command)
+        if model.updateAllRunning, model.updateAllSource == .apps {
+            batchControls
+        } else if model.checked, !model.availableItems.isEmpty {
+            PillButton(title: "Update all", filled: false) { model.updateAllApps() }
+        }
+    }
+
+    /// Homebrew: rows come from the local index for free; Refresh is the
+    /// network step (`brew update`), and the batch is available as soon as
+    /// there is anything to upgrade.
+    @ViewBuilder
+    private var brewActions: some View {
+        if model.brewLoading {
+            progressLabel(NSLocalizedString(model.brewRefreshing ? "Refreshing…" : "Checking Homebrew…", comment: ""))
+        } else if model.brewProblem == nil {
+            Text("Listed from Homebrew's local index — Refresh contacts Homebrew's update feeds.")
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+        }
+        if model.brewProblem != .notInstalled {
+            PillButton(title: "Refresh", filled: false) { model.refreshBrew() }
+                .keyboardShortcut("r", modifiers: .command)
+        }
+        if model.updateAllRunning, model.updateAllSource == .homebrew {
+            batchControls
+        } else if !model.brewItems.isEmpty {
+            PillButton(title: "Update all", filled: !model.brewLoading) { model.upgradeAllBrews() }
+        }
+    }
+
+    private var batchControls: some View {
+        HStack(spacing: 10) {
+            Text(verbatim: "\(model.updateAllCompleted)/\(model.updateAllTotal)")
+                .font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+                .accessibilityLabel(String(
+                    format: NSLocalizedString("%d of %d update steps processed", comment: ""),
+                    model.updateAllCompleted,
+                    model.updateAllTotal
+                ))
+            PillButton(title: model.cancelUpdateAllAfterCurrent
+                        ? "Stopping after current…" : "Stop after current",
+                       filled: false) {
+                model.cancelUpdateAll()
+            }
+            .disabled(model.cancelUpdateAllAfterCurrent)
+        }
+    }
+
+    private func progressLabel(_ text: String) -> some View {
+        HStack(spacing: 6) {
+            ProgressView().controlSize(.small)
+            Text(text).font(Brand.mono(10)).foregroundStyle(Brand.textTertiary)
+        }
+    }
+
+    // MARK: Lists
+
+    @ViewBuilder
+    private var appsList: some View {
+        if model.checking && model.appItems.isEmpty {
+            center { ProgressView("Checking update sources…").controlSize(.large).tint(Tool.apps.accent).font(Brand.mono(11)) }
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if let error = model.error {
+                        noteRow(error, color: Brand.amber)
+                    }
+                    if model.checked, model.availableItems.isEmpty {
+                        upToDateBanner
+                    }
+                    if !model.availableItems.isEmpty {
+                        sectionHeader(NSLocalizedString("Updates available", comment: ""), count: model.availableItems.count)
+                        ForEach(model.availableItems) { appRow($0) }
+                    }
+                    if model.checked, !model.upToDateItems.isEmpty {
+                        sectionHeader(NSLocalizedString("Up to date", comment: ""), count: model.upToDateItems.count)
+                        ForEach(model.upToDateItems) { appRow($0) }
+                    }
+                    if !model.checked {
+                        sectionHeader(NSLocalizedString("Apps with an update mechanism", comment: ""), count: model.appItems.count)
+                        ForEach(model.appItems) { appRow($0) }
+                    }
+                    if !model.uncheckableApps.isEmpty {
+                        sectionHeader(NSLocalizedString("Not checkable", comment: ""), count: model.uncheckableApps.count)
+                        Text("No App Store receipt, Sparkle feed, or known updater inside these bundles.")
+                            .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
+                            .padding(.horizontal, 14).padding(.bottom, 4)
+                        ForEach(model.uncheckableApps, id: \.id) { app in
+                            plainRow(app)
+                        }
+                    }
+                }
+                .padding(.horizontal, 10).padding(.vertical, 4)
+            }
+            .scrollIndicators(.visible)
+        }
+    }
+
+    @ViewBuilder
+    private var brewList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
-                if let error = model.error {
-                    Text(error)
-                        .font(Brand.mono(10)).foregroundStyle(Brand.amber)
-                        .padding(.horizontal, 14).padding(.vertical, 8)
-                        .accessibilityLabel(error)
+                switch model.brewProblem {
+                case .notInstalled:
+                    noteRow(NSLocalizedString("Homebrew (`brew`) not found on this Mac.", comment: ""), color: Brand.textTertiary)
+                case let .failed(message):
+                    noteRow(message, color: Brand.amber)
+                case nil:
+                    EmptyView()
                 }
-                if model.checked, model.availableItems.isEmpty, model.brewItems.isEmpty {
-                    VStack(spacing: 10) {
-                        Image(systemName: "checkmark.seal.fill").font(.system(size: Brand.scaled(30))).foregroundStyle(Brand.green)
-                        Text("Everything's up to date").font(Brand.serif(18)).foregroundStyle(Brand.textPrimary)
-                    }
-                    .frame(maxWidth: .infinity).padding(.vertical, 36)
+                if model.brewLoaded, model.brewItems.isEmpty, model.brewProblem == nil {
+                    upToDateBanner
                 }
-                if !model.availableItems.isEmpty || !model.brewItems.isEmpty {
-                    sectionHeader(NSLocalizedString("Updates available", comment: ""),
-                                  count: model.availableItems.count + model.brewItems.count)
-                    ForEach(model.availableItems) { appRow($0) }
+                if !model.brewItems.isEmpty {
+                    sectionHeader(NSLocalizedString("Updates available", comment: ""), count: model.brewItems.count)
                     ForEach(model.brewItems) { brewRow($0) }
-                }
-                if model.checked, !model.upToDateItems.isEmpty {
-                    sectionHeader(NSLocalizedString("Up to date", comment: ""), count: model.upToDateItems.count)
-                    ForEach(model.upToDateItems) { appRow($0) }
-                }
-                if !model.checked {
-                    sectionHeader(NSLocalizedString("Apps with an update mechanism", comment: ""), count: model.appItems.count)
-                    ForEach(model.appItems) { appRow($0) }
-                }
-                if !model.uncheckableApps.isEmpty {
-                    sectionHeader(NSLocalizedString("Not checkable", comment: ""), count: model.uncheckableApps.count)
-                    Text("No App Store receipt, Sparkle feed, or known updater inside these bundles.")
-                        .font(Brand.mono(9)).foregroundStyle(Brand.textTertiary)
-                        .padding(.horizontal, 14).padding(.bottom, 4)
-                    ForEach(model.uncheckableApps, id: \.id) { app in
-                        plainRow(app)
-                    }
                 }
             }
             .padding(.horizontal, 10).padding(.vertical, 4)
         }
         .scrollIndicators(.visible)
+    }
+
+    private var upToDateBanner: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "checkmark.seal.fill").font(.system(size: Brand.scaled(30))).foregroundStyle(Brand.green)
+            Text("Everything's up to date").font(Brand.serif(18)).foregroundStyle(Brand.textPrimary)
+        }
+        .frame(maxWidth: .infinity).padding(.vertical, 36)
+    }
+
+    private func noteRow(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(Brand.mono(10)).foregroundStyle(color)
+            .padding(.horizontal, 14).padding(.vertical, 8)
+            .accessibilityLabel(text)
     }
 
     private func sectionHeader(_ title: String, count: Int) -> some View {
@@ -293,7 +410,7 @@ struct UpdatesView: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Text(title).font(Brand.sans(11, .semibold))
+            Text(NSLocalizedString(title, comment: "")).font(Brand.sans(11, .semibold))
                 .foregroundStyle(filled ? Color.white : Tool.apps.accent)
                 .padding(.horizontal, 12).padding(.vertical, 5)
                 .background(Capsule().fill(filled ? Tool.apps.accent : Tool.apps.accent.opacity(0.12)))
@@ -398,6 +515,9 @@ final class UpdatesModel: ObservableObject {
     @Published var appItems: [AppUpdateItem] = []
     @Published var uncheckableApps: [InstalledApp] = []
     @Published var brewItems: [OutdatedItem] = []
+    /// Which half of the pane is showing. Lives here rather than in the view
+    /// so switching Software segments and back doesn't reset it.
+    @Published var source: UpdatesSource = .apps
     @Published var checking = false
     @Published var checked = false
     @Published var error: String?
@@ -406,10 +526,20 @@ final class UpdatesModel: ObservableObject {
     @Published private(set) var updateAllRunning = false
     @Published private(set) var updateAllCompleted = 0
     @Published private(set) var updateAllTotal = 0
+    /// Which source the running batch belongs to, so only that header shows
+    /// its progress and stop control.
+    @Published private(set) var updateAllSource: UpdatesSource?
     /// Live brew step during an upgrade (H: brew-upgrade streaming).
     @Published var brewPhrase: String = ""
-    /// True while the on-open `brew outdated` surface is running (shows a spinner).
-    @Published var brewSurfacing = false
+    /// True while a `brew outdated` list is being produced (shows a spinner).
+    @Published private(set) var brewLoading = false
+    /// True when the load in flight is the network refresh (`brew update`).
+    @Published private(set) var brewRefreshing = false
+    /// A list has been produced at least once this session, so an empty one
+    /// means "up to date" rather than "not looked yet".
+    @Published private(set) var brewLoaded = false
+    /// Why the Homebrew list is empty or stale, shown in place of the rows.
+    @Published private(set) var brewProblem: BrewOutdated.Problem?
     private struct InventoryFingerprint: Equatable {
         let id: String
         let bundleID: String
@@ -426,7 +556,11 @@ final class UpdatesModel: ObservableObject {
     private let checkItem: (AppUpdateItem) async -> AppUpdateCheckResult
     private let retrySleep: (UInt64) async -> Void
     private let retryDelayNanoseconds: UInt64
-    private let loadBrewOutdated: () async -> [OutdatedItem]
+    /// `refresh: true` runs `brew update` first (network); false reads the
+    /// local index only.
+    private let loadBrewOutdated: (Bool) async -> BrewOutdated
+    /// Runs `brew upgrade <name>`, streaming progress lines; returns the exit code.
+    private let upgradeBrew: (OutdatedItem, @escaping (String) -> Void) async -> Int32
     private let stageElectron: (String, ElectronUpdateDescriptor) async -> ElectronStageOutcome
     private let installElectron: @MainActor (StagedElectronUpdate) async -> ElectronInstallOutcome
     private let confirmRestart: @MainActor (AppUpdateItem) -> Bool
@@ -462,7 +596,8 @@ final class UpdatesModel: ObservableObject {
         checkItem: ((AppUpdateItem) async -> AppUpdateCheckResult)? = nil,
         retrySleep: ((UInt64) async -> Void)? = nil,
         retryDelayNanoseconds: UInt64 = 750_000_000,
-        loadBrewOutdated: (() async -> [OutdatedItem])? = nil,
+        loadBrewOutdated: ((Bool) async -> BrewOutdated)? = nil,
+        upgradeBrew: ((OutdatedItem, @escaping (String) -> Void) async -> Int32)? = nil,
         stageElectron: ((String, ElectronUpdateDescriptor) async -> ElectronStageOutcome)? = nil,
         installElectron: (@MainActor (StagedElectronUpdate) async -> ElectronInstallOutcome)? = nil,
         confirmRestart: (@MainActor (AppUpdateItem) -> Bool)? = nil
@@ -472,7 +607,8 @@ final class UpdatesModel: ObservableObject {
         self.checkItem = checkItem ?? { await Self.check($0) }
         self.retrySleep = retrySleep ?? { delay in try? await Task.sleep(nanoseconds: delay) }
         self.retryDelayNanoseconds = min(retryDelayNanoseconds, 2_000_000_000)
-        self.loadBrewOutdated = loadBrewOutdated ?? { await Self.brewOutdated() }
+        self.loadBrewOutdated = loadBrewOutdated ?? { await Self.loadBrewOutdated(refresh: $0) }
+        self.upgradeBrew = upgradeBrew ?? { await Self.runBrewUpgrade($0, onLine: $1) }
         self.stageElectron = stageElectron ?? { await ElectronReplacementInstaller.stage(appPath: $0, descriptor: $1) }
         self.installElectron = installElectron ?? { await ElectronReplacementInstaller.install($0) }
         self.confirmRestart = confirmRestart ?? { Self.confirmRestartBeforeInstalling($0) }
@@ -559,25 +695,51 @@ final class UpdatesModel: ObservableObject {
         }
     }
 
-    /// Auto-surface the low-sensitivity sources on tab open: `brew outdated`
-    /// is the user's own tool (no app-controlled egress), so it runs without
-    /// the explicit click that gates the third-party appcast/iTunes checks.
-    /// Once per session; the manual "Check" still does the full network pass.
+    /// Surface Homebrew's list on tab open from its LOCAL index only
+    /// (`HOMEBREW_NO_AUTO_UPDATE=1`): no network, so it's instant and works
+    /// offline, and nothing leaves the Mac without a click — the same rule
+    /// the app checks follow. Once per session; Refresh is the network step.
     func autoSurface() {
-        guard !brewSurfaced, !checking else { return }
+        guard !brewSurfaced else { return }
         brewSurfaced = true
-        brewSurfacing = true
-        Task {
-            let brews = await loadBrewOutdated()
-            await MainActor.run {
-                if self.brewItems.isEmpty { self.brewItems = brews }
-                self.brewSurfacing = false
-            }
+        loadBrew(refresh: false)
+    }
+
+    /// The explicit Homebrew network step: `brew update` against the user's
+    /// configured feeds (mirrors included, #424), then the local list again.
+    func refreshBrew() {
+        loadBrew(refresh: true)
+    }
+
+    private func loadBrew(refresh: Bool) {
+        guard !brewLoading, upgrading.isEmpty, updateAllSource != .homebrew else { return }
+        brewLoading = true
+        brewRefreshing = refresh
+        let loadBrewOutdated = self.loadBrewOutdated
+        Task { @MainActor [weak self] in
+            let result = await loadBrewOutdated(refresh)
+            guard let self else { return }
+            self.apply(result)
+            self.brewLoading = false
+            self.brewRefreshing = false
         }
     }
 
-    /// The manual check: Sparkle appcasts + iTunes lookups + brew
-    /// outdated, bounded concurrency.
+    private func apply(_ result: BrewOutdated) {
+        brewItems = result.items
+        brewProblem = result.problem
+        brewLoaded = true
+        // Rows that vanished from the list take their finished phases with
+        // them; a row that is still outdated keeps its failure visible.
+        let live = Set(result.items.map(\.id))
+        phases = phases.filter { entry in
+            let isBrew = entry.key.hasPrefix("formula:") || entry.key.hasPrefix("cask:")
+            return !isBrew || live.contains(entry.key)
+        }
+    }
+
+    /// The manual check: Sparkle appcasts + iTunes lookups, bounded
+    /// concurrency. Homebrew has its own Refresh; this never touches it.
     func checkNow() {
         guard !checking, !updateAllRunning, appTasks.isEmpty, sparkleSessions.isEmpty, upgrading.isEmpty else { return }
         checking = true
@@ -588,7 +750,6 @@ final class UpdatesModel: ObservableObject {
         let checkItem = self.checkItem
         let retrySleep = self.retrySleep
         let retryDelayNanoseconds = self.retryDelayNanoseconds
-        let loadBrewOutdated = self.loadBrewOutdated
         for item in items {
             phases[item.id] = .checking
             checkFailureIDs.remove(item.id)
@@ -619,7 +780,6 @@ final class UpdatesModel: ObservableObject {
                     if let next = iterator.next() { enqueue(next) }
                 }
             }
-            let brews = await loadBrewOutdated()
             await MainActor.run {
                 guard generation == self.checkGeneration else { return }
                 let byID = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
@@ -659,7 +819,6 @@ final class UpdatesModel: ObservableObject {
                     }
                     return copy
                 }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                self.brewItems = brews
                 self.checking = false
                 self.checked = true
                 let failures = results.filter { if case .failed = $0.phase { return true }; return false }.count
@@ -842,17 +1001,13 @@ final class UpdatesModel: ObservableObject {
         appTasks.removeValue(forKey: id)
     }
 
-    private func isCurrentUpdateAll(inventoryGeneration: Int) -> Bool {
-        updateAllRunning && prepareGeneration == inventoryGeneration
-    }
-
     private func isCurrentAppUpdate(for id: String, owner: AppUpdateOwner) -> Bool {
         switch owner {
         case let .row(generation):
             return appTasks[id]?.generation == generation
                 && appItems.contains(where: { $0.id == id })
         case let .updateAll(inventoryGeneration):
-            return isCurrentUpdateAll(inventoryGeneration: inventoryGeneration)
+            return updateAllRunning && prepareGeneration == inventoryGeneration
                 && appItems.contains(where: { $0.id == id })
         }
     }
@@ -1060,35 +1215,26 @@ final class UpdatesModel: ObservableObject {
     // MARK: Homebrew (the existing flow)
 
     func upgrade(_ item: OutdatedItem) {
-        guard upgrading.isEmpty, !updateAllRunning else { return }
+        guard upgrading.isEmpty, !updateAllRunning, !brewLoading else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             await self.performBrewUpdate(item)
-            self.brewItems = await self.loadBrewOutdated()
+            await self.reloadBrewAfterUpgrade()
         }
     }
 
-    /// Processes every available item serially. Electron replacements stop at
-    /// the visible ready-to-install boundary; only an explicit Install &
+    /// Processes every available Mac app serially. Electron replacements stop
+    /// at the visible ready-to-install boundary; only an explicit Install &
     /// Restart confirmation may let the batch or row quit and replace it.
     /// Cancellation is deliberately a boundary between apps: interrupting a
-    /// download or `brew` transaction halfway through is less safe than
-    /// finishing the current item and stopping before the next one.
-    func updateAll() {
-        guard !updateAllRunning,
-              updateAllTask == nil,
-              upgrading.isEmpty,
-              appTasks.isEmpty,
-              sparkleSessions.isEmpty else { return }
+    /// download halfway through is less safe than finishing the current item
+    /// and stopping before the next one.
+    func updateAllApps() {
+        guard canStartBatch else { return }
         let apps = availableItems
-        let brews = brewItems
-        guard !apps.isEmpty || !brews.isEmpty else { return }
-        let inventoryGeneration = prepareGeneration
-        let owner = AppUpdateOwner.updateAll(inventoryGeneration: inventoryGeneration)
-        cancelUpdateAllAfterCurrent = false
-        updateAllRunning = true
-        updateAllCompleted = 0
-        updateAllTotal = apps.count + brews.count
+        guard !apps.isEmpty else { return }
+        let owner = AppUpdateOwner.updateAll(inventoryGeneration: prepareGeneration)
+        beginBatch(source: .apps, total: apps.count)
         updateAllTask = Task { @MainActor [weak self] in
             guard let self else { return }
             for item in apps {
@@ -1102,17 +1248,26 @@ final class UpdatesModel: ObservableObject {
                 }
                 self.updateAllCompleted += 1
             }
+            self.endBatch()
+        }
+    }
+
+    /// `brew upgrade` every listed formula and cask, one at a time — the same
+    /// boundary rule as the app batch: a stop lands between transactions.
+    func upgradeAllBrews() {
+        guard canStartBatch, !brewLoading else { return }
+        let brews = brewItems
+        guard !brews.isEmpty else { return }
+        beginBatch(source: .homebrew, total: brews.count)
+        updateAllTask = Task { @MainActor [weak self] in
+            guard let self else { return }
             for item in brews {
-                guard !self.cancelUpdateAllAfterCurrent,
-                      self.isCurrentUpdateAll(inventoryGeneration: inventoryGeneration) else { break }
+                guard !self.cancelUpdateAllAfterCurrent else { break }
                 await self.performBrewUpdate(item)
-                guard self.isCurrentUpdateAll(inventoryGeneration: inventoryGeneration) else { break }
                 self.updateAllCompleted += 1
             }
-            self.brewItems = await self.loadBrewOutdated()
-            self.updateAllRunning = false
-            self.updateAllTask = nil
-            self.cancelUpdateAllAfterCurrent = false
+            self.endBatch()
+            await self.reloadBrewAfterUpgrade()
         }
     }
 
@@ -1121,24 +1276,50 @@ final class UpdatesModel: ObservableObject {
         cancelUpdateAllAfterCurrent = true
     }
 
-    func upgradeAll() {
-        updateAll()
+    /// One batch at a time across both sources, and never over a row that
+    /// is already mid-update.
+    private var canStartBatch: Bool {
+        !updateAllRunning && updateAllTask == nil && upgrading.isEmpty
+            && appTasks.isEmpty && sparkleSessions.isEmpty
+    }
+
+    private func beginBatch(source: UpdatesSource, total: Int) {
+        cancelUpdateAllAfterCurrent = false
+        updateAllRunning = true
+        updateAllSource = source
+        updateAllCompleted = 0
+        updateAllTotal = total
+    }
+
+    private func endBatch() {
+        updateAllRunning = false
+        updateAllSource = nil
+        updateAllTask = nil
+        cancelUpdateAllAfterCurrent = false
+    }
+
+    /// Re-read the local index after an upgrade so finished rows drop out
+    /// and a failed one stays, with its message, for another try.
+    private func reloadBrewAfterUpgrade() async {
+        guard !brewLoading else { return }
+        brewLoading = true
+        let result = await loadBrewOutdated(false)
+        apply(result)
+        brewLoading = false
     }
 
     private func performBrewUpdate(_ item: OutdatedItem) async {
-        guard let brew = Self.brewPath() else {
+        guard BrewClient.isInstalled else {
             phases[item.id] = .failed(.unsupported(NSLocalizedString("Homebrew is no longer available.", comment: "")))
             return
         }
         guard upgrading.isEmpty else { return }
         upgrading.insert(item.id)
         phases[item.id] = .installing
-        let code = await Task.detached(priority: .userInitiated) {
-            Self.runBrewStreaming(brew, ["upgrade", item.name], timeout: 1800) { line in
-                guard let phrase = BrewProgress.phrase(line) else { return }
-                Task { @MainActor [weak self] in self?.brewPhrase = phrase }
-            }
-        }.value
+        let code = await upgradeBrew(item) { line in
+            guard let phrase = BrewProgress.phrase(line) else { return }
+            Task { @MainActor [weak self] in self?.brewPhrase = phrase }
+        }
         brewPhrase = ""
         upgrading.remove(item.id)
         phases[item.id] = code == 0
@@ -1149,49 +1330,63 @@ final class UpdatesModel: ObservableObject {
             )))
     }
 
-    private static func brewOutdated() async -> [OutdatedItem] {
-        guard let brew = brewPath() else { return [] }
+    // MARK: Homebrew process seam
+
+    /// Produce the outdated list. `refresh` first runs `brew update` — the
+    /// only network call in this half of the pane — and a failure there
+    /// still falls through to the local list, so the rows stay useful and
+    /// the reason shows beside them. The list itself always runs with
+    /// auto-update off; without that, `brew outdated` fetches taps from
+    /// GitHub first, which is what stalled for two minutes and then showed
+    /// as "nothing to update" (#424).
+    nonisolated static func loadBrewOutdated(refresh: Bool) async -> BrewOutdated {
+        guard BrewClient.isInstalled else { return BrewOutdated(problem: .notInstalled) }
         return await Task.detached(priority: .userInitiated) {
-            let r = runBrew(brew, ["outdated", "--json=v2"])
-            return parseOutdated(r.out)
+            var problem: BrewOutdated.Problem?
+            if refresh {
+                let update = BrewClient.run(["update"], timeout: 600)
+                if update.code != 0 {
+                    problem = .failed(String(
+                        format: NSLocalizedString("Homebrew couldn't refresh: %@", comment: ""),
+                        brewProblemMessage(update)))
+                }
+            }
+            let outdated = BrewClient.run(["outdated", "--json=v2"], timeout: 120, autoUpdate: false)
+            guard outdated.code == 0 else {
+                return BrewOutdated(problem: .failed(String(
+                    format: NSLocalizedString("Homebrew couldn't list outdated packages: %@", comment: ""),
+                    brewProblemMessage(outdated))))
+            }
+            return BrewOutdated(items: parseOutdated(outdated.out), problem: problem)
         }.value
     }
 
-    nonisolated static func brewPath() -> String? {
-        for p in ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
-        where FileManager.default.isExecutableFile(atPath: p) { return p }
-        return nil
+    /// The one line worth showing from a failed brew run: the deadline if
+    /// that is what ended it, else brew's last stderr line, else the status.
+    nonisolated static func brewProblemMessage(_ result: BrewClient.Result) -> String {
+        if result.timedOut { return NSLocalizedString("Homebrew didn't respond in time.", comment: "") }
+        let lines = result.err.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+        if let last = lines.last(where: { !$0.isEmpty }) { return last }
+        return String(format: NSLocalizedString("Homebrew exited with status %d.", comment: ""), result.code)
     }
 
-    private struct BrewResult { let out: String; let err: String; let code: Int32 }
-
-    private nonisolated static func runBrew(_ brew: String, _ args: [String], timeout: TimeInterval = 120) -> BrewResult {
-        var env = Foundation.ProcessInfo.processInfo.environment
-        let dir = (brew as NSString).deletingLastPathComponent
-        env["PATH"] = "\(dir):/usr/bin:/bin:/usr/sbin:/sbin:" + (env["PATH"] ?? "")
-        do {
-            let result = try EngineRunner.shared.capture(
-                MoCommand(target: .executable(brew), args: args,
-                          environment: env, timeout: timeout))
-            return BrewResult(out: result.stdout, err: result.stderr, code: result.exitCode)
-        } catch {
-            return BrewResult(out: "", err: "\(error)", code: -1)
-        }
-    }
-
-    /// Stream a brew run, calling `onLine` per stdout line (H: live progress).
-    /// The readability handler drains the pipe so waitUntilExit can't deadlock;
+    /// `brew upgrade <name>`, streamed line by line (H: live progress). The
+    /// readability handler drains the pipe so waitUntilExit can't deadlock;
     /// a work item terminates on timeout.
+    nonisolated static func runBrewUpgrade(_ item: OutdatedItem, onLine: @escaping (String) -> Void) async -> Int32 {
+        guard let brew = BrewClient.path() else { return -1 }
+        return await Task.detached(priority: .userInitiated) {
+            runBrewStreaming(brew, ["upgrade", item.name], timeout: 1800, onLine: onLine)
+        }.value
+    }
+
     private nonisolated static func runBrewStreaming(_ brew: String, _ args: [String],
                                                      timeout: TimeInterval,
                                                      onLine: @escaping (String) -> Void) -> Int32 {
-        var env = Foundation.ProcessInfo.processInfo.environment
-        let dir = (brew as NSString).deletingLastPathComponent
-        env["PATH"] = "\(dir):/usr/bin:/bin:/usr/sbin:/sbin:" + (env["PATH"] ?? "")
         let p = Process()
         p.executableURL = URL(fileURLWithPath: brew)
         p.arguments = args
-        p.environment = env
+        p.environment = BrewClient.environment(brew: brew)
         let pipe = Pipe()
         p.standardOutput = pipe
         p.standardError = pipe

--- a/macos/Sources/UpdatesView.swift
+++ b/macos/Sources/UpdatesView.swift
@@ -531,9 +531,13 @@ final class UpdatesModel: ObservableObject {
     @Published private(set) var updateAllSource: UpdatesSource?
     /// Live brew step during an upgrade (H: brew-upgrade streaming).
     @Published var brewPhrase: String = ""
-    /// True while a `brew outdated` list is being produced (shows a spinner).
+    /// Two flags rather than one enum because they answer different
+    /// questions: `brewLoading` gates every brew action (no upgrade or second
+    /// load under a list still being produced, whichever kind), while
+    /// `brewRefreshing` only picks the spinner's copy — a local read finishes
+    /// in a second, a refresh can sit on the network for minutes, and the
+    /// user should know which one they are waiting on.
     @Published private(set) var brewLoading = false
-    /// True when the load in flight is the network refresh (`brew update`).
     @Published private(set) var brewRefreshing = false
     /// A list has been produced at least once this session, so an empty one
     /// means "up to date" rather than "not looked yet".

--- a/macos/Tests/HomebrewEnvironmentTests.swift
+++ b/macos/Tests/HomebrewEnvironmentTests.swift
@@ -1,0 +1,69 @@
+//
+//  HomebrewEnvironmentTests.swift
+//  BurrowTests
+//
+//  The login-shell import behind #424: only `HOMEBREW_*` crosses from the
+//  user's shell into the brew Burrow spawns, PATH stays Burrow's own, and
+//  the local list read turns auto-update off.
+//
+
+import XCTest
+@testable import Burrow
+
+final class HomebrewEnvironmentTests: XCTestCase {
+    func testParseKeepsOnlyWellFormedHomebrewAssignments() {
+        let output = """
+        Welcome banner printed by .zshrc
+        PATH=/opt/homebrew/bin:/usr/bin
+        HOMEBREW_API_DOMAIN=https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles/api
+        HOMEBREW_BOTTLE_DOMAIN=https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles
+        HOMEBREW_NO_ENV_HINTS=1
+        HOMEBREW_=no name
+        HOMEBREW_lower=no
+        HOMEBREW_EMPTY=
+        homebrew_prefix=/opt/homebrew
+        HOMEBREW_WITH_EQUALS=a=b
+        SHELL=/bin/zsh
+        """
+        XCTAssertEqual(HomebrewEnvironment.parse(output), [
+            "HOMEBREW_API_DOMAIN": "https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles/api",
+            "HOMEBREW_BOTTLE_DOMAIN": "https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles",
+            "HOMEBREW_NO_ENV_HINTS": "1",
+            "HOMEBREW_WITH_EQUALS": "a=b",
+        ])
+    }
+
+    func testParseOfNoiseIsEmpty() {
+        XCTAssertTrue(HomebrewEnvironment.parse("").isEmpty)
+        XCTAssertTrue(HomebrewEnvironment.parse("zsh: can't set job control\n=\nHOMEBREW\n").isEmpty)
+    }
+
+    func testLoginShellMustBeAnAbsoluteExecutableAndDefaultsToZsh() {
+        XCTAssertEqual(HomebrewEnvironment.loginShell(environment: ["SHELL": "/bin/zsh"]), "/bin/zsh")
+        XCTAssertEqual(HomebrewEnvironment.loginShell(environment: [:]), "/bin/zsh")
+        XCTAssertEqual(HomebrewEnvironment.loginShell(environment: ["SHELL": ""]), "/bin/zsh")
+        XCTAssertNil(HomebrewEnvironment.loginShell(environment: ["SHELL": "zsh"]))
+        XCTAssertNil(HomebrewEnvironment.loginShell(environment: ["SHELL": "/nonexistent/shell"]))
+    }
+
+    func testBrewEnvironmentLayersImportsOverTheAppEnvironment() {
+        let base = ["PATH": "/usr/bin:/bin", "HOME": "/Users/x", "HOMEBREW_NO_AUTO_UPDATE": "0"]
+        let imported = [
+            "HOMEBREW_API_DOMAIN": "https://mirror.example/api",
+            "PATH": "/tmp/evil",
+            "HOMEBREW_bad": "x",
+        ]
+
+        let local = BrewClient.environment(
+            brew: "/opt/homebrew/bin/brew", autoUpdate: false, base: base, imported: imported)
+        XCTAssertEqual(local["PATH"], "/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/bin:/bin")
+        XCTAssertEqual(local["HOMEBREW_API_DOMAIN"], "https://mirror.example/api")
+        XCTAssertNil(local["HOMEBREW_bad"])
+        XCTAssertEqual(local["HOME"], "/Users/x")
+        XCTAssertEqual(local["HOMEBREW_NO_AUTO_UPDATE"], "1", "a local read never fetches, whatever the user set")
+
+        let network = BrewClient.environment(
+            brew: "/opt/homebrew/bin/brew", autoUpdate: true, base: base, imported: imported)
+        XCTAssertEqual(network["HOMEBREW_NO_AUTO_UPDATE"], "0", "otherwise the user's own setting stands")
+    }
+}

--- a/macos/Tests/UpdatesModelTests.swift
+++ b/macos/Tests/UpdatesModelTests.swift
@@ -604,7 +604,9 @@ final class UpdatesModelTests: XCTestCase {
         XCTAssertTrue(model.brewItems.isEmpty)
         XCTAssertFalse(model.brewLoading)
 
-        // A second open and the app check both leave Homebrew alone.
+        // Neither a second open nor the app check may re-run brew: the open
+        // is once per session by design, and the app check must not be held
+        // hostage by a brew that can stall on the network (#424).
         model.autoSurface()
         model.checkNow()
         await eventually { model.checked }

--- a/macos/Tests/UpdatesModelTests.swift
+++ b/macos/Tests/UpdatesModelTests.swift
@@ -131,7 +131,7 @@ final class UpdatesModelTests: XCTestCase {
         let model = UpdatesModel(
             checkItem: { item in responses.next(for: item.id) },
             retrySleep: { delay in retryDelays.append(delay) },
-            loadBrewOutdated: { [] }
+            loadBrewOutdated: { _ in .empty }
         )
         model.appItems = [updateItem(id: "electron", installed: "1.0.0", source: .electron)]
 
@@ -155,7 +155,7 @@ final class UpdatesModelTests: XCTestCase {
         let model = UpdatesModel(
             checkItem: { item in responses.next(for: item.id) },
             retrySleep: { delay in retryDelays.append(delay) },
-            loadBrewOutdated: { [] }
+            loadBrewOutdated: { _ in .empty }
         )
         model.appItems = [updateItem(
             id: "electron",
@@ -182,7 +182,7 @@ final class UpdatesModelTests: XCTestCase {
         let model = UpdatesModel(
             checkItem: { item in responses.next(for: item.id) },
             retrySleep: { _ in },
-            loadBrewOutdated: { [] }
+            loadBrewOutdated: { _ in .empty }
         )
         model.appItems = [updateItem(
             id: "electron",
@@ -206,7 +206,7 @@ final class UpdatesModelTests: XCTestCase {
         ])
         let model = UpdatesModel(
             checkItem: { item in responses.next(for: item.id) },
-            loadBrewOutdated: { [] }
+            loadBrewOutdated: { _ in .empty }
         )
         model.appItems = [updateItem(
             id: "electron",
@@ -231,7 +231,7 @@ final class UpdatesModelTests: XCTestCase {
             detectSource: { _ in .electron },
             sourceFingerprint: { $0.path },
             checkItem: { item in await responder.response(for: item.id) },
-            loadBrewOutdated: { [] }
+            loadBrewOutdated: { _ in .empty }
         )
 
         model.prepare(apps: [app(id: "old", name: "Old", path: "/Applications/Old.app")])
@@ -265,7 +265,7 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in await staging.stage() }
         )
         model.appItems = [updateItem(id: "electron", installed: "1.0.0", source: .electron)]
@@ -274,7 +274,7 @@ final class UpdatesModelTests: XCTestCase {
 
         model.update(model.appItems[0])
         await fulfillment(of: [rowStageStarted], timeout: 1)
-        model.updateAll()
+        model.updateAllApps()
 
         XCTAssertFalse(model.updateAllRunning)
         await staging.finishFirst(with: .failure(.cancelled))
@@ -295,14 +295,14 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in await staging.stage() }
         )
         model.appItems = [updateItem(id: "electron", installed: "1.0.0", source: .electron)]
         model.checkNow()
         await eventually { model.checked }
 
-        model.updateAll()
+        model.updateAllApps()
         model.update(model.appItems[0])
         await fulfillment(of: [batchStageStarted], timeout: 1)
         await staging.finishFirst(with: .failure(.cancelled))
@@ -337,7 +337,7 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in await staging.stage() },
             installElectron: { _ in
                 installCount += 1
@@ -354,7 +354,7 @@ final class UpdatesModelTests: XCTestCase {
         model.checkNow()
         await eventually { model.checked && model.availableItems.map(\.id) == ["electron"] }
 
-        model.updateAll()
+        model.updateAllApps()
         await fulfillment(of: [stageStarted], timeout: 1)
         model.prepare(apps: [])
         XCTAssertTrue(model.appItems.isEmpty)
@@ -393,7 +393,7 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in .ready(staged) },
             installElectron: { _ in
                 installCount += 1
@@ -455,7 +455,7 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in await staging.stage() }
         )
         model.appItems = [updateItem(id: "electron", installed: "1.0.0", source: .electron)]
@@ -470,7 +470,7 @@ final class UpdatesModelTests: XCTestCase {
 
         await staging.finish(call: 1, with: .ready(cancelledStage))
         await eventually { !FileManager.default.fileExists(atPath: stagingRoot.path) }
-        model.updateAll()
+        model.updateAllApps()
 
         XCTAssertFalse(model.updateAllRunning)
         await staging.finish(call: 2, with: .failure(.offline))
@@ -504,7 +504,7 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in await staging.stage() },
             installElectron: { staged in
                 installedCandidate = staged.candidateURL
@@ -562,7 +562,7 @@ final class UpdatesModelTests: XCTestCase {
             checkItem: { item in
                 .available(id: item.id, version: descriptor.version, electronDescriptor: descriptor)
             },
-            loadBrewOutdated: { [] },
+            loadBrewOutdated: { _ in .empty },
             stageElectron: { _, _ in workflow.stage() },
             installElectron: { staged in workflow.install(staged) },
             confirmRestart: { item in workflow.confirmRestart(for: item.name) }
@@ -571,7 +571,7 @@ final class UpdatesModelTests: XCTestCase {
         model.checkNow()
         await eventually { model.checked }
 
-        model.updateAll()
+        model.updateAllApps()
         await eventually { !model.updateAllRunning && model.phase(for: "electron") == .readyToInstall }
 
         XCTAssertEqual(workflow.stageCount, 1)
@@ -586,6 +586,130 @@ final class UpdatesModelTests: XCTestCase {
         XCTAssertEqual(workflow.installCount, 1)
         XCTAssertEqual(workflow.confirmedNames, ["Electron", "Electron"])
         XCTAssertEqual(workflow.events, ["stage", "confirm:Electron", "confirm:Electron", "install"])
+    }
+
+    // MARK: Homebrew half (#424)
+
+    func testAutoSurfaceReadsTheLocalIndexOnceAndSurfacesAProblem() async {
+        let loads = LockedStringRecorder()
+        let model = UpdatesModel(loadBrewOutdated: { refresh in
+            loads.append(refresh ? "refresh" : "local")
+            return BrewOutdated(problem: .failed("Error: git fetch exited with 128"))
+        })
+
+        model.autoSurface()
+        await eventually { model.brewLoaded }
+
+        XCTAssertEqual(model.brewProblem, .failed("Error: git fetch exited with 128"))
+        XCTAssertTrue(model.brewItems.isEmpty)
+        XCTAssertFalse(model.brewLoading)
+
+        // A second open and the app check both leave Homebrew alone.
+        model.autoSurface()
+        model.checkNow()
+        await eventually { model.checked }
+        XCTAssertEqual(loads.values, ["local"])
+    }
+
+    func testRefreshBrewRunsTheNetworkStepAndReplacesTheList() async {
+        let loads = LockedStringRecorder()
+        let model = UpdatesModel(loadBrewOutdated: { refresh in
+            loads.append(refresh ? "refresh" : "local")
+            return refresh ? BrewOutdated(items: [brew("git")]) : .empty
+        })
+        model.autoSurface()
+        await eventually { model.brewLoaded }
+        XCTAssertTrue(model.brewItems.isEmpty)
+
+        model.refreshBrew()
+        XCTAssertTrue(model.brewLoading)
+        XCTAssertTrue(model.brewRefreshing)
+        await eventually { model.brewItems.map(\.name) == ["git"] }
+
+        XCTAssertNil(model.brewProblem)
+        XCTAssertFalse(model.brewRefreshing)
+        XCTAssertEqual(loads.values, ["local", "refresh"])
+    }
+
+    func testUpgradeAllBrewsRunsSeriallyThenReloadsSoFinishedRowsDropOut() async {
+        let upgraded = LockedStringRecorder()
+        let model = UpdatesModel(
+            loadBrewOutdated: { _ in
+                let done = Set(upgraded.values)
+                return BrewOutdated(items: [brew("git"), brew("wget")].filter { !done.contains($0.name) })
+            },
+            upgradeBrew: { item, _ in
+                upgraded.append(item.name)
+                return 0
+            }
+        )
+        model.autoSurface()
+        await eventually { model.brewItems.count == 2 }
+
+        model.upgradeAllBrews()
+        XCTAssertTrue(model.updateAllRunning)
+        XCTAssertEqual(model.updateAllSource, .homebrew)
+        XCTAssertEqual(model.updateAllTotal, 2)
+        await eventually { !model.updateAllRunning && !model.brewLoading && model.brewItems.isEmpty }
+
+        XCTAssertEqual(upgraded.values, ["git", "wget"])
+        XCTAssertEqual(model.updateAllCompleted, 2)
+        XCTAssertNil(model.updateAllSource)
+        XCTAssertEqual(model.phase(for: "formula:git"), .idle)
+        XCTAssertEqual(model.phase(for: "formula:wget"), .idle)
+    }
+
+    func testBrewBatchStopsAfterTheCurrentItemAndKeepsAFailureOnItsRow() async {
+        let upgraded = LockedStringRecorder()
+        let gate = BrewGate()
+        let model = UpdatesModel(
+            loadBrewOutdated: { _ in BrewOutdated(items: [brew("git"), brew("wget")]) },
+            upgradeBrew: { item, _ in
+                upgraded.append(item.name)
+                return await gate.wait()
+            }
+        )
+        model.autoSurface()
+        await eventually { model.brewItems.count == 2 }
+
+        model.upgradeAllBrews()
+        await eventually { upgraded.values == ["git"] }
+        model.cancelUpdateAll()
+        XCTAssertTrue(model.cancelUpdateAllAfterCurrent)
+        await gate.release(1)
+        await eventually { !model.updateAllRunning && !model.brewLoading }
+
+        XCTAssertEqual(upgraded.values, ["git"], "the stop lands between transactions")
+        XCTAssertEqual(model.updateAllCompleted, 1)
+        guard case .failed = model.phase(for: "formula:git") else {
+            return XCTFail("the still-outdated row keeps its failure, got \(model.phase(for: "formula:git"))")
+        }
+        XCTAssertEqual(model.phase(for: "formula:wget"), .idle)
+    }
+
+    func testOneBatchAtATimeAcrossBothSources() async {
+        let gate = BrewGate()
+        let model = UpdatesModel(
+            checkItem: { item in .available(id: item.id, version: "2.0.0") },
+            loadBrewOutdated: { _ in BrewOutdated(items: [brew("git")]) },
+            upgradeBrew: { _, _ in await gate.wait() }
+        )
+        model.appItems = [updateItem(id: "sparkle", installed: "1.0.0", source: .sparkle)]
+        model.autoSurface()
+        model.checkNow()
+        await eventually { model.checked && model.brewItems.count == 1 }
+        XCTAssertEqual(model.availableItems.map(\.id), ["sparkle"])
+
+        model.upgradeAllBrews()
+        XCTAssertEqual(model.updateAllSource, .homebrew)
+        model.updateAllApps()
+        XCTAssertEqual(model.updateAllSource, .homebrew, "the app batch waits its turn")
+        model.refreshBrew()
+        XCTAssertFalse(model.brewLoading, "no reload underneath a running upgrade")
+
+        await gate.release(0)
+        await eventually { !model.updateAllRunning && !model.brewLoading }
+        XCTAssertNil(model.updateAllSource)
     }
 
     private func app(id: String, name: String, path: String) -> InstalledApp {
@@ -853,5 +977,26 @@ private final class LockedStringRecorder: @unchecked Sendable {
         lock.lock()
         storage.append(value)
         lock.unlock()
+    }
+}
+
+private func brew(_ name: String, kind: String = "formula") -> OutdatedItem {
+    OutdatedItem(id: "\(kind):\(name)", name: name, installed: "1.0", latest: "2.0", kind: kind)
+}
+
+/// Holds a fake `brew upgrade` open until the test releases it, so a stop
+/// can be requested while an item is mid-flight. A release that arrives
+/// before the wait is kept, never lost.
+private actor BrewGate {
+    private var waiters: [CheckedContinuation<Int32, Never>] = []
+    private var pending: [Int32] = []
+
+    func wait() async -> Int32 {
+        if !pending.isEmpty { return pending.removeFirst() }
+        return await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release(_ code: Int32) {
+        if waiters.isEmpty { pending.append(code) } else { waiters.removeFirst().resume(returning: code) }
     }
 }

--- a/macos/Tests/UpdatesParseTests.swift
+++ b/macos/Tests/UpdatesParseTests.swift
@@ -33,4 +33,19 @@ final class UpdatesParseTests: XCTestCase {
         XCTAssertTrue(UpdatesModel.parseOutdated("not json").isEmpty)
         XCTAssertTrue(UpdatesModel.parseOutdated("").isEmpty)
     }
+
+    /// A failed brew run used to vanish into an empty list (#424); the one
+    /// line the pane shows comes from here.
+    func testBrewProblemMessage_prefersDeadlineThenLastStderrLineThenStatus() {
+        XCTAssertEqual(
+            UpdatesModel.brewProblemMessage(.init(out: "", err: "Error: x", code: 1, timedOut: true)),
+            "Homebrew didn't respond in time.")
+        XCTAssertEqual(
+            UpdatesModel.brewProblemMessage(.init(
+                out: "", err: "==> Updating Homebrew...\nError: Failure while executing; `git fetch` exited with 128.\n   \n", code: 1)),
+            "Error: Failure while executing; `git fetch` exited with 128.")
+        XCTAssertEqual(
+            UpdatesModel.brewProblemMessage(.init(out: "", err: "", code: 2)),
+            "Homebrew exited with status 2.")
+    }
 }


### PR DESCRIPTION
Refs #424.

The reporter asked whether Burrow could update Homebrew packages. It already could, in Software → Updates, so the real problem is that the pane had shown them nothing. This PR fixes the causes and reworks the pane so the two sources stop getting in each other's way.

## What was wrong

- **A failed `brew outdated` looked like "nothing to update".** The loader parsed stdout and dropped the exit code, stderr, and the timed-out flag.
- **Opening the tab did network work.** `brew outdated` runs Homebrew's auto-update first (a tap fetch from GitHub): 36 s on a fast US connection, and past the 120 s deadline on a slow path to GitHub. The autoSurface comment claimed no egress; that wasn't true.
- **The user's Homebrew mirror was ignored.** brew ran with launchd's environment, so `HOMEBREW_API_DOMAIN`, `HOMEBREW_BOTTLE_DOMAIN`, and the `*_GIT_REMOTE` exports in the login shell never reached it. Inside Burrow, brew went straight to github.com / ghcr.io.
- **The layout.** One long list, one Check button that only governed Mac apps but sat above the brew rows, Mac apps below a scroll of brew rows, and a mixed Update All.

## What changed

- **Tab open reads Homebrew's local index only** (`HOMEBREW_NO_AUTO_UPDATE=1`): instant and offline. **Refresh** is the explicit network step (`brew update`, then the list again). A failed refresh still shows the local rows with the reason beside them.
- **Brew problems are shown.** Timeout, exit status, or last stderr line, in place of the rows. Homebrew-not-installed is a quiet note rather than an empty pane.
- **`HOMEBREW_*` is imported from the login shell** once per process (`HomebrewEnvironment`), allowlisted to that prefix. PATH stays Burrow's own and brew is still resolved from its known prefixes. Applies to every brew call through `BrewClient`, including the streaming upgrade.
- **Two halves behind a picker: Mac apps / Homebrew.** Each has its own header and its own actions. Mac apps: Check for updates (still the only path that contacts Apple/vendor servers), then Update all. Homebrew: Refresh, Update all. Batches run per source, one at a time, with the same stop-after-current boundary.
- **Localization.** "Update All" was keyed differently from its translation and rendered in English in every locale; the row buttons (Update, Retry, Install & Restart, Open updater, Open App Store, Release notes) and the batch/header strings were never localized. All nine tables gained the keys.

## Tests

- `UpdatesModelTests`: local vs refresh loads, problem surfacing, serial brew batch that reloads so finished rows drop out, stop-after-current keeping a failure on its row, and one batch at a time across both sources. Existing app-batch tests updated for the rename.
- `HomebrewEnvironmentTests`: the `env` parser, login-shell resolution, and `BrewClient.environment` layering (imports win, PATH fixed, auto-update off only for the local read).
- `UpdatesParseTests`: the problem-message precedence.

Full suite: 1347 tests, 0 failures. Hand-checked the pane in a Debug build: 201 outdated formulae/casks listed instantly from the local index, badge on the Homebrew tab, Refresh and Update all beside the rows.

## Docs

SECURITY.md and README now describe the local-index open, the Refresh network step, and the `HOMEBREW_*` import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split Software › Updates into separate Mac apps and Homebrew sections.
  * Added Homebrew refresh, progress, cancellation, retry, and failure-status controls.
  * App and Homebrew updates can now be run independently or in batches.
  * Homebrew mirror settings are supported, with local update checks that avoid automatic refreshes.

* **Documentation**
  * Clarified update behavior and Homebrew refresh controls.

* **Localization**
  * Added translations for the updated experience in German, Spanish, French, Japanese, Korean, Brazilian Portuguese, Russian, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->